### PR TITLE
[bug] Resolve control-to-risk mapping inconsistencies

### DIFF
--- a/risk-map/yaml/controls.yaml
+++ b/risk-map/yaml/controls.yaml
@@ -448,6 +448,8 @@ controls:
   risks:
   - ADI
   - MLD
+  - MST
+  - MXF 
 - id: controlFederatedTrainingPrivacyAndRobustAggregation
   title: Federated Training Privacy and Robust Aggregation
   description:
@@ -479,6 +481,7 @@ controls:
   - componentApplication
   risks:
   - ORH
+  - MDT
 - id: controlModelRepositoryTrustAndAttestation
   title: Model Repository Trust and Attestation
   description:
@@ -496,6 +499,8 @@ controls:
   risks:
   - ADI
   - MLD
+  - MST
+  - MXF
 - id: controlCostQuotaGuardrails
   title: Cost Quota Guardrails
   description:
@@ -511,6 +516,7 @@ controls:
   - componentModelServing
   risks:
   - EDW
+  - DMS
 - id: controlEvaluationProvenanceAndDriftDetection
   title: Evaluation Provenance and Drift Detection
   description:

--- a/risk-map/yaml/risks.yaml
+++ b/risk-map/yaml/risks.yaml
@@ -884,6 +884,7 @@ risks:
   - controlModelAndDataAccessControls
   - controlThreatDetection
   - controlVulnerabilityManagement
+  - controlAcceleratorIsolationAndSideChannelMitigation
   examples:
   - >
     Research has demonstrated <a href="https://arxiv.org/abs/2006.12784" target="_blank"
@@ -954,6 +955,7 @@ risks:
   - controlApplicationAccessManagement
   - controlThreatDetection
   - controlVulnerabilityManagement
+  - controlCostQuotaGuardrails
   examples:
   - >
     Research has shown <a href="https://arxiv.org/abs/2401.07464" target="_blank"
@@ -1018,6 +1020,7 @@ risks:
   - controlModelAndDataIntegrityManagement
   - controlThreatDetection
   - controlSecureByDefaultMLTooling
+  - controlFederatedTrainingPrivacyAndRobustAggregation
   examples:
   - >
     Research demonstrates <a href="https://arxiv.org/abs/1906.08935" target="_blank"
@@ -1085,6 +1088,8 @@ risks:
   - controlModelAndDataAccessControls
   - controlSecureByDefaultMLTooling
   - controlVulnerabilityManagement
+  - controlAdapterIntegrityAndAllowlisting
+  - controlModelRepositoryTrustAndAttestation
   examples:
   - >
     Research demonstrates <a href="https://arxiv.org/abs/2311.03262" target="_blank"
@@ -1151,6 +1156,7 @@ risks:
   - controlModelAndDataAccessControls
   - controlSecureByDefaultMLTooling
   - controlThreatDetection
+  - controlOrchestratorAndRouteIntegrity
   examples:
   - >
     Security research shows <a href="https://arxiv.org/abs/2402.14020" target="_blank"
@@ -1218,6 +1224,7 @@ risks:
   - controlRedTeaming
   - controlVulnerabilityManagement
   - controlThreatDetection
+  - controlEvaluationProvenanceAndDriftDetection
   examples:
   - >
     Research demonstrates <a href="https://arxiv.org/abs/2108.07258" target="_blank"
@@ -1360,6 +1367,8 @@ risks:
   - controlSecureByDefaultMLTooling
   - controlInputValidationAndSanitization
   - controlVulnerabilityManagement
+  - controlAdapterIntegrityAndAllowlisting
+  - controlModelRepositoryTrustAndAttestation
   examples:
   - >
     Research has demonstrated <a href="https://blog.trailofbits.com/2021/03/15/never-a-dill-moment-exploiting-machine-learning-pickle-files/"
@@ -1494,6 +1503,7 @@ risks:
   - controlModelAndDataIntegrityManagement
   - controlInputValidationAndSanitization
   - controlOutputValidationAndSanitization
+  - controlRetrievalAndVectorStorePoisoningDefense
   examples:
   - >
     Researchers have demonstrated <a href="https://arxiv.org/abs/2310.19156"


### PR DESCRIPTION
# Fix: Resolve control-to-risk mapping inconsistencies

Fixes #41 

## Summary
This PR fixes all 12 bidirectional mapping inconsistencies between `controls.yaml` and `risks.yaml` identified during GitHub Actions validation testing.

## Changes Made
**Files modified:**
- `risk-map/yaml/controls.yaml` - Updated control-to-risk mappings
- `risk-map/yaml/risks.yaml` - Updated risk-to-control mappings

## Issues Resolved
✅ **Fixed 12 cross-reference consistency errors:**

```bash
     - [ISSUE: risks.yaml] Control 'controlAdapterIntegrityAndAllowlisting' claims to address risks '['ADI', 'MLD']' in controls.yaml, but the risk(s) don't list this control in their 'controls' section in risks.yaml
     - [ISSUE: controls.yaml] Risks ['MST', 'MXF'] reference control 'controlAdapterIntegrityAndAllowlisting' in risks.yaml, but this control doesn't list these risks in its 'risks' section in controls.yaml
     - [ISSUE: risks.yaml] Control 'controlOrchestratorAndRouteIntegrity' claims to address risks '['ORH']' in controls.yaml, but the risk(s) don't list this control in their 'controls' section in risks.yaml
     - [ISSUE: controls.yaml] Risks ['MDT'] reference control 'controlOrchestratorAndRouteIntegrity' in risks.yaml, but this control doesn't list these risks in its 'risks' section in controls.yaml
     - [ISSUE: risks.yaml] Control 'controlAcceleratorIsolationAndSideChannelMitigation' lists risks '['ASC']' in controls.yaml, but none of these risks reference the control(s) in risks.yaml
     - [ISSUE: risks.yaml] Control 'controlModelRepositoryTrustAndAttestation' claims to address risks '['ADI', 'MLD']' in controls.yaml, but the risk(s) don't list this control in their 'controls' section in risks.yaml
     - [ISSUE: controls.yaml] Risks ['MST', 'MXF'] reference control 'controlModelRepositoryTrustAndAttestation' in risks.yaml, but this control doesn't list these risks in its 'risks' section in controls.yaml
     - [ISSUE: risks.yaml] Control 'controlFederatedTrainingPrivacyAndRobustAggregation' lists risks '['FLP']' in controls.yaml, but none of these risks reference the control(s) in risks.yaml
     - [ISSUE: risks.yaml] Control 'controlCostQuotaGuardrails' claims to address risks '['EDW']' in controls.yaml, but the risk(s) don't list this control in their 'controls' section in risks.yaml
     - [ISSUE: controls.yaml] Risks ['DMS'] reference control 'controlCostQuotaGuardrails' in risks.yaml, but this control doesn't list these risks in its 'risks' section in controls.yaml
     - [ISSUE: risks.yaml] Control 'controlRetrievalAndVectorStorePoisoningDefense' lists risks '['RVP']' in controls.yaml, but none of these risks reference the control(s) in risks.yaml
     - [ISSUE: risks.yaml] Control 'controlEvaluationProvenanceAndDriftDetection' lists risks '['EBM']' in controls.yaml, but none of these risks reference the control(s) in risks.yaml
```

- Controls updated to properly claim risks: All offending controls now correctly list their associated risks in bidirectional consistency.

- Risks updated to properly reference controls: All corresponding risks now correctly list their associated controls in bidirectional consistency.

## Validation
- ✅ All control-risk relationships are now bidirectionally consistent
- ✅ GitHub Actions validation should now pass
- ✅ Schema validation maintained

## Testing
This resolves the validation failures identified in the GitHub Actions workflow and should allow CI/CD pipeline to pass.

## Commit Details
- **Single commit:** `resolved all inconsistencies identified in Issue #41`
- **Focused scope:** Only mapping consistency fixes, no functional changes
- **Data integrity:** Maintains all existing valid relationships while fixing inconsistencies

