### PR TITLE
This commit remediates CodeQL workflow permission findings

### DIFF
--- a/.github/workflows/validate-issue-templates.yml
+++ b/.github/workflows/validate-issue-templates.yml
@@ -18,6 +18,9 @@ on:
       - '.github/dependabot.yml'
       - 'risk-map/schemas/**'
 
+permissions:
+  contents: read
+
 jobs:
   # Setup job to install dependencies
   setup:

--- a/.github/workflows/validate_python.yml
+++ b/.github/workflows/validate_python.yml
@@ -10,6 +10,10 @@ on:
       - '**.py'
       - 'requirements*.txt'
       - 'pyproject.toml'
+
+permissions:
+  contents: read
+
 jobs:
   # Setup job to install dependencies and prepare validation scripts
   setup:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -12,6 +12,9 @@ on:
       - 'risk-map/yaml/**'
       - 'risk-map/schemas/**'
 
+permissions:
+  contents: read
+
 jobs:
   # Setup job to install dependencies and prepare validation scripts
   setup:

--- a/scripts/hooks/issue_template_generator/tests/test_template_renderer.py
+++ b/scripts/hooks/issue_template_generator/tests/test_template_renderer.py
@@ -1255,11 +1255,8 @@ class TestExpandFrameworkMappings:
         # Check description includes framework details
         description = mitre_section["attributes"]["description"]
         assert "MITRE ATLAS" in description or "mitre-atlas" in description.lower()
-        mitre_framework = next(
-            framework for framework in sample_frameworks_data["frameworks"] if framework["id"] == "mitre-atlas"
-        )
-        expected_suffix = f"({mitre_framework['baseUri']})"
-        assert description.endswith(expected_suffix)
+        expected_url = "https://atlas.mitre.org"
+        assert description.endswith(f"({expected_url})")
 
     def test_expand_framework_mappings_empty_frameworks(self, sample_schema_parser: SchemaParser) -> None:
         """

--- a/scripts/hooks/issue_template_generator/tests/test_template_renderer.py
+++ b/scripts/hooks/issue_template_generator/tests/test_template_renderer.py
@@ -1255,7 +1255,11 @@ class TestExpandFrameworkMappings:
         # Check description includes framework details
         description = mitre_section["attributes"]["description"]
         assert "MITRE ATLAS" in description or "mitre-atlas" in description.lower()
-        assert "atlas.mitre.org" in description or "https://atlas.mitre.org" in description
+        mitre_framework = next(
+            framework for framework in sample_frameworks_data["frameworks"] if framework["id"] == "mitre-atlas"
+        )
+        expected_suffix = f"({mitre_framework['baseUri']})"
+        assert description.endswith(expected_suffix)
 
     def test_expand_framework_mappings_empty_frameworks(self, sample_schema_parser: SchemaParser) -> None:
         """


### PR DESCRIPTION
## Summary

This PR addresses the current open CodeQL findings in `cosai-oasis/secure-ai-tooling`.

The alert set was reviewed before making changes to distinguish real issues from scanner noise:

- the GitHub Actions `missing-workflow-permissions` findings are real hardening gaps
- the Python `incomplete-url-substring-sanitization` findings were triggered in test assertions, not in production sanitization logic

This PR applies least-privilege workflow permissions and refactors the flagged test assertion so the branch is clean without changing runtime behavior.

## What Changed

- added explicit workflow-level `permissions: contents: read` to:
  - `.github/workflows/validate_python.yml`
  - `.github/workflows/validate-issue-templates.yml`
  - `.github/workflows/validation.yml`
- updated `scripts/hooks/issue_template_generator/tests/test_template_renderer.py` to validate the expected MITRE framework `baseUri` via fixture data instead of matching the raw URL substring pattern that CodeQL flagged

## Alert Triage

As of April 3, 2026, the open CodeQL alert set reviewed for this repo consisted of:

- 17 `actions/missing-workflow-permissions` alerts
- 2 `py/incomplete-url-substring-sanitization` alerts

Assessment:

- `actions/missing-workflow-permissions`: valid findings
- `py/incomplete-url-substring-sanitization`: false positives in test code

The Python findings were not evidence of exploitable URL sanitization bypass in repository runtime code. They came from hardcoded assertion patterns in a unit test:

- the flagged code was under `scripts/hooks/issue_template_generator/tests/`
- it asserted expected framework metadata for a trusted fixture value
- no user-controlled URL sanitization path was involved

## Validation

The following checks were run locally:

- `uv run --no-project --with-requirements requirements.txt pytest scripts/hooks/issue_template_generator/tests/test_template_renderer.py -q`
- `uv run --no-project --with-requirements requirements.txt python -c "import yaml; ..."`

Observed results:

- `84 passed` in `test_template_renderer.py`
- modified workflow YAML parsed successfully