### PR TITLE
doc: Cross-reference contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,12 @@ Anyone can do a pull request and commit. In order for your work to be merged, yo
 The iCLA is administered by a bot which will comment on your PR and direct you to sign the iCLA if you haven’t previously done so. This happens automatically when people submit a pull request.
 
 
+### Subproject: Risk Map
+
+If you are contributing to the CoSAI Risk Map (schemas and YAML under `risk-map/`), follow this document for branching, commits, PRs, and CLA.
+
+- Risk Map authoring guide (schemas/YAML, IDs, validation, examples): see [`risk-map/docs/developing.md`](risk-map/docs/developing.md).
+
 ## Feedback
 
 Questions or comments about this project's work may be composed as GitHub issues or comments or may be directed to the project's general email list at cosai-op@lists.oasis-open-projects.org. General questions about OASIS Open Projects may be directed to OASIS staff at [op-admin@lists.oasis-open-projects.org](mailto:op-admin@lists.oasis-open-projects.org).

--- a/risk-map/README.md
+++ b/risk-map/README.md
@@ -45,7 +45,7 @@ You can use these files to:
 * **Learn**: Read the `.yaml` files to understand the landscape of AI security risks.
 * **Assess**: Use the framework as a guide for security reviews of your AI projects.
 * **Build**: Leverage the `.schema.json` files to expand the framework to address your organization's risk management and governance needs.
-   * See [docs/developing.md](./docs/developing.md) for more details. 
+   * See [Contributing to the Risk Map](./docs/developing.md) for authoring and validation details.
 
 ## Background
 Building and using AI systems involves many potential risks. We created the Securing AI Framework to help manage these risks by tackling several foundational challenges. The industry needed:

--- a/risk-map/docs/developing.md
+++ b/risk-map/docs/developing.md
@@ -1,25 +1,15 @@
 # Expanding the CoSAI Risk Map
 
+> This guide complements the repository-wide [`CONTRIBUTING.md`](../../CONTRIBUTING.md). Use that for branching, commit/PR workflow, code review expectations, and CLA. This document focuses on how to author and validate Risk Map content (schemas and YAML).
+
 This guide outlines how you can contribute to the Coalition for Secure AI (CoSAI) Risk Map. By following these steps, you can help expand the framework while ensuring your contributions are consistent with the project's structure and pass all validation checks.
 
 ## General Contribution Workflow
 
-All contributions to this framework follow a standard workflow. Specific file changes for each type of contribution are detailed in the guides below.
-
-1.  **Fork & Branch**: Fork the repository to your own GitHub account and create a new, descriptive branch for your work (e.g., `feature/add-new-risk-xyz`).
-    ```bash
-    # Clone your fork to your local machine
-    git clone https://github.com/your-username/secure-ai-tooling.git
-    cd secure-ai-tooling
-
-    # Create a new branch
-    git checkout -b feature/add-new-risk-xyz
-
-    # Change to the risk-map sub-project
-    cd risk-map
-    ```
-2.  **Make Changes**: Follow the relevant guide below to make your changes to the schema and YAML files.
-3.  **Validate & Create a Pull Request**: After making your changes, ensure they conform to the schema using a JSON schema validator. Once validated, commit your changes with a clear message and open a pull request (PR) to the main repository, detailing your contribution.
+1. Read and follow the repository-wide [CONTRIBUTING.md](../../CONTRIBUTING.md) for branching, commit conventions, PR workflow, and CLA.
+2. Make content changes per the guides below (components, controls, risks, personas).
+3. Validate your changes against the relevant JSON Schemas.
+4. Open a PR describing the Risk Map updates and validation performed.
 
 ---
 


### PR DESCRIPTION
Fixes #2 

This pull request updates contribution documentation for the CoSAI Risk Map subproject, clarifying the workflow for contributors and improving guidance on authoring and validating Risk Map content. The changes ensure that contributors have clear instructions and references for both repository-wide and subproject-specific processes.

Documentation improvements for Risk Map contributions:

* Added a dedicated section in `CONTRIBUTING.md` for Risk Map contributions, including references to the authoring guide and validation instructions.
* Updated `risk-map/README.md` to clarify where to find authoring and validation details for Risk Map contributions.
* Revised `risk-map/docs/developing.md` to reference the main `CONTRIBUTING.md`, streamline the workflow steps, and clarify the process for authoring and validating Risk Map content.