### PR TITLE
Contributor guidance: title style guides, submission readiness, and template-generator hardening

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_component.yml
+++ b/.github/ISSUE_TEMPLATE/new_component.yml
@@ -9,27 +9,20 @@ body:
         ## Propose a New Component
         Use this template to suggest a new AI system component for the risk framework.
 
+        📋 **Before you submit**: Read the [Submission Readiness Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/submission-readiness-guide.md) to understand the quality bar.
+
         **Required fields** are marked with an asterisk (*).
 
         ⚠️ **Important**: Component edges must be bidirectional. If you add `A → B`, then `B ← A` must also exist.
 
   - type: input
-    id: component-id
-    attributes:
-      label: Component ID*
-      description: |
-        Unique identifier in camelCase format
-
-        Must start with "component" (e.g., componentMyNewComponent)
-      placeholder: 'e.g., componentPromptCache'
-    validations:
-      required: true
-
-  - type: input
     id: component-title
     attributes:
       label: Component Title*
-      description: A concise, human-readable name for the component
+      description: |
+        A concise, human-readable name for the component. The ID is mechanically derived from this title.
+
+        📋 See the [Component Titles Style Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/component-titles-style-guide.md) for naming rules.
       placeholder: 'e.g., Prompt Cache'
     validations:
       required: true
@@ -123,4 +116,6 @@ body:
       description: Please confirm the following
       options:
         - label: I have reviewed existing components to ensure this is not a duplicate
+          required: true
+        - label: I have read the Submission Readiness Guide and believe my proposal meets the quality bar
           required: true

--- a/.github/ISSUE_TEMPLATE/new_control.yml
+++ b/.github/ISSUE_TEMPLATE/new_control.yml
@@ -9,14 +9,19 @@ body:
         ## Propose a New Control
         Use this template to suggest a new security control for the AI risk framework.
 
+        📋 **Before you submit**: Read the [Submission Readiness Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/submission-readiness-guide.md) to understand the quality bar and see [Common Review Findings](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/common-review-findings.md) to avoid the most frequent rework requests.
+
         **Required fields** are marked with an asterisk (*).
 
   - type: input
     id: control-title
     attributes:
       label: Control Title*
-      description: A concise, descriptive name for the control
-      placeholder: 'e.g., Privacy Enhancing Technologies'
+      description: |
+        A concise noun phrase naming the defense. The ID is mechanically derived from this title.
+
+        📋 See the [Control Titles Style Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/control-titles-style-guide.md) for naming rules.
+      placeholder: 'e.g., Prompt Isolation'
     validations:
       required: true
 
@@ -58,8 +63,6 @@ body:
         - label: personaApplicationDeveloper
         - label: personaGovernance
         - label: personaEndUser
-        - label: personaModelCreator
-        - label: personaModelConsumer
 
   - type: textarea
     id: components
@@ -103,7 +106,9 @@ body:
         Map this control to external security frameworks by listing relevant mitigation or control IDs.
         Enter one ID per line. Format: `framework-id: mapping-value`
 
-        Valid frameworks for controls include: mitre-atlas, nist-ai-rmf, owasp-top10-llm, eu-ai-act
+        Valid frameworks for controls include: mitre-atlas, nist-ai-rmf, owasp-top10-llm, eu-ai-act. Controls use MITRE ATLAS **mitigations** (`AML.M####`), not techniques.
+
+        📋 See the [Framework Mappings Style Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/framework-mappings-style-guide.md) for per-framework rules.
       placeholder: |
         mitre-atlas: AML.M0007
         nist-ai-rmf: GV-6.2
@@ -170,4 +175,6 @@ body:
       description: Please confirm the following
       options:
         - label: I have reviewed existing controls to ensure this is not a duplicate
+          required: true
+        - label: I have read the Submission Readiness Guide and believe my proposal meets the quality bar
           required: true

--- a/.github/ISSUE_TEMPLATE/new_persona.yml
+++ b/.github/ISSUE_TEMPLATE/new_persona.yml
@@ -10,29 +10,19 @@ body:
 
         Use this template to suggest a new persona for the AI risk framework.
 
+        📋 **Before you submit**: Read the [Submission Readiness Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/submission-readiness-guide.md) to understand the quality bar.
+
         **Required fields** are marked with an asterisk (*).
 
-        **Current personas**: Model Creator, Model Consumer
+        **Current personas**: see [`personas.yaml`](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/yaml/personas.yaml) for the full list (10 personas as of writing, including Model Provider, Data Provider, Platform Provider, Model Serving, Agentic Provider, Application Developer, AI System Governance, and End User).
 
         **Note**: Personas represent key roles in the AI ecosystem responsible for implementing controls and managing risks. Consider carefully whether a new persona is needed or if the proposed role fits within existing personas.
-
-  - type: input
-    id: persona-id
-    attributes:
-      label: Persona ID*
-      description: |
-        Unique identifier in camelCase format
-
-        Must start with "persona" (e.g., personaModelAuditor)
-      placeholder: 'e.g., personaModelAuditor'
-    validations:
-      required: true
 
   - type: input
     id: persona-title
     attributes:
       label: Persona Title*
-      description: A concise, human-readable name for the persona
+      description: A concise, human-readable name for the persona. The ID is mechanically derived from this title.
       placeholder: 'e.g., Model Auditor'
     validations:
       required: true
@@ -102,15 +92,27 @@ body:
         - Lack of independent oversight
 
   - type: textarea
+    id: identification-questions
+    attributes:
+      label: Identification Questions (Optional)
+      description: |
+        Yes/no, second-person, activity-based questions a reader can use to determine whether they are this persona.
+
+        📋 See the [Identification Questions Style Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/identification-questions-style-guide.md) for required form, scoping clauses, and reviewer checklist.
+      placeholder: |
+        Are you responsible for evaluating AI/ML models for compliance with internal or external policies?
+        Do you produce assessment reports about model behavior that other teams act on?
+
+  - type: textarea
     id: relationship-to-existing
     attributes:
       label: Relationship to Existing Personas*
       description: |
-        Explain how this persona relates to and differs from Model Creator and Model Consumer
+        Explain how this persona relates to and differs from the closest existing personas (e.g., Model Provider, Application Developer, End User)
 
         Why can't existing personas cover this role?
       placeholder: |
-        Unlike Model Creator (who develops models) and Model Consumer (who deploys models), this persona...
+        Unlike Model Provider (who trains/distributes models) and Application Developer (who integrates models into applications), this persona...
 
         This role is distinct because...
     validations:
@@ -147,4 +149,6 @@ body:
       description: Please confirm the following
       options:
         - label: I have reviewed existing personas to ensure this is not redundant
+          required: true
+        - label: I have read the Submission Readiness Guide and believe my proposal meets the quality bar
           required: true

--- a/.github/ISSUE_TEMPLATE/new_risk.yml
+++ b/.github/ISSUE_TEMPLATE/new_risk.yml
@@ -9,26 +9,19 @@ body:
         ## Propose a New Risk
         Use this template to suggest a new AI security risk for the framework.
 
+        📋 **Before you submit**: Read the [Submission Readiness Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/submission-readiness-guide.md) to understand the quality bar and see [Common Review Findings](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/common-review-findings.md) to avoid the most frequent rework requests.
+
         **Required fields** are marked with an asterisk (*).
-
-  - type: input
-    id: risk-id
-    attributes:
-      label: Risk ID*
-      description: |
-        Unique identifier using `risk` prefix + camelCase descriptor
-
-        Examples: riskDataPoisoning, riskPromptInjection, riskModelSourceTampering
-      placeholder: 'e.g., riskMembershipInference'
-    validations:
-      required: true
 
   - type: input
     id: risk-title
     attributes:
       label: Risk Title*
-      description: A concise, descriptive name for the risk
-      placeholder: 'e.g., Model Extraction via Membership Inference'
+      description: |
+        A concise noun phrase (2-5 words) naming the threat. The ID is mechanically derived from this title.
+
+        📋 See the [Risk Titles Style Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/risk-titles-style-guide.md) for naming rules.
+      placeholder: 'e.g., Membership Inference'
     validations:
       required: true
 
@@ -83,7 +76,10 @@ body:
     id: personas
     attributes:
       label: Applicable Personas*
-      description: Which personas need to mitigate this risk?
+      description: |
+        Which personas are **impacted by** this risk? (Risks list the personas harmed, not the personas who implement defenses.)
+
+        Note: `personaGovernance` is a controls-only persona and is not listed here. `personaEndUser` applies to most risks.
       options:
         - label: personaModelProvider
         - label: personaDataProvider
@@ -91,10 +87,7 @@ body:
         - label: personaModelServing
         - label: personaAgenticProvider
         - label: personaApplicationDeveloper
-        - label: personaGovernance
         - label: personaEndUser
-        - label: personaModelCreator
-        - label: personaModelConsumer
 
   - type: textarea
     id: controls
@@ -144,10 +137,13 @@ body:
         Map this risk to external security frameworks by listing relevant technique/attack IDs.
         Enter one ID per line. Format: `framework-id: mapping-value`
 
-        Valid frameworks for risks include: mitre-atlas, stride, owasp-top10-llm
+        Valid frameworks for risks include: mitre-atlas, stride, owasp-top10-llm. Risks use MITRE ATLAS **techniques** (`AML.T####`), not mitigations.
+
+        📋 See the [Framework Mappings Style Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/framework-mappings-style-guide.md) for per-framework rules.
       placeholder: |
-        mitre-atlas: AML.M0007
-        nist-ai-rmf: GV-6.2
+        mitre-atlas: AML.T0051
+        stride: information-disclosure
+        owasp-top10-llm: LLM01
 
   - type: checkboxes
     id: lifecycle-stage
@@ -211,4 +207,6 @@ body:
       description: Please confirm the following
       options:
         - label: I have reviewed existing risks to ensure this is not a duplicate
+          required: true
+        - label: I have read the Submission Readiness Guide and believe my proposal meets the quality bar
           required: true

--- a/.github/ISSUE_TEMPLATE/update_component.yml
+++ b/.github/ISSUE_TEMPLATE/update_component.yml
@@ -10,6 +10,8 @@ body:
 
         Use this template to propose changes to an existing component. Only fill out the sections relevant to your proposed changes.
 
+        📋 **Before you submit**: Skim the [Submission Readiness Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/submission-readiness-guide.md) for general conventions.
+
         ✨ **Automatic Bidirectionality**: When you modify edges, the reverse edges are automatically updated. If you add/remove an edge here, the connected components will be automatically updated to maintain bidirectional consistency.
 
   - type: input
@@ -122,4 +124,6 @@ body:
       description: Please confirm the following
       options:
         - label: I have provided a valid GitHub permalink to the component
+          required: true
+        - label: My proposed changes conform to the Submission Readiness Guide
           required: true

--- a/.github/ISSUE_TEMPLATE/update_control.yml
+++ b/.github/ISSUE_TEMPLATE/update_control.yml
@@ -10,6 +10,8 @@ body:
 
         Use this template to propose changes to an existing control. Only fill out the sections relevant to your proposed changes.
 
+        📋 **Before you submit**: Skim the [Submission Readiness Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/submission-readiness-guide.md) — the same persona, universal-control, and framework-mapping rules apply to updates.
+
   - type: input
     id: control-permalink
     attributes:
@@ -101,7 +103,9 @@ body:
         Add or remove framework mappings. Use `+` to add, `-` to remove.
         Format: `+/- framework-id: mapping-value`
 
-        Valid frameworks for controls: mitre-atlas, nist-ai-rmf, owasp-top10-llm, eu-ai-act
+        Valid frameworks for controls: mitre-atlas, nist-ai-rmf, owasp-top10-llm, eu-ai-act. Controls use MITRE ATLAS **mitigations** (`AML.M####`).
+
+        📋 See the [Framework Mappings Style Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/framework-mappings-style-guide.md) for per-framework rules.
       placeholder: |
         + mitre-atlas: AML.M0015
         + nist-ai-rmf: GV-4.1
@@ -125,4 +129,6 @@ body:
       description: Please confirm the following
       options:
         - label: I have provided a valid GitHub permalink to the control
+          required: true
+        - label: My proposed changes conform to the Submission Readiness Guide
           required: true

--- a/.github/ISSUE_TEMPLATE/update_persona.yml
+++ b/.github/ISSUE_TEMPLATE/update_persona.yml
@@ -10,7 +10,9 @@ body:
 
         Use this template to propose changes to an existing persona. Only fill out the sections relevant to your proposed changes.
 
-        **Current personas**: Model Creator, Model Consumer
+        📋 **Before you submit**: Skim the [Submission Readiness Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/submission-readiness-guide.md) for general conventions.
+
+        **Current personas**: see [`personas.yaml`](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/yaml/personas.yaml) for the full list.
 
   - type: input
     id: persona-permalink
@@ -33,6 +35,7 @@ body:
         - Update title (rename persona)
         - Update description (clarification or expansion)
         - Refine scope or responsibilities
+        - Update identification questions
         - Other (describe below)
     validations:
       required: true
@@ -45,10 +48,10 @@ body:
         Describe what you want to change and why. Be specific about what should be added, removed, or modified.
 
         **Examples:**
-        - "Update description to clarify that Model Creator includes both those who train from scratch and those who fine-tune existing models"
+        - "Update description to clarify that Model Provider includes both those who train from scratch and those who distribute foundation models"
         - "Expand scope to explicitly include MLOps engineers who manage model deployment pipelines"
-        - "Clarify distinction between Model Creator and Model Consumer for organizations that do both"
-        - "Update title from 'Model Creator' to 'Model Developer' for better industry alignment"
+        - "Clarify distinction between Model Provider and Application Developer for organizations that do both"
+        - "Update title from 'Model Serving' to 'Model Hosting' for better industry alignment"
       placeholder: |
         Current state: [what it says now]
         Proposed change: [what it should say]
@@ -85,6 +88,20 @@ body:
         - Role D
 
   - type: textarea
+    id: identification-questions
+    attributes:
+      label: Identification Questions Changes
+      description: |
+        Add or update identification questions for this persona. Use `+` to add, `-` to remove, or paste the full updated list.
+
+        Questions must be yes/no, second-person, and activity-based.
+
+        📋 See the [Identification Questions Style Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/identification-questions-style-guide.md) for required form, scoping clauses, and reviewer checklist.
+      placeholder: |
+        + Are you producing model evaluation reports that other teams act on?
+        - Do you build models? (replaced by more specific question above)
+
+  - type: textarea
     id: framework-impact
     attributes:
       label: Framework Impact Assessment
@@ -119,4 +136,6 @@ body:
       description: Please confirm the following
       options:
         - label: I have provided a valid GitHub permalink to the persona
+          required: true
+        - label: My proposed changes conform to the Submission Readiness Guide
           required: true

--- a/.github/ISSUE_TEMPLATE/update_risk.yml
+++ b/.github/ISSUE_TEMPLATE/update_risk.yml
@@ -10,6 +10,8 @@ body:
 
         Use this template to propose changes to an existing risk. Only fill out the sections relevant to your proposed changes.
 
+        📋 **Before you submit**: Skim the [Submission Readiness Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/submission-readiness-guide.md) — the same persona, universal-control, and framework-mapping rules apply to updates.
+
   - type: input
     id: risk-permalink
     attributes:
@@ -90,7 +92,9 @@ body:
         Add or remove framework mappings. Use `+` to add, `-` to remove.
         Format: `+/- framework-id: mapping-value`
 
-        Valid frameworks for risks: mitre-atlas, stride, owasp-top10-llm
+        Valid frameworks for risks: mitre-atlas, stride, owasp-top10-llm. Risks use MITRE ATLAS **techniques** (`AML.T####`).
+
+        📋 See the [Framework Mappings Style Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/framework-mappings-style-guide.md) for per-framework rules.
       placeholder: |
         + mitre-atlas: AML.T0051
         + stride: information-disclosure
@@ -138,4 +142,6 @@ body:
       description: Please confirm the following
       options:
         - label: I have provided a valid GitHub permalink to the risk
+          required: true
+        - label: My proposed changes conform to the Submission Readiness Guide
           required: true

--- a/risk-map/docs/contributing/common-review-findings.md
+++ b/risk-map/docs/contributing/common-review-findings.md
@@ -1,0 +1,158 @@
+# Common Review Findings
+
+This document lists the issues reviewers flag most often on new and updated CoSAI-RM content. Use it as a companion to [`submission-readiness-guide.md`](./submission-readiness-guide.md) — that guide tells you how to prepare a good proposal; this one tells you what goes wrong most often.
+
+Findings are grouped by severity. Structural issues block submission until fixed. Content-quality issues are flagged for human review and usually trigger a DISCUSS verdict.
+
+## Contents
+
+**Structural issues (block submission)**
+
+1. [ID convention violation or collision](#1-id-convention-violation-or-collision)
+2. [Dangling references](#2-dangling-references)
+3. [Bidirectional inconsistency](#3-bidirectional-inconsistency)
+4. [Missing required fields](#4-missing-required-fields)
+5. [Invalid enum value](#5-invalid-enum-value)
+
+**Content-quality issues (flagged for human review)**
+
+1. [Under-specification: description is too generic](#1-under-specification-description-is-too-generic)
+2. [Over-specification: mandates a specific vendor or technology](#2-over-specification-mandates-a-specific-vendor-or-technology)
+3. [Scope creep: one entry covers 2+ distinct concerns](#3-scope-creep-one-entry-covers-2-distinct-concerns)
+4. [Wrong persona model: implementers listed on a risk](#4-wrong-persona-model-implementers-listed-on-a-risk)
+5. [`personaGovernance` on a risk](#5-personagovernance-on-a-risk)
+6. [Universal control listed explicitly on a risk](#6-universal-control-listed-explicitly-on-a-risk)
+7. [Examples are hypothetical or vendor announcements](#7-examples-are-hypothetical-or-vendor-announcements)
+8. [Framework mapping ID doesn't exist or is the wrong type](#8-framework-mapping-id-doesnt-exist-or-is-the-wrong-type)
+9. [Parent technique and sub-technique both listed (MITRE ATLAS)](#9-parent-technique-and-sub-technique-both-listed-mitre-atlas)
+10. [Missing classical security equivalent](#10-missing-classical-security-equivalent)
+11. [Title doesn't follow the style guide](#11-title-doesnt-follow-the-style-guide)
+12. [Identification questions are miscalibrated (personas)](#12-identification-questions-are-miscalibrated-personas)
+
+---
+
+## Structural issues (block submission)
+
+These are auto-detected by the content-reviewer agent and validation tooling. A proposal with any of these findings cannot proceed until the issue is resolved.
+
+### 1. ID convention violation or collision
+
+The ID derived from the title is malformed (wrong casing, separators, uppercase abbreviation) or collides with an existing entry. The fix is always in the **title**, since the ID is mechanically derived from it.
+
+- Malformed examples: title yielding `risk_data_poisoning`, `RiskDataPoisoning`, or `riskMCPInjection`.
+- Collision example: a "Prompt Injection" proposal when `riskPromptInjection` already exists.
+- Fix: rewrite the title so the derived ID is lowercase prefix + camelCase and unique. To resolve collisions, add the discriminating dimension (surface, technique, scope) — do not suffix numbers or abbreviate. See [`submission-readiness-guide.md §1`](./submission-readiness-guide.md#section-1-creating-a-valid-id).
+
+### 2. Dangling references
+
+A field points to an ID that does not exist in the framework.
+
+- Example: a risk lists `controlFooBar` but no such control is defined.
+- Fix: verify every ID against the current YAML files. If the target entry doesn't exist yet, propose it separately.
+
+### 3. Bidirectional inconsistency
+
+Two entries reference each other asymmetrically — e.g., a control lists a risk but the risk doesn't list that control back.
+
+- Fix: when you propose an update that adds a relationship, update **both sides** of the edge.
+
+### 4. Missing required fields
+
+A field required by the schema is empty or absent.
+
+- Common omissions: `shortDescription`, `category`, `personas`, `examples`.
+- Fix: consult the schema file and the relevant issue template. Every `required: true` field must have content.
+
+### 5. Invalid enum value
+
+A field constrained by schema enum (e.g., `category`, `lifecycle`, `impact`, `actorAccess`) contains a value outside the allowed set.
+
+- Fix: copy the allowed values from the schema; do not invent new categories inline.
+
+---
+
+## Content-quality issues (flagged for human review)
+
+These are not auto-blocking but almost always trigger reviewer feedback. Addressing them upfront speeds the path to PROCEED.
+
+### 1. Under-specification: description is too generic
+
+The long description could apply to any software system, not specifically to AI or agentic systems.
+
+- Symptom: no mention of model training, inference, prompts, agents, tools, or AI-specific data flows.
+- Fix: state the classical security equivalent first, then name the AI-specific amplifier.
+
+### 2. Over-specification: mandates a specific vendor or technology
+
+The entry names a product, library, or vendor as the canonical implementation.
+
+- Fix: describe the capability, not the implementer. Vendor examples belong in the `examples` field with citations, not in the core description.
+
+### 3. Scope creep: one entry covers 2+ distinct concerns
+
+The proposal bundles multiple risks or controls that should be separate entries.
+
+- Symptom: the title contains "and," the description switches topics midway, or the personas/controls lists span unrelated domains.
+- Fix: split into multiple proposals. One entry, one concern.
+
+### 4. Wrong persona model: implementers listed on a risk
+
+The risk's `personas` field lists who would mitigate the risk rather than who is impacted.
+
+- Fix: re-read [`submission-readiness-guide.md §3`](./submission-readiness-guide.md#section-3-the-persona-model). Risks list impacted personas; controls list implementer personas.
+
+### 5. `personaGovernance` on a risk
+
+Governance is a control-side role. It should never appear on a risk's persona list.
+
+- Fix: remove `personaGovernance` from the risk. If the governance angle is important, it belongs in an associated governance control.
+
+### 6. Universal control listed explicitly on a risk
+
+The risk's `controls` field includes one of the 7 universal controls (`controlRedTeaming`, `controlVulnerabilityManagement`, `controlThreatDetection`, `controlIncidentResponseManagement`, `controlInternalPoliciesAndEducation`, `controlProductGovernance`, `controlRiskGovernance`).
+
+- Fix: remove them. Universal controls apply via `risks: all` and should never be enumerated per-risk.
+
+### 7. Examples are hypothetical or vendor announcements
+
+The `examples` field cites "what if" scenarios or product launch blog posts rather than real incidents or research.
+
+- Fix: replace with published incidents, academic papers, CVEs, or post-mortems. Every example must include a verifiable URL.
+
+### 8. Framework mapping ID doesn't exist or is the wrong type
+
+The proposal maps to an invalid MITRE ATLAS technique, a non-existent OWASP LLM entry, or applies a mitigation ID to a risk (or vice versa).
+
+- Fix: verify each ID against the referenced framework. Risks use techniques (`AML.T####`), controls use mitigations (`AML.M####`). See [`framework-mappings-style-guide.md`](./framework-mappings-style-guide.md).
+
+### 9. Parent technique and sub-technique both listed (MITRE ATLAS)
+
+The mappings list both `AML.T0020` and `AML.T0020.001`.
+
+- Fix: keep only the most specific applicable ID. Do not list both.
+
+### 10. Missing classical security equivalent
+
+The long description jumps straight into AI-specific framing without grounding the risk in a pre-AI security concept.
+
+- Fix: open with a one-sentence mapping to the classical equivalent (e.g., "Data poisoning extends classical supply-chain tampering into the model training pipeline..."), then explain the AI-specific amplifier.
+
+### 11. Title doesn't follow the style guide
+
+Common symptoms: 6+ words, verb phrases, "via"/"through"/"due to" clauses, compound "X and Y" titles, "Insufficient/Missing/Failure to" framing.
+
+- Fix: rewrite as a 2-5 word noun phrase naming the threat (for risks) or defense (for controls). See the per-type title style guides.
+
+### 12. Identification questions are miscalibrated (personas)
+
+Persona `identificationQuestions` are activity-based and yes/no answerable. Common defects: title-repeating questions, open-ended phrasing, or questions that overlap with another persona without scoping.
+
+- Fix: see [`identification-questions-style-guide.md`](./identification-questions-style-guide.md).
+
+---
+
+## How to self-check before submitting
+
+Run through the checklist in [`submission-readiness-guide.md`](./submission-readiness-guide.md#pre-submission-checklist). Every item on that list corresponds to a finding above. If you can confidently check all boxes, you have handled the common cases.
+
+For maintainers: the [content-reviewer agent](../../../scripts/agents/content-reviewer.md) and the [issue-response-reviewer agent](../../../scripts/agents/issue-response-reviewer.md) operationalize most of these checks. The content-reviewer is the source of truth for structural/quality findings; the issue-response-reviewer composes feedback for individual issues. When this document drifts, those agents take precedence.

--- a/risk-map/docs/contributing/component-titles-style-guide.md
+++ b/risk-map/docs/contributing/component-titles-style-guide.md
@@ -1,0 +1,185 @@
+# Component Titles Style Guide
+
+This guide covers how to write `title` fields for components in `risk-map/yaml/components.yaml`. Component titles name the building blocks of AI systems in the framework's architecture model.
+
+---
+
+## Purpose
+
+Component titles serve three functions:
+
+1. **Architecture communication** — Titles label nodes in the component relationship graph. They must be immediately understandable to someone reading the diagram.
+2. **ID derivation** — Component IDs are mechanically derived from titles using `component` + camelCase (e.g., "Training Data" becomes `componentTrainingData`).
+3. **Cross-reference clarity** — Components appear in control mappings, risk descriptions, and persona scoping. Consistent naming prevents confusion when the same component is referenced across entity types.
+
+---
+
+## Title Structure
+
+### Length
+
+Write titles of 1-4 words. Components are architectural elements, not descriptions — brevity is essential.
+
+| Words | Example | Notes |
+|-------|---------|-------|
+| 1 | Application | Only for top-level, broadly scoped elements |
+| 2 | Training Data | Most common — subject + qualifier |
+| 3 | Model Serving Infrastructure | Adds infrastructure/system context |
+| 4 | External Tools and Services | Upper bound — compound with "and" |
+
+### Form
+
+Titles must be **concrete nouns** that name the architectural element. They answer "what is this thing in the system?" — not "what does it do?"
+
+**Correct pattern:** `[Domain Qualifier] [Element]`
+
+```
+Training Data
+Model Storage
+Agent Reasoning Core
+Output Handling
+Data Sources
+```
+
+---
+
+## Content Rules
+
+### Name the element, not the function
+
+Component titles identify a part of the system architecture. They do not describe an activity, process, or capability.
+
+| Avoid | Prefer | Why |
+|-------|--------|-----|
+| Filtering Data | Data Filtering and Processing | Names the element, not the action |
+| How Models Are Served | Model Serving Infrastructure | Names the component, not the process |
+| Stores for Models | Model Storage | Concise noun form |
+
+### Reuse titles across categories when appropriate
+
+When the same functional role appears in multiple architectural categories (Application, Agent, Orchestration), the same title can be reused. The category provides the distinguishing context.
+
+```
+# Application category
+componentApplicationInputHandling   → "Input Handling"
+componentApplicationOutputHandling  → "Output Handling"
+
+# Agent category
+componentAgentInputHandling         → "Input Handling"
+componentAgentOutputHandling        → "Output Handling"
+
+# Orchestration category
+componentOrchestrationInputHandling → "Input Handling"
+componentOrchestrationOutputHandling→ "Output Handling"
+```
+
+The ID carries the category prefix; the title stays clean and reusable.
+
+### Use "and" sparingly for compound elements
+
+Join two tightly coupled elements with "and" when they form a single architectural concept that would be artificial to separate.
+
+```
+Data Filtering and Processing       # Tightly coupled pipeline stages
+External Tools and Services         # Both are external integrations
+Model Frameworks and Code           # Both are development artifacts
+```
+
+Do not use "and" to merge architecturally distinct components that happen to be related.
+
+### Add "Infrastructure" for deployment-layer components
+
+When a component names the serving, storage, or compute layer (rather than the logical element), append "Infrastructure" to distinguish it from the logical concept.
+
+```
+Data Storage Infrastructure         # The storage system, not the data
+Model Serving Infrastructure        # The serving layer, not the model
+```
+
+Compare with logical elements that omit the suffix:
+
+```
+Training Data                       # The data itself
+The Model                           # The model artifact itself
+Model Storage                       # Acceptable shorthand when context is clear
+```
+
+### Avoid acronyms except established terms
+
+Spell out concepts in full. The exception is industry-standard terms where the acronym is more recognizable than the expansion.
+
+| Avoid | Prefer |
+|-------|--------|
+| RAG Content | Retrieval Augmented Generation & Content |
+| ML Frameworks | Model Frameworks and Code |
+
+The ampersand (`&`) is acceptable in component titles where "and" would be ambiguous or overly long (e.g., "Retrieval Augmented Generation & Content").
+
+---
+
+## Reviewer Checklist
+
+When reviewing a proposed component title, check each criterion:
+
+- [ ] **1-4 words** — is the title within the expected length range?
+- [ ] **Concrete noun** — does it name an architectural element, not an activity?
+- [ ] **Reuse check** — if the same functional role exists in another category, does the title match?
+- [ ] **"And" justified** — if "and" is used, are the two elements genuinely inseparable?
+- [ ] **Infrastructure suffix** — if this is a deployment-layer component, is "Infrastructure" appended?
+- [ ] **Clean ID derivation** — does `component` + camelCase of this title produce a readable ID?
+
+---
+
+## Reference: Current Component Titles
+
+All 23 titles in the current framework, organized by category:
+
+**Data:**
+```
+Data Sources
+Data Filtering and Processing
+Training Data
+Data Storage Infrastructure
+```
+
+**Model:**
+```
+Model Frameworks and Code
+Model Evaluation
+Training and Tuning
+Model Storage
+Model Serving Infrastructure
+The Model
+```
+
+**Application:**
+```
+Application
+Output Handling
+Input Handling
+```
+
+**Orchestration:**
+```
+Agent Reasoning Core
+Output Handling
+Input Handling
+External Tools and Services
+Model Memory
+Retrieval Augmented Generation & Content
+```
+
+**Agent:**
+```
+Agent User Query
+Agent System Instructions
+Input Handling
+Output Handling
+```
+
+---
+
+**Related:**
+- [Adding a Component](../guide-components.md) — Step-by-step guide for adding component entries
+- [Risk Titles Style Guide](risk-titles-style-guide.md) — Naming conventions for risks
+- [Control Titles Style Guide](control-titles-style-guide.md) — Naming conventions for controls

--- a/risk-map/docs/contributing/control-titles-style-guide.md
+++ b/risk-map/docs/contributing/control-titles-style-guide.md
@@ -1,0 +1,168 @@
+# Control Titles Style Guide
+
+This guide covers how to write `title` fields for controls in `risk-map/yaml/controls.yaml`. Control titles are the primary human-readable identifier for each security measure in the framework.
+
+---
+
+## Purpose
+
+Control titles serve three functions:
+
+1. **Identification** — Contributors and readers use titles to quickly understand what a control provides without reading the full description.
+2. **ID derivation** — Control IDs are mechanically derived from titles using `control` + camelCase (e.g., "Training Data Management" becomes `controlTrainingDataManagement`).
+3. **Complementarity with risks** — Risk titles name threats; control titles name defenses. The two should read as natural complements (e.g., risk "Data Poisoning" is addressed by control "Training Data Sanitization").
+
+---
+
+## Title Structure
+
+### Length
+
+Write titles of 2-6 words. Most controls use 3-4 words.
+
+| Words | Example | Notes |
+|-------|---------|-------|
+| 2 | Red Teaming | Established security concept |
+| 3 | Training Data Management | Common — subject + capability |
+| 4 | Input Validation and Sanitization | Paired capabilities using "and" |
+| 5 | Model and Data Access Controls | Compound subject + capability |
+| 6 | Privacy Enhancing Technologies for Inference | Upper bound — uses "for" scope qualifier |
+
+### Form
+
+Titles must be **noun phrases** that name the defensive capability, security measure, or governance practice. They describe what the control provides, not what risk it prevents.
+
+**Correct pattern:** `[Subject/Domain] [Capability/Measure]`
+
+```
+Training Data Sanitization
+Model and Data Access Controls
+Agent Observability
+Threat Detection
+Orchestrator and Route Integrity
+```
+
+---
+
+## Content Rules
+
+### Name the defense, not the risk
+
+Control titles describe the protective capability. They do not restate the risk they mitigate.
+
+| Avoid | Prefer | Why |
+|-------|--------|-----|
+| Preventing Data Poisoning | Training Data Sanitization | Names the capability, not the risk |
+| Stopping Prompt Injection | Input Validation and Sanitization | Names the measure, not the attack |
+
+### Use "and" for paired capabilities
+
+Unlike risk titles (which avoid compound conjunctions), control titles commonly pair related capabilities with "and" when both are essential to the control's scope.
+
+```
+Input Validation and Sanitization
+Model and Data Integrity Management
+Adversarial Training and Testing
+User Transparency and Controls
+```
+
+Keep to two terms. Do not chain three or more concepts with "and."
+
+### Use "for" to scope context when needed
+
+When the same capability applies to different lifecycle stages or domains, use "for [context]" to distinguish.
+
+```
+Privacy Enhancing Technologies for Model Training
+Privacy Enhancing Technologies for Inference
+```
+
+This pattern is appropriate when the control's implementation differs materially between contexts. Do not add "for" qualifiers when the context is already clear from the subject.
+
+### Scope to AI/ML domain when needed
+
+When a title uses a generic security term, add a domain qualifier to distinguish it from general IT security practices.
+
+| Generic | Scoped | Qualifier |
+|---------|--------|-----------|
+| Access Controls | Model and Data Access Controls | "Model and Data" |
+| Tooling Security | Secure-by-Default ML Tooling | "ML" |
+| Observability | Agent Observability | "Agent" |
+| Permissions | Agent Permissions | "Agent" |
+
+Established security terms that already imply the domain do not need additional scoping:
+
+```
+Red Teaming                     # Already understood in AI context
+Threat Detection                # Generic but appropriately broad
+Vulnerability Management        # Standard security practice
+```
+
+### Avoid verb-led titles
+
+Control titles should not start with verbs or read as instructions.
+
+| Avoid | Prefer |
+|-------|--------|
+| Manage Training Data | Training Data Management |
+| Detect Threats | Threat Detection |
+| Isolate Compute | Isolated and Confidential Computing |
+
+---
+
+## Reviewer Checklist
+
+When reviewing a proposed control title, check each criterion:
+
+- [ ] **2-6 words** — is the title within the expected length range?
+- [ ] **Noun phrase** — does it read as a capability/measure, not a sentence or instruction?
+- [ ] **Names the defense** — does it describe what the control provides, not what risk it prevents?
+- [ ] **"And" used correctly** — are paired capabilities joined, not three-way chains?
+- [ ] **AI/ML scoped** — if using a generic security term, is it scoped to the AI domain?
+- [ ] **No verb-led phrasing** — does it avoid starting with an imperative verb?
+- [ ] **Clean ID derivation** — does `control` + camelCase of this title produce a readable ID?
+
+---
+
+## Reference: Current Control Titles
+
+All 29 titles in the current framework, sorted alphabetically:
+
+```
+Adversarial Training and Testing
+Agent Observability
+Agent Permissions
+Agent User Control
+Application Access and Resource Management
+Incident Response Management
+Input Validation and Sanitization
+Internal Policies and Education
+Isolated and Confidential Computing
+Model and Data Access Controls
+Model and Data Execution Integrity
+Model and Data Integrity Management
+Model and Data Inventory Management
+Orchestrator and Route Integrity
+Output Validation and Sanitization
+Privacy Enhancing Technologies for Inference
+Privacy Enhancing Technologies for Model Training
+Product Governance
+Red Teaming
+Retrieval and Vector System Integrity Management
+Risk Governance
+Secure-by-Default ML Tooling
+Threat Detection
+Training Data Management
+Training Data Sanitization
+User Data Management
+User Policies and Education
+User Transparency and Controls
+Vulnerability Management
+```
+
+---
+
+**Related:**
+- [Adding a Control](../guide-controls.md) — Step-by-step guide for adding control entries
+- [Risk Titles Style Guide](risk-titles-style-guide.md) — Complementary conventions for risk titles
+- [Framework Mappings Style Guide](framework-mappings-style-guide.md) — How to map controls to external frameworks

--- a/risk-map/docs/contributing/issue-templates-guide.md
+++ b/risk-map/docs/contributing/issue-templates-guide.md
@@ -2,16 +2,24 @@
 
 This guide explains how to use the GitHub issue templates available in the CoSAI Risk Map repository. These templates streamline the process of proposing new content or updating existing content in the AI security framework.
 
+> **Read these first.** Templates capture the _what_; two companion documents capture the _quality bar_:
+>
+> - [`submission-readiness-guide.md`](./submission-readiness-guide.md) — pre-submission checklist, ID conventions, persona model, universal controls, framework mappings, and overlap checking.
+> - [`common-review-findings.md`](./common-review-findings.md) — the issues reviewers flag most often, grouped by severity, with fix guidance.
+>
+> Every `new_*` template links to both. Working through the readiness guide before opening an issue is the fastest path to a PROCEED verdict.
+
 ## Table of Contents
 
 1. [Overview](#overview)
-2. [Control Templates](#control-templates)
-3. [Risk Templates](#risk-templates)
-4. [Component Templates](#component-templates)
-5. [Persona Templates](#persona-templates)
-6. [Infrastructure Template](#infrastructure-template)
-7. [Key Concepts](#key-concepts)
-8. [Common Pitfalls](#common-pitfalls)
+2. [Recent Template Changes](#recent-template-changes)
+3. [Control Templates](#control-templates)
+4. [Risk Templates](#risk-templates)
+5. [Component Templates](#component-templates)
+6. [Persona Templates](#persona-templates)
+7. [Infrastructure Template](#infrastructure-template)
+8. [Key Concepts](#key-concepts)
+9. [Common Pitfalls](#common-pitfalls)
 
 ---
 
@@ -44,6 +52,29 @@ The repository provides 9 issue templates organized into 5 categories:
 - **Update templates**: KISS (Keep It Simple, Stupid) approach with GitHub permalinks and free-form descriptions
 - **Automatic bidirectionality**: The system automatically creates reverse mappings (you don't need to update both sides manually)
 
+> **About "Required for review" counts:** Each template section below lists the fields a reviewer expects on a complete submission. GitHub Issue Forms only enforces a subset of these at submit time — it can mark individual `input`/`textarea` fields required, but it cannot require that any option in a `checkbox` group be selected. So a submission with empty Applicable Personas or Applicable Controls will pass the form but be flagged DISCUSS in review. Treat the counts as the review bar, not the form-validation bar.
+
+---
+
+## Recent Template Changes
+
+_Snapshot as of 2026-04-15. This section is a history aid and will drift; consult the live `.github/ISSUE_TEMPLATE/*.yml` files for current behavior._
+
+The following changes were applied across the issue templates alongside the introduction of the [Submission Readiness Guide](./submission-readiness-guide.md):
+
+| Template                   | Change                                                                                                  | Rationale                                                                                                                                                            |
+| -------------------------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `new_risk.yml`             | Removed `personaGovernance` from the persona checkbox list                                              | `personaGovernance` is a controls-only persona; risks list **impacted** personas, not implementers.                                                                  |
+| `new_risk.yml`             | Personas description rewritten to "impacted by," not "need to mitigate"                                 | Aligns with the documented persona model (risks = impacted, controls = implementers).                                                                                |
+| All `new_*` templates      | Removed manual ID input fields                                                                          | IDs are mechanically derived from the Title field — having both invited drift between submitted ID and title.                                                        |
+| `new_persona.yml`          | Added optional `Identification Questions` textarea with style guide link                                | Personas are scoped using yes/no, second-person, activity-based questions per the [Identification Questions Style Guide](./identification-questions-style-guide.md). |
+| `update_persona.yml`       | Added `Identification Questions Changes` field and "Update identification questions" change-type option | Allows targeted updates to a persona's identification questions without conflating them with description rewrites.                                                   |
+| All `new_*` and `update_*` | Added pointer to `submission-readiness-guide.md` in opening markdown and submission checklist           | Surfaces the quality bar before fields are filled.                                                                                                                   |
+| Title fields (`new_*`)     | Added pointer to per-entity title style guide                                                           | Title style guides are the source of truth; templates now route contributors there.                                                                                  |
+| Framework mapping fields   | Added pointer to `framework-mappings-style-guide.md` and noted the technique-vs-mitigation rule inline  | Wrong-entity-type mapping (e.g., `AML.M####` on a risk) is one of the most common review findings.                                                                   |
+
+If you maintain templates, see [`template-sync-procedures.md`](./template-sync-procedures.md) for keeping the YAML sources, schemas, and this guide in sync.
+
 ---
 
 ## Control Templates
@@ -54,14 +85,14 @@ The repository provides 9 issue templates organized into 5 categories:
 
 **File:** `.github/ISSUE_TEMPLATE/new_control.yml`
 
-**Required Fields (5):**
+**Required for review (6):**
 
-1. **Control Title** - Concise, descriptive name (e.g., "Privacy Enhancing Technologies")
+1. **Control Title** - Concise noun phrase naming the defense (e.g., "Privacy Enhancing Technologies for Model Training"). See [`control-titles-style-guide.md`](./control-titles-style-guide.md). The Control ID is mechanically derived from this title (`control` prefix + camelCase descriptor, e.g., `controlPrivacyEnhancingTechnologiesForModelTraining`).
 2. **Control Description** - Detailed explanation of purpose, implementation, and expected outcomes
-3. **Control Category** - Primary category from: Data, Infrastructure, Model, Application, Assurance, Governance
-4. **Applicable Personas** - Which personas implement this (Model Creator, Model Consumer)
-5. **Applicable Components** - Component IDs this control applies to (one per line) or "all"/"none"
-6. **Mitigated Risks** - Risk IDs this control addresses (one per line) or "all"
+3. **Control Category** - One of: `controlsData`, `controlsInfrastructure`, `controlsModel`, `controlsApplication`, `controlsAssurance`, `controlsGovernance`
+4. **Applicable Personas** - Which personas **implement** this control. See [persona model](./submission-readiness-guide.md#section-3-the-persona-model).
+5. **Applicable Components** - Component IDs this control applies to (one per line) or `all`/`none`
+6. **Mitigated Risks** - Risk IDs this control addresses (one per line) or `all` (universal control)
 
 **Optional Fields:**
 
@@ -74,18 +105,20 @@ The repository provides 9 issue templates organized into 5 categories:
 **Example Walkthrough:**
 
 ```yaml
-Control Title: Model Input Validation
-Control Description: Implement validation checks on all inputs to AI models to detect and reject malicious or malformed data before processing.
-Control Category: controlsModel (Model Controls)
+# Illustrative — fields show the form a new-control proposal takes.
+# (ID is mechanically derived from Title — submitter does not enter it.)
+Control Title: Prompt Isolation
+Control Description: Isolate untrusted prompt content from system instructions and tool-call surfaces so model-mediated injection cannot escalate into unintended actions.
+Control Category: controlsApplication
 Applicable Personas:
-  ☑ Model Creator
-  ☑ Model Consumer
+  ☑ personaApplicationDeveloper
+  ☑ personaAgenticProvider
 Applicable Components:
 componentInputHandling
 componentModelServing
 Mitigated Risks:
 riskPromptInjection
-SSRF
+riskModelEvasion
 ```
 
 **Reference Links:**
@@ -107,7 +140,7 @@ The template includes inline links to:
 
 **File:** `.github/ISSUE_TEMPLATE/update_control.yml`
 
-**Required Fields (3):**
+**Required for review (3):**
 
 1. **Control Permalink** - GitHub permalink to the control in `controls.yaml` (right-click line number → Copy permalink)
 2. **Change Type** - What you're changing (description, mappings, category, metadata, other)
@@ -163,15 +196,14 @@ This provides exact context for maintainers to see what you're changing.
 
 **File:** `.github/ISSUE_TEMPLATE/new_risk.yml`
 
-**Required Fields (7):**
+**Required for review (6):**
 
-1. **Risk ID** - Identifier using `risk` + camelCase descriptor format (e.g., `riskPromptInjection`, `riskDataPoisoning`, `riskModelSourceTampering`)
-2. **Risk Title** - Human-readable name
-3. **Short Description** - One-sentence summary
-4. **Long Description** - Detailed explanation of the risk
-5. **Risk Category** - Category from schema (e.g., Integrity, Confidentiality, Availability)
-6. **Applicable Personas** - Which personas face this risk
-7. **Applicable Controls** - Control IDs that mitigate this risk (one per line) or "all"
+1. **Risk Title** - Concise noun phrase naming the threat. See [`risk-titles-style-guide.md`](./risk-titles-style-guide.md). The Risk ID is mechanically derived from this title (`risk` prefix + camelCase descriptor, e.g., `riskPromptInjection`).
+2. **Short Description** - One- or two-sentence summary
+3. **Long Description** - Maps to a classical security concept, then names the AI-specific amplifier
+4. **Risk Category** - One of: `risksSupplyChainAndDevelopment`, `risksDeploymentAndInfrastructure`, `risksRuntimeInputSecurity`, `risksRuntimeDataSecurity`, `risksRuntimeOutputSecurity`
+5. **Applicable Personas** - Which personas are **impacted by** this risk (not implementers). `personaGovernance` is controls-only and is not listed here.
+6. **Applicable Controls** - Control IDs that mitigate this risk (one per line). Do **not** list the 7 universal controls — see [Universal Controls](./submission-readiness-guide.md#section-4-universal-controls).
 
 **Optional Fields:**
 
@@ -185,27 +217,35 @@ This provides exact context for maintainers to see what you're changing.
 **Example Walkthrough:**
 
 ```yaml
-Risk ID: MBTD
-Risk Title: Model Backdoor Trojan Deployment
-Short Description: Adversary embeds hidden functionality in model that activates on specific triggers
-Long Description: An attacker inserts malicious logic into the AI model during training or fine-tuning that remains dormant until triggered by specific inputs, allowing unauthorized actions or data exfiltration.
+# Illustrative — fields show the form a new-risk proposal takes.
+# (riskModelSourceTampering already exists in risks.yaml; this example shows
+# what a fresh proposal of that entry would look like.)
+# (ID is mechanically derived from Title — submitter does not enter it.)
+Risk Title: Model Source Tampering
+Short Description: An attacker modifies model weights or training artifacts before deployment, embedding hidden behaviors that activate on specific triggers at runtime.
+Long Description: |
+  Model source tampering is a model-supply-chain integrity risk — the classical
+  equivalent is a trojaned binary in a software supply chain. The AI-specific
+  amplifier is that the malicious behavior is encoded in model weights rather
+  than in inspectable source code, making it difficult to detect through
+  conventional code review. Tampering may occur during training, fine-tuning,
+  or via tampered base models.
 
-Risk Category: Integrity
+Risk Category: risksSupplyChainAndDevelopment
 Applicable Personas:
-  ☑ Model Creator
-  ☑ Model Consumer
+  ☑ personaModelProvider
+  ☑ personaApplicationDeveloper
+  ☑ personaEndUser
 Applicable Controls:
-controlModelValidation
-controlSupplyChainSecurity
-controlAdversarialTesting
+controlModelAndDataIntegrityManagement
+controlAdversarialTrainingAndTesting
 
 Examples:
-- Backdoor triggered by specific pixel patterns in images
-- Hidden functionality activated by rare token sequences
+<a href="https://arxiv.org/abs/1708.06733" target="_blank" rel="noopener">BadNets: Identifying Vulnerabilities in the Machine Learning Model Supply Chain (Gu et al., 2017)</a>
 
 Framework Mappings:
-MITRE ATLAS: AML.T0018
-STRIDE: Tampering
+mitre-atlas: AML.T0018
+stride: tampering
 ```
 
 **Reference Links:**
@@ -224,7 +264,7 @@ STRIDE: Tampering
 
 **File:** `.github/ISSUE_TEMPLATE/update_risk.yml`
 
-**Required Fields (3):**
+**Required for review (3):**
 
 1. **Risk Permalink** - GitHub permalink to the risk in `risks.yaml`
 2. **Change Type** - What you're changing (description, examples, mappings, etc.)
@@ -274,13 +314,12 @@ Supporting Evidence:
 
 **File:** `.github/ISSUE_TEMPLATE/new_component.yml`
 
-**Required Fields (5):**
+**Required for review (4):**
 
-1. **Component ID** - camelCase identifier starting with "component" (e.g., `componentFeatureStore`)
-2. **Component Title** - Human-readable name
-3. **Component Description** - What this component does and why it's important
-4. **Component Category** - Data, Infrastructure, Model, or Application
-5. **Edges** - Relationships to other components
+1. **Component Title** - Human-readable name. See [`component-titles-style-guide.md`](./component-titles-style-guide.md). The Component ID is mechanically derived from this title (`component` prefix + camelCase descriptor, e.g., `componentFeatureStore`).
+2. **Component Description** - What this component does and why it's important
+3. **Component Category** - Data, Infrastructure, Model, or Application
+4. **Edges** - Relationships to other components
 
 **Edge Relationships:**
 
@@ -290,7 +329,7 @@ Supporting Evidence:
 **Example Walkthrough:**
 
 ```yaml
-Component ID: componentFeatureStore
+# (ID is mechanically derived from Title — submitter does not enter it.)
 Component Title: Feature Store
 Component Description: Centralized repository for storing, managing, and serving features for ML training and inference.
 Component Category: Data
@@ -320,7 +359,7 @@ componentDataProcessing
 
 **File:** `.github/ISSUE_TEMPLATE/update_component.yml`
 
-**Required Fields (3):**
+**Required for review (3):**
 
 1. **Component Permalink** - GitHub permalink to component in `components.yaml`
 2. **Change Type** - What you're changing
@@ -367,14 +406,13 @@ Supporting Evidence:
 
 **File:** `.github/ISSUE_TEMPLATE/new_persona.yml`
 
-**Important Note:** Personas are rarely added. The framework currently has 2 personas (Model Creator, Model Consumer) that cover most use cases. Before proposing a new persona, carefully justify why existing personas don't suffice.
+**Important Note:** Personas are rarely added. The framework defines several personas covering common roles in AI development and deployment (see [`personas.yaml`](../../yaml/personas.yaml) for the current set). Before proposing a new persona, carefully justify why existing personas don't suffice. New personas should also propose `identificationQuestions` so readers can determine whether they fit — see the [Identification Questions Style Guide](./identification-questions-style-guide.md).
 
-**Required Fields (4):**
+**Required for review (3):**
 
-1. **Persona ID** - camelCase starting with "persona" (e.g., `personaModelAuditor`)
-2. **Persona Title** - Human-readable name
-3. **Persona Description** - Who this persona is and their responsibilities
-4. **Justification** - Why existing personas don't cover this use case
+1. **Persona Title** - Human-readable name. The Persona ID is mechanically derived from this title (`persona` prefix + camelCase descriptor, e.g., `personaModelAuditor`).
+2. **Persona Description** - Who this persona is and their responsibilities
+3. **Justification** - Why existing personas don't cover this use case
 
 **Additional Fields:**
 
@@ -387,16 +425,20 @@ Supporting Evidence:
 **Example Walkthrough:**
 
 ```yaml
-Persona ID: personaModelAuditor
+# (ID is mechanically derived from Title — submitter does not enter it.)
 Persona Title: Model Auditor
 Persona Description: External third-party auditor responsible for independent assessment and certification of AI systems for compliance and security.
 
 Justification:
-Existing personas (Model Creator, Model Consumer) don't cover external auditors who:
-  - Don't create or deploy models
+None of the existing personas (Model Provider, Data Provider, Platform Provider,
+Model Serving, Agentic Provider, Application Developer, AI System Governance,
+End User) cover external auditors who:
+  - Don't create or deploy models themselves
   - Need read-only access to inspect training data, model artifacts, and logs
   - Assess compliance against regulatory frameworks
   - Issue certification reports
+  (Distinct from personaGovernance, which sets internal policy rather than
+  performing external attestation.)
 
 Use Cases:
   - Third-party AI system certification
@@ -420,14 +462,17 @@ Personas don't have bidirectional relationships, so there's no automatic cross-m
 
 **File:** `.github/ISSUE_TEMPLATE/update_persona.yml`
 
-**Required Fields (3):**
+**Required for review (3):**
 
 1. **Persona Permalink** - GitHub permalink to persona in `personas.yaml`
 2. **Change Type** - What you're changing
 3. **Proposed Changes** - Free-form description
 
+**Change Type Options:** Update title (rename persona), Update description, Refine scope or responsibilities, **Update identification questions**, Other.
+
 **Additional Fields:**
 
+- **Identification Questions Changes** - Add or update identification questions for the persona using `+`/`-` syntax (or paste the full updated list). See the [Identification Questions Style Guide](./identification-questions-style-guide.md) for required form, scoping clauses, and reviewer checklist.
 - Framework impact assessment
 - Scope clarification (included/excluded roles)
 - Supporting evidence (industry standards, role definitions)
@@ -440,19 +485,20 @@ Persona Permalink: https://github.com/cosai-oasis/secure-ai-tooling/blob/jkl012/
 Change Type: Clarify scope and responsibilities
 
 Proposed Changes:
-Clarify that Model Consumer also includes organizations that fine-tune foundation models, not just those deploying off-the-shelf models.
+Clarify that Application Developer also includes organizations that fine-tune foundation models for their applications, not just those integrating off-the-shelf models.
 
 Scope Clarification:
 Included roles:
-- Organizations deploying pre-trained models
-- Organizations fine-tuning foundation models
-- SaaS providers integrating AI capabilities
+- Organizations integrating pre-trained models into applications
+- Organizations fine-tuning foundation models for application-specific use
+- SaaS providers building AI capabilities into their products
 
 Excluded roles:
-- End users of AI applications (not responsible for model deployment)
+- End users of AI applications (covered by personaEndUser)
+- Organizations training base models from scratch (covered by personaModelProvider)
 
 Supporting Evidence:
-- NIST AI RMF guidance on consumer responsibilities
+- NIST AI RMF guidance on application-developer responsibilities
 - MLOps maturity model: https://...
 ```
 

--- a/risk-map/docs/contributing/risk-titles-style-guide.md
+++ b/risk-map/docs/contributing/risk-titles-style-guide.md
@@ -1,0 +1,175 @@
+# Risk Titles Style Guide
+
+This guide covers how to write `title` fields for risks in `risk-map/yaml/risks.yaml`. Risk titles are the primary human-readable identifier for each risk and must be consistent across the framework.
+
+---
+
+## Purpose
+
+Risk titles serve three functions:
+
+1. **Identification** — Contributors and readers use titles to quickly understand what a risk describes without reading the full description.
+2. **ID derivation** — Risk IDs are mechanically derived from titles using `risk` + camelCase (e.g., "Data Poisoning" becomes `riskDataPoisoning`). A clear title produces a clear ID.
+3. **Framework consistency** — Titles appear in summary tables, graph visualizations, issue templates, and cross-references. Inconsistent titles degrade the framework's usability.
+
+---
+
+## Title Structure
+
+### Length
+
+Write titles of 2-5 words. Shorter titles are preferred when they capture the risk without ambiguity.
+
+| Words | Example | Notes |
+|-------|---------|-------|
+| 2 | Data Poisoning | Ideal — concise and precise |
+| 3 | Model Source Tampering | Common — subject + threat |
+| 4 | Economic Denial of Wallet | Acceptable — established term |
+| 5 | Excessive Data Handling During Inference | Upper bound — only when scoping is essential |
+| 6+ | — | Avoid — rephrase or split |
+
+### Form
+
+Titles must be **noun phrases** that name the threat, vulnerability, or attack vector. They are not sentences, not descriptions of missing controls, and not explanations of consequences.
+
+**Correct pattern:** `[Subject/Scope] [Threat Noun]`
+
+```
+Model Source Tampering
+Prompt Injection
+Tool Registry Tampering
+Agent Over-Permissioning
+MCP Transport Hijacking
+```
+
+---
+
+## Content Rules
+
+### Name the threat, not the missing control
+
+Titles describe what the attacker does or what goes wrong — not what defense is absent. Avoid "insufficient," "failure to," "lack of," or "missing" framing.
+
+| Avoid | Prefer | Why |
+|-------|--------|-----|
+| Insufficient Logging of Delegation Chains | Agent Delegation Chain Opacity | Names the threat state, not the absent control |
+| Failure to Bind Agent Identity to Model Artifacts | Stale Agent Identity Binding | Names the vulnerability, not the process failure |
+| Input Validation Failures in MCP Interactions | MCP Parameter Injection | Names the attack vector, not the missing defense |
+| MCP Session and Transport Security Failures | MCP Transport Hijacking | Names the attack, not the absent security |
+
+### No mechanism or scope clauses
+
+Do not embed "via...", "in...", "due to...", or "through..." clauses that explain how or where the risk occurs. That detail belongs in the description.
+
+| Avoid | Prefer | Why |
+|-------|--------|-----|
+| Resource Exhaustion via Uncontrolled Agent Tool Chaining | Runaway Agent Tool Loops | "via..." is a mechanism explanation |
+| Cross-Tenant Propagation via Shared Agent Identities | Cross-Tenant Credential Propagation | "via..." is redundant context |
+| Input Validation Failures in MCP Interactions | MCP Parameter Injection | "in..." is a scope qualifier |
+
+### No compound conjunctions
+
+Do not join two concepts with "and" unless both are essential to the risk's identity. If the second clause describes a consequence rather than a co-equal threat, drop it.
+
+| Avoid | Prefer | Why |
+|-------|--------|-----|
+| Broken Delegation Chains and Loss of Actor Clarity | Agent Delegation Chain Opacity | "Loss of Actor Clarity" is a consequence, not a second threat |
+| Input Validation and Sanitization Failures | MCP Parameter Injection | "Validation and Sanitization" is a compound where one term suffices |
+
+### Scope to AI/agentic domain when needed
+
+When a title uses a generic security concept that could apply to any software system, add an AI/agentic qualifier to scope it to this framework's domain.
+
+| Generic | Scoped | Pattern |
+|---------|--------|---------|
+| Confused Deputy Delegation | Agentic Delegation Confused Deputy | Adds "agentic" to scope the classic pattern |
+| Delegation Chain Opacity | Agent Delegation Chain Opacity | Adds "agent" to distinguish from general delegation |
+| Over-Permissioning | Agent Over-Permissioning | Adds "agent" like "Denial of ML Service" adds "ML" |
+
+Established AI/agentic terms that already imply the domain do not need additional scoping:
+
+```
+MCP Transport Hijacking          # "MCP" is inherently agentic
+Tool Registry Tampering           # "Tool Registry" is framework-specific
+Prompt Injection                  # "Prompt" is inherently AI
+```
+
+### Slashes for alternatives
+
+When a title involves two complementary or alternative terms, use a slash without spaces to join them. Both terms are retained in the derived ID.
+
+```
+Adapter/PEFT Injection           → riskAdapterPEFTInjection
+Prompt/Response Cache Poisoning  → riskPromptResponseCachePoisoning
+Zombie / Shadow MCP Servers      → riskZombieShadowMCPServers
+```
+
+---
+
+## Reviewer Checklist
+
+When reviewing a proposed risk title, check each criterion:
+
+- [ ] **2-5 words** — is the title within the expected length range?
+- [ ] **Noun phrase** — does it read as a thing, not a sentence or action?
+- [ ] **Names the threat** — does it describe the attack/vulnerability, not the missing control?
+- [ ] **No mechanism clauses** — free of "via...", "in...", "due to..." qualifiers?
+- [ ] **No compound conjunctions** — free of "and [consequence]" appendages?
+- [ ] **AI/agentic scoped** — if using a generic security term, is it scoped to the AI domain?
+- [ ] **Clean ID derivation** — does `risk` + camelCase of this title produce a readable ID?
+
+---
+
+## Reference: Current Risk Titles
+
+All 28 titles in the current framework, sorted alphabetically:
+
+```
+Accelerator and System Side-channels
+Adapter/PEFT Injection
+Agent Delegation Chain Opacity
+Agent Over-Permissioning
+Agentic Delegation Confused Deputy
+Covert Channels in Model Outputs
+Cross-Tenant Credential Propagation
+Data Poisoning
+Denial of ML Service
+Economic Denial of Wallet
+Evaluation/Benchmark Manipulation
+Excessive Data Handling
+Excessive Data Handling During Inference
+Federated/Distributed Training Privacy
+Inferred Sensitive Data
+Insecure Integrated Component
+Insecure Model Output
+Malicious Loader/Deserialization
+MCP Parameter Injection
+MCP Transport Hijacking
+Model Deployment Tampering
+Model Evasion
+Model Exfiltration
+Model Reverse Engineering
+Model Source Tampering
+Orchestrator/Route Hijack
+Prompt Injection
+Prompt/Response Cache Poisoning
+Retrieval/Vector Store Poisoning
+Rogue Actions
+Runaway Agent Tool Loops
+Sensitive Data Disclosure
+Shadow and Unknown Agents
+Stale Agent Identity Binding
+Tool Registry Tampering
+Tool Source Provenance
+Unauthorized Training Data
+Zombie / Shadow MCP Servers
+```
+
+**Note:** This list includes proposed new risks currently under review (issues #188-#199) alongside established entries. Proposed entries are subject to consolidation decisions and may not all be accepted.
+
+---
+
+**Related:**
+- [Adding a Risk](../guide-risks.md) — Step-by-step guide for adding risk entries
+- [Risk ID Migration](../design/risk-id-migration.md) — ID naming rules and full legacy-to-new mapping
+- [Framework Mappings Style Guide](framework-mappings-style-guide.md) — How to map risks to external frameworks

--- a/risk-map/docs/contributing/submission-readiness-guide.md
+++ b/risk-map/docs/contributing/submission-readiness-guide.md
@@ -1,0 +1,198 @@
+# Submission Readiness Guide
+
+This guide tells contributors how to prepare a high-quality proposal before opening a GitHub issue against CoSAI-RM. It covers the quality bar that reviewers apply, the conventions enforced by the content-reviewer, and the most common reasons proposals get sent back for revision.
+
+If you want to propose a new risk, control, component, or persona — or update an existing one — start here.
+
+---
+
+## Who this guide is for
+
+- You have an issue in mind and want to know what "good" looks like before you submit.
+- You've opened the issue template but aren't sure how strict the fields are.
+- You've received reviewer feedback and want to understand the rules behind it.
+
+If you just want to browse the framework, see [`risk-map/docs/README.md`](../README.md) and the summary tables instead.
+
+---
+
+## Pre-submission checklist
+
+Work through this list before opening an issue. Every item maps to a section below.
+
+- [ ] **Title yields a valid ID** — the ID is auto-derived as prefix + camelCase from the title (e.g., "Data Poisoning" → `riskDataPoisoning`, "Red Teaming" → `controlRedTeaming`); confirm your title produces a clean, non-colliding ID.
+- [ ] **Title follows the style guide** — noun phrase, correct length, no "via/through/due to" clauses.
+- [ ] **Description is AI- or agentic-specific** — not a restatement of a generic security concern.
+- [ ] **Classical security equivalent is named** — the long description maps to a pre-AI risk/defense, then explains the AI-specific amplifier.
+- [ ] **Personas use the correct model** — risks list _impacted_ personas; controls list _implementer_ personas.
+- [ ] **No universal controls on risks** — the 7 universal controls apply to all risks implicitly.
+- [ ] **Examples are real** — incidents, research, or vulnerability disclosures with verifiable URLs.
+- [ ] **Framework mappings use valid IDs from the correct framework** — no parent + sub-technique, no wrong entity type.
+- [ ] **No overlap with existing entries** — searched `risks-summary.md` / `controls-summary.md` and found nothing close.
+- [ ] **Short description is 1-2 sentences** — the long-form detail belongs in the description field.
+
+---
+
+## Section 1: Creating a valid ID
+
+IDs are **mechanically derived** from titles using the pattern `<prefix>` + `camelCase(title)`:
+
+| Entity    | Prefix      | Title          | ID                      |
+| --------- | ----------- | -------------- | ----------------------- |
+| Risk      | `risk`      | Data Poisoning | `riskDataPoisoning`     |
+| Control   | `control`   | Red Teaming    | `controlRedTeaming`     |
+| Component | `component` | Model Storage  | `componentModelStorage` |
+| Persona   | `persona`   | Model Provider | `personaModelProvider`  |
+
+Write the title first. The ID follows.
+
+**Common mistakes:**
+
+- **Uppercase abbreviations** (`riskMCPInjection`) — use `riskMcpInjection`. CoSAI-RM migrated away from uppercase abbreviations; see the [risk ID migration design doc](../design/risk-id-migration.md) for history.
+- **Underscores or hyphens** (`risk_data_poisoning`, `risk-data-poisoning`) — always camelCase, no separators.
+- **Plural prefix** (`risksDataPoisoning`) — the prefix is singular even though the YAML key is plural.
+- **Collision with an existing ID** — if your derived ID matches one already in `<entity>.yaml`, refine the **title** to disambiguate (add the discriminating dimension — surface, technique, scope). Do not suffix numbers (`riskPromptInjection2`), abbreviate (`riskPI`), or otherwise hand-edit the ID; the title is the only knob.
+
+---
+
+## Section 2: Writing a good title
+
+Each entity type has a dedicated style guide. Read the one that applies before drafting:
+
+- Risks → [`risk-titles-style-guide.md`](./risk-titles-style-guide.md)
+- Controls → [`control-titles-style-guide.md`](./control-titles-style-guide.md)
+- Components → [`component-titles-style-guide.md`](./component-titles-style-guide.md)
+
+**Quick self-test:** Does the title read as a _thing_ (noun phrase) rather than an _action_ (verb phrase) or a _sentence_? If it starts with "Insufficient," "Failure to," "Lack of," or "Missing," rephrase it to name the threat or defense directly.
+
+| Avoid                                 | Prefer                        |
+| ------------------------------------- | ----------------------------- |
+| Insufficient Logging of Agent Actions | Agent Action Opacity          |
+| Failure to Validate Tool Inputs       | Tool Input Injection          |
+| Lack of Output Sanitization           | Output Sanitization (control) |
+
+---
+
+## Section 3: The persona model
+
+CoSAI-RM uses **two different persona models** depending on the entity type. Getting this wrong is one of the most common review findings.
+
+### For risks: personas = who is _impacted_
+
+List the personas **harmed by** the risk, not the personas who could mitigate it.
+
+- `personaEndUser` appears on most risks. End users are almost always impacted.
+- `personaGovernance` **does not appear on risks**. Governance is a control-side role — governance personas implement policy; they are not harmed by threats in the same direct sense as operational personas.
+- `personaModelProvider`, `personaApplicationDeveloper`, `personaEndUser`, etc. appear on risks whose failure modes directly hit those roles.
+
+### For controls: personas = who _implements_ the defense
+
+List the personas **responsible for** putting the control in place.
+
+- `personaGovernance` is common on policy, governance, and assurance controls.
+- `personaEndUser` rarely appears on controls — end users generally cannot implement technical defenses.
+- `personaApplicationDeveloper`, `personaModelServing`, etc. appear on controls they own operationally.
+
+### Common mistake
+
+Listing implementers on a risk (e.g., adding `personaApplicationDeveloper` to a risk because developers are the ones who should fix it). Fix it by asking: _is this persona harmed when this risk materializes?_ If not, remove them.
+
+---
+
+## Section 4: Universal controls
+
+Seven controls have `risks: all` in `controls.yaml` — they apply to **every risk implicitly**:
+
+1. `controlRedTeaming` — Red Teaming
+2. `controlVulnerabilityManagement` — Vulnerability Management
+3. `controlThreatDetection` — Threat Detection
+4. `controlIncidentResponseManagement` — Incident Response Management
+5. `controlInternalPoliciesAndEducation` — Internal Policies and Education
+6. `controlProductGovernance` — Product Governance
+7. `controlRiskGovernance` — Risk Governance
+
+**Rule:** never list a universal control in a risk's `controls` field, and never list a risk in a universal control's `risks` field. The `all` sentinel handles the relationship.
+
+**Why:** the framework checks bidirectional integrity — if a risk lists a universal control explicitly, it creates a duplicate edge that fails validation and confuses downstream tables.
+
+When you propose a new risk, do **not** enumerate the 7 universal controls as applicable. Only list non-universal controls.
+
+---
+
+## Section 5: Examples requirements
+
+The `examples` field anchors a risk or control to observable reality. Reviewers apply three checks:
+
+1. **Real, not hypothetical.** Published incidents, academic research, vulnerability disclosures, or documented bugs qualify. Thought experiments and "what if an attacker..." scenarios do not.
+2. **Not a vendor product announcement.** A blog post announcing a new defensive product is not evidence of a risk or control. A post-mortem describing how that product caught an incident is.
+3. **Verifiable URLs.** Every example must cite a source the reader can open. Format examples as HTML anchors matching existing entries in the YAML files.
+
+When in doubt, browse existing `examples` fields in `risks.yaml` or `controls.yaml` to calibrate.
+
+---
+
+## Section 6: Framework mappings
+
+Different entity types map to different external frameworks. See [`framework-mappings-style-guide.md`](./framework-mappings-style-guide.md) for the full rules.
+
+| Entity  | STRIDE                 | MITRE ATLAS               | OWASP LLM Top 10 | NIST AI RMF           |
+| ------- | ---------------------- | ------------------------- | ---------------- | --------------------- |
+| Risk    | ✓ (lowercase category) | Techniques (`AML.T####`)  | ✓ (`LLM##`)      | —                     |
+| Control | —                      | Mitigations (`AML.M####`) | —                | ✓ (subcategory level) |
+
+**Rules of thumb:**
+
+- Risks map to **techniques**; controls map to **mitigations**. Do not mix.
+- Never map a parent technique **and** one of its sub-techniques. Pick the most specific applicable ID.
+- Verify every mapping ID exists in the referenced framework before submitting.
+
+---
+
+## Section 7: Checking for overlap
+
+Before you open a new-entry issue, verify your proposal doesn't duplicate or near-duplicate an existing entry.
+
+1. **Browse the summary tables**
+   - Risks → [`risk-map/tables/risks-summary.md`](../../tables/risks-summary.md)
+   - Controls → [`risk-map/tables/controls-summary.md`](../../tables/controls-summary.md)
+2. **Search the YAML** for keywords from your title and description.
+3. **If you find a close match**, propose an **update** to the existing entry rather than a new entry. Use the appropriate `update_*.yml` template.
+
+If the overlap is partial (your proposal covers an additional angle), call that out explicitly in the issue so the reviewer can decide whether to extend the existing entry or create a new one.
+
+---
+
+## Section 8: What happens after you submit
+
+1. **Triage.** A maintainer labels the issue and confirms it has enough detail to review.
+2. **Automated checks.** The content-reviewer agent runs structural and style checks and posts findings as a comment.
+3. **Human review.** A maintainer reviews the proposal against this guide, overlap with existing content, and framework fit.
+4. **Verdict.** One of:
+   - **PROCEED** — the proposal is accepted; a PR follows.
+   - **DISCUSS** — the proposal needs scoping, clarification, or consolidation before it can proceed.
+   - **RETHINK** — the proposal doesn't fit CoSAI-RM's scope as currently framed.
+
+Common revision requests:
+
+- Split one proposal into two (scope creep).
+- Consolidate with an existing entry.
+- Rename the title to conform to the style guide.
+- Remove universal controls, or move governance personas off a risk.
+- Replace hypothetical examples with cited incidents.
+
+See [`common-review-findings.md`](./common-review-findings.md) for the full list of flagged issues.
+
+---
+
+## Related documentation
+
+- **Style guides:**
+  - [`risk-titles-style-guide.md`](./risk-titles-style-guide.md)
+  - [`control-titles-style-guide.md`](./control-titles-style-guide.md)
+  - [`component-titles-style-guide.md`](./component-titles-style-guide.md)
+  - [`identification-questions-style-guide.md`](./identification-questions-style-guide.md)
+  - [`framework-mappings-style-guide.md`](./framework-mappings-style-guide.md)
+- **Process:**
+  - [`issue-templates-guide.md`](./issue-templates-guide.md) — which template to use and when
+  - [`common-review-findings.md`](./common-review-findings.md) — top reviewer findings with fix guidance
+  - [`template-sync-procedures.md`](./template-sync-procedures.md) — for maintainers keeping templates in sync

--- a/risk-map/docs/contributing/template-sync-procedures.md
+++ b/risk-map/docs/contributing/template-sync-procedures.md
@@ -330,7 +330,7 @@ Additional properties are not allowed ('validations' was unexpected)
   attributes:
     label: Applicable Personas*
     options:
-      - label: Model Creator
+      - label: Model Provider
   validations:
     required: true # <- NOT ALLOWED
 
@@ -340,7 +340,7 @@ Additional properties are not allowed ('validations' was unexpected)
   attributes:
     label: Applicable Personas*
     options:
-      - label: Model Creator
+      - label: Model Provider
         required: true # <- ALLOWED
 ```
 

--- a/risk-map/docs/guide-components.md
+++ b/risk-map/docs/guide-components.md
@@ -4,10 +4,10 @@ Once you've determined the need for a new component, the following steps are req
 
 ## 1. Add the new component ID to the schema
 
-First, declare the new component's unique ID in the schema. This makes the system aware of the new component and allows for validation.
+First, derive the new component ID from the component title (`component` + camelCase descriptor — e.g., "Feature Store" → `componentFeatureStore`) and declare it in the schema. This makes the system aware of the new component and allows for validation. (The issue-template flow derives this ID automatically; when authoring YAML/schema directly via PR, apply the same convention by hand.)
 
 - **File to edit**: `schemas/components.schema.json`
-- **Action**: Find the `enum` list under `definitions.component.properties.id` and add your new component's ID. The ID should follow the `component[Name]` convention.
+- **Action**: Find the `enum` list under `definitions.component.properties.id` and add your new component's ID alphabetically.
 
 ```json
 // In schemas/components.schema.json

--- a/risk-map/docs/guide-components.md
+++ b/risk-map/docs/guide-components.md
@@ -25,6 +25,8 @@ First, declare the new component's unique ID in the schema. This makes the syste
 
 Next, define the properties of your new component in the main data file. This includes its ID, title, a detailed description, and its category.
 
+> **Title convention**: Component titles must be short concrete nouns (1-4 words) that name the architectural element. See the [Component Titles Style Guide](contributing/component-titles-style-guide.md) for rules and examples.
+
 - **File to edit**: `components.yaml`
 - **Action**: Add a new entry to the `components` list.
 
@@ -139,6 +141,7 @@ After successful validation, follow the [General Content Contribution Workflow](
 ---
 
 **Related:**
+- [Component Titles Style Guide](contributing/component-titles-style-guide.md) - Title naming convention and reviewer checklist
 - [Validation Tools](validation.md) - Detailed validation commands
 - [Troubleshooting](troubleshooting.md) - Help with edge validation errors
 - [Best Practices](best-practices.md) - Development workflow tips

--- a/risk-map/docs/guide-controls.md
+++ b/risk-map/docs/guide-controls.md
@@ -27,6 +27,8 @@ First, declare the new control's unique ID in the `controls.schema.json` file. T
 
 Next, define the control's properties in the main `controls.yaml` data file. This is where you describe what the control is and map it to other parts of the framework.
 
+> **Title convention**: Control titles must be short noun phrases (2-6 words) that name the defensive capability or security measure. See the [Control Titles Style Guide](contributing/control-titles-style-guide.md) for rules and examples.
+
 - **File to edit**: `controls.yaml`
 - **Action**: Add a new entry to the `controls` list. When filling out the properties, you must select valid IDs from the other schema files.
 
@@ -187,6 +189,7 @@ Once validated, follow the [General Content Contribution Workflow](workflow.md) 
 ---
 
 **Related:**
+- [Control Titles Style Guide](contributing/control-titles-style-guide.md) - Title naming convention and reviewer checklist
 - [Validation Tools](validation.md) - Detailed validation commands
 - [Troubleshooting](troubleshooting.md) - Help with validation errors
 - [Best Practices](best-practices.md) - Development workflow tips

--- a/risk-map/docs/guide-controls.md
+++ b/risk-map/docs/guide-controls.md
@@ -4,7 +4,7 @@ Adding a new control involves defining it and then mapping it to the components,
 
 ## 1. Add the new control ID to the schema
 
-First, declare the new control's unique ID in the `controls.schema.json` file. This registers the new control with the framework. The ID should follow the `control[Name]` convention.
+First, derive the new control ID from the control title (`control` + camelCase descriptor — e.g., "Red Teaming" → `controlRedTeaming`) and declare it in `controls.schema.json`. This registers the new control with the framework. (The issue-template flow derives this ID automatically; when authoring YAML/schema directly via PR, apply the same convention by hand.)
 
 - **File to edit**: `schemas/controls.schema.json`
 - **Action**: Find the `enum` list under `definitions.control.properties.id` and add your new control ID alphabetically.
@@ -46,8 +46,8 @@ Next, define the control's properties in the main `controls.yaml` data file. Thi
       and why it is an effective safeguard.
   category: controlsModel
   personas:
-    - personaModelCreator
-    - personaModelConsumer
+    - personaModelProvider
+    - personaApplicationDeveloper
   components:
     - componentTheModel
     - componentOutputHandling
@@ -64,8 +64,8 @@ Next, define the control's properties in the main `controls.yaml` data file. Thi
       on AI infrastructure and products.
   category: controlsAssurance
   personas:
-    - personaModelCreator
-    - personaModelConsumer
+    - personaModelProvider
+    - personaApplicationDeveloper
   components: all # This control applies to all components
   risks: all # This control applies to all risks
 ```

--- a/risk-map/docs/guide-frameworks.md
+++ b/risk-map/docs/guide-frameworks.md
@@ -217,8 +217,8 @@ See [Personas Guide](guide-personas.md) for detailed persona descriptions and re
     - "Attackers compromise the model supply chain by injecting malicious code..."
   category: risksSupplyChainAndDevelopment
   personas:
-    - personaModelCreator
-    - personaModelConsumer
+    - personaModelProvider
+    - personaApplicationDeveloper
   controls:
     - controlVulnerabilityManagement
     - controlModelAndDataIntegrityManagement
@@ -251,8 +251,8 @@ See [Personas Guide](guide-personas.md) for detailed persona descriptions and re
     - "Implement cryptographic signing and verification for models and datasets"
   category: controlsModel
   personas:
-    - personaModelCreator
-    - personaModelConsumer
+    - personaModelProvider
+    - personaApplicationDeveloper
   components:
     - componentModelStorage
     - componentModelServing

--- a/risk-map/docs/guide-metadata.md
+++ b/risk-map/docs/guide-metadata.md
@@ -211,8 +211,8 @@ actorAccess:
     - "Attackers compromise the model supply chain by injecting malicious code..."
   category: risksSupplyChainAndDevelopment
   personas:
-    - personaModelCreator
-    - personaModelConsumer
+    - personaModelProvider
+    - personaApplicationDeveloper
   controls:
     - controlVulnerabilityManagement
     - controlModelAndDataIntegrityManagement
@@ -245,8 +245,8 @@ actorAccess:
     - "Implement cryptographic signing and verification for models and datasets"
   category: controlsModel
   personas:
-    - personaModelCreator
-    - personaModelConsumer
+    - personaModelProvider
+    - personaApplicationDeveloper
   components:
     - componentModelStorage
     - componentModelServing

--- a/risk-map/docs/guide-risks.md
+++ b/risk-map/docs/guide-risks.md
@@ -4,7 +4,7 @@ Risks represent the potential security threats that can affect the components of
 
 ## 1. Add the new risk ID to the schema
 
-First, add a unique ID for the new risk to the `risks.schema.json` file. The ID should follow the format `risk` + camelCase descriptor derived from the risk title (e.g., `riskDataPoisoning`, `riskPromptInjection`).
+First, derive the new risk ID from the risk title (`risk` + camelCase descriptor — e.g., "Data Poisoning" → `riskDataPoisoning`, "Prompt Injection" → `riskPromptInjection`) and add it to `risks.schema.json`. (The issue-template flow derives this ID automatically; when authoring YAML/schema directly via PR, apply the same convention by hand.)
 
 - **File to edit**: `schemas/risks.schema.json`
 - **Action**: Find the `enum` list under `definitions.risk.properties.id` and add your new risk ID alphabetically.
@@ -41,7 +41,7 @@ Next, provide the full definition of the risk in `risks.yaml`. This includes its
       and what its potential impact is.
   category: risksSupplyChainAndDevelopment # Required: Must match one of the risk categories
   personas:
-    - personaModelConsumer
+    - personaApplicationDeveloper
   controls:
     - controlNewControl
   examples: # Provide links to real-world examples or research

--- a/risk-map/docs/guide-risks.md
+++ b/risk-map/docs/guide-risks.md
@@ -21,6 +21,8 @@ First, add a unique ID for the new risk to the `risks.schema.json` file. The ID 
 
 Next, provide the full definition of the risk in `risks.yaml`. This includes its title, descriptions, associated personas, mitigating controls, and contextual information.
 
+> **Title convention**: Risk titles must be short noun phrases (2-5 words) that name the threat or attack vector directly. See the [Risk Titles Style Guide](contributing/risk-titles-style-guide.md) for rules and examples.
+
 - **File to edit**: `risks.yaml`
 - **Action**: Add a new entry to the `risks` list. The `personas` and `controls` lists must contain valid IDs from their respective schema files.
 
@@ -185,6 +187,7 @@ Once validated, follow the [General Content Contribution Workflow](workflow.md) 
 ---
 
 **Related:**
+- [Risk Titles Style Guide](contributing/risk-titles-style-guide.md) - Title naming convention and reviewer checklist
 - [Validation Tools](validation.md) - Detailed validation commands
 - [Troubleshooting](troubleshooting.md) - Help with validation errors
 - [Best Practices](best-practices.md) - Development workflow tips

--- a/scripts/TEMPLATES/new_component.template.yml
+++ b/scripts/TEMPLATES/new_component.template.yml
@@ -9,27 +9,20 @@ body:
         ## Propose a New Component
         Use this template to suggest a new AI system component for the risk framework.
 
+        📋 **Before you submit**: Read the [Submission Readiness Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/submission-readiness-guide.md) to understand the quality bar.
+
         **Required fields** are marked with an asterisk (*).
 
         ⚠️ **Important**: Component edges must be bidirectional. If you add `A → B`, then `B ← A` must also exist.
 
   - type: input
-    id: component-id
-    attributes:
-      label: Component ID*
-      description: |
-        Unique identifier in camelCase format
-
-        Must start with "component" (e.g., componentMyNewComponent)
-      placeholder: 'e.g., componentPromptCache'
-    validations:
-      required: true
-
-  - type: input
     id: component-title
     attributes:
       label: Component Title*
-      description: A concise, human-readable name for the component
+      description: |
+        A concise, human-readable name for the component. The ID is mechanically derived from this title.
+
+        📋 See the [Component Titles Style Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/component-titles-style-guide.md) for naming rules.
       placeholder: 'e.g., Prompt Cache'
     validations:
       required: true
@@ -121,4 +114,6 @@ body:
       description: Please confirm the following
       options:
         - label: I have reviewed existing components to ensure this is not a duplicate
+          required: true
+        - label: I have read the Submission Readiness Guide and believe my proposal meets the quality bar
           required: true

--- a/scripts/TEMPLATES/new_control.template.yml
+++ b/scripts/TEMPLATES/new_control.template.yml
@@ -9,14 +9,19 @@ body:
         ## Propose a New Control
         Use this template to suggest a new security control for the AI risk framework.
 
+        📋 **Before you submit**: Read the [Submission Readiness Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/submission-readiness-guide.md) to understand the quality bar and see [Common Review Findings](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/common-review-findings.md) to avoid the most frequent rework requests.
+
         **Required fields** are marked with an asterisk (*).
 
   - type: input
     id: control-title
     attributes:
       label: Control Title*
-      description: A concise, descriptive name for the control
-      placeholder: 'e.g., Privacy Enhancing Technologies'
+      description: |
+        A concise noun phrase naming the defense. The ID is mechanically derived from this title.
+
+        📋 See the [Control Titles Style Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/control-titles-style-guide.md) for naming rules.
+      placeholder: 'e.g., Prompt Isolation'
     validations:
       required: true
 
@@ -89,7 +94,9 @@ body:
         Map this control to external security frameworks by listing relevant mitigation or control IDs.
         Enter one ID per line. Format: `framework-id: mapping-value`
 
-        Valid frameworks for controls include: {{CONTROL_FRAMEWORKS_LIST}}
+        Valid frameworks for controls include: {{CONTROL_FRAMEWORKS_LIST}}. Controls use MITRE ATLAS **mitigations** (`AML.M####`), not techniques.
+
+        📋 See the [Framework Mappings Style Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/framework-mappings-style-guide.md) for per-framework rules.
       placeholder: |
         mitre-atlas: AML.M0007
         nist-ai-rmf: GV-6.2
@@ -132,4 +139,6 @@ body:
       description: Please confirm the following
       options:
         - label: I have reviewed existing controls to ensure this is not a duplicate
+          required: true
+        - label: I have read the Submission Readiness Guide and believe my proposal meets the quality bar
           required: true

--- a/scripts/TEMPLATES/new_risk.template.yml
+++ b/scripts/TEMPLATES/new_risk.template.yml
@@ -9,26 +9,19 @@ body:
         ## Propose a New Risk
         Use this template to suggest a new AI security risk for the framework.
 
+        📋 **Before you submit**: Read the [Submission Readiness Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/submission-readiness-guide.md) to understand the quality bar and see [Common Review Findings](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/common-review-findings.md) to avoid the most frequent rework requests.
+
         **Required fields** are marked with an asterisk (*).
-
-  - type: input
-    id: risk-id
-    attributes:
-      label: Risk ID*
-      description: |
-        Unique identifier using `risk` prefix + camelCase descriptor
-
-        Examples: riskDataPoisoning, riskPromptInjection, riskModelSourceTampering
-      placeholder: 'e.g., riskMembershipInference'
-    validations:
-      required: true
 
   - type: input
     id: risk-title
     attributes:
       label: Risk Title*
-      description: A concise, descriptive name for the risk
-      placeholder: 'e.g., Model Extraction via Membership Inference'
+      description: |
+        A concise noun phrase (2-5 words) naming the threat. The ID is mechanically derived from this title.
+
+        📋 See the [Risk Titles Style Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/risk-titles-style-guide.md) for naming rules.
+      placeholder: 'e.g., Membership Inference'
     validations:
       required: true
 
@@ -79,9 +72,12 @@ body:
     id: personas
     attributes:
       label: Applicable Personas*
-      description: Which personas need to mitigate this risk?
+      description: |
+        Which personas are **impacted by** this risk? (Risks list the personas harmed, not the personas who implement defenses.)
+
+        Note: `personaGovernance` is a controls-only persona and is not listed here. `personaEndUser` applies to most risks.
       options:
-        {{PERSONAS}}
+        {{PERSONAS_FOR_RISKS}}
 
   - type: textarea
     id: controls
@@ -131,10 +127,13 @@ body:
         Map this risk to external security frameworks by listing relevant technique/attack IDs.
         Enter one ID per line. Format: `framework-id: mapping-value`
 
-        Valid frameworks for risks include: {{RISK_FRAMEWORKS_LIST}}
+        Valid frameworks for risks include: {{RISK_FRAMEWORKS_LIST}}. Risks use MITRE ATLAS **techniques** (`AML.T####`), not mitigations.
+
+        📋 See the [Framework Mappings Style Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/framework-mappings-style-guide.md) for per-framework rules.
       placeholder: |
-        mitre-atlas: AML.M0007
-        nist-ai-rmf: GV-6.2
+        mitre-atlas: AML.T0051
+        stride: information-disclosure
+        owasp-top10-llm: LLM01
 
   - type: checkboxes
     id: lifecycle-stage
@@ -174,4 +173,6 @@ body:
       description: Please confirm the following
       options:
         - label: I have reviewed existing risks to ensure this is not a duplicate
+          required: true
+        - label: I have read the Submission Readiness Guide and believe my proposal meets the quality bar
           required: true

--- a/scripts/TEMPLATES/update_control.template.yml
+++ b/scripts/TEMPLATES/update_control.template.yml
@@ -10,6 +10,8 @@ body:
 
         Use this template to propose changes to an existing control. Only fill out the sections relevant to your proposed changes.
 
+        📋 **Before you submit**: Skim the [Submission Readiness Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/submission-readiness-guide.md) — the same persona, universal-control, and framework-mapping rules apply to updates.
+
   - type: input
     id: control-permalink
     attributes:
@@ -101,7 +103,9 @@ body:
         Add or remove framework mappings. Use `+` to add, `-` to remove.
         Format: `+/- framework-id: mapping-value`
 
-        Valid frameworks for controls: {{CONTROL_FRAMEWORKS_LIST}}
+        Valid frameworks for controls: {{CONTROL_FRAMEWORKS_LIST}}. Controls use MITRE ATLAS **mitigations** (`AML.M####`).
+
+        📋 See the [Framework Mappings Style Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/framework-mappings-style-guide.md) for per-framework rules.
       placeholder: |
         + mitre-atlas: AML.M0015
         + nist-ai-rmf: GV-4.1
@@ -125,4 +129,6 @@ body:
       description: Please confirm the following
       options:
         - label: I have provided a valid GitHub permalink to the control
+          required: true
+        - label: My proposed changes conform to the Submission Readiness Guide
           required: true

--- a/scripts/TEMPLATES/update_risk.template.yml
+++ b/scripts/TEMPLATES/update_risk.template.yml
@@ -10,6 +10,8 @@ body:
 
         Use this template to propose changes to an existing risk. Only fill out the sections relevant to your proposed changes.
 
+        📋 **Before you submit**: Skim the [Submission Readiness Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/submission-readiness-guide.md) — the same persona, universal-control, and framework-mapping rules apply to updates.
+
   - type: input
     id: risk-permalink
     attributes:
@@ -90,7 +92,9 @@ body:
         Add or remove framework mappings. Use `+` to add, `-` to remove.
         Format: `+/- framework-id: mapping-value`
 
-        Valid frameworks for risks: {{RISK_FRAMEWORKS_LIST}}
+        Valid frameworks for risks: {{RISK_FRAMEWORKS_LIST}}. Risks use MITRE ATLAS **techniques** (`AML.T####`).
+
+        📋 See the [Framework Mappings Style Guide](https://github.com/cosai-oasis/secure-ai-tooling/blob/main/risk-map/docs/contributing/framework-mappings-style-guide.md) for per-framework rules.
       placeholder: |
         + mitre-atlas: AML.T0051
         + stride: information-disclosure
@@ -138,4 +142,6 @@ body:
       description: Please confirm the following
       options:
         - label: I have provided a valid GitHub permalink to the risk
+          required: true
+        - label: My proposed changes conform to the Submission Readiness Guide
           required: true

--- a/scripts/agents/content-reviewer.md
+++ b/scripts/agents/content-reviewer.md
@@ -4,14 +4,15 @@
 **Scope:** Content update review for the CoSAI Risk Map framework (`secure-ai-tooling` repository)
 
 ---
+
 ## Agent
+
 - **Name:** content-reviewer
-- **Description:** Use this agent to review CoSAI-RM content updates (YAML data files for risks, controls, components, personas). 
-  - Operates in 3 modes 
+- **Description:** Use this agent to review CoSAI-RM content updates (YAML data files for risks, controls, components, personas).
+  - Operates in 3 modes
     - diff (PR review of changed YAML)
-    - full (pre-submission quality check on complete files), 
-    - issue (evaluate a GitHub issue proposal before implementation) 
-    
+    - full (pre-submission quality check on complete files),
+    - issue (evaluate a GitHub issue proposal before implementation)
   - Specify mode and format (human or agent) when invoking.
 
   - Examples:
@@ -25,6 +26,11 @@
       Assistant: "Let me use the content-reviewer agent in issue mode to evaluate this proposal."
       <invoke content-reviewer agent>
 
+## Composition
+
+`content-reviewer` is composed by `scripts/agents/issue-response-reviewer.md`, which calls this agent in `issue` mode to source overlap, integrity, and style-guide findings before assembling a contributor-facing review comment. When a caller's goal is to draft a maintainer review for a GitHub issue, prefer invoking `issue-response-reviewer` (which delegates here) over invoking this agent directly.
+
+---
 
 ## Identity & Purpose
 
@@ -42,7 +48,7 @@ You operate in three modes, specified by the caller:
 
 - **`diff`** — PR review. You receive proposed YAML changes (additions, modifications, deletions) against the current framework state. Focus analysis on the delta and its ripple effects.
 - **`full`** — Full-file quality review. You receive a complete YAML file and assess it holistically. Used for pre-submission quality checks.
-- **`issue`** — Pre-implementation review. You receive a GitHub issue describing a proposed change (in prose, not YAML). You evaluate the proposal for fit, overlap, completeness, and projected impact *before* implementation begins.
+- **`issue`** — Pre-implementation review. You receive a GitHub issue describing a proposed change (in prose, not YAML). You evaluate the proposal for fit, overlap, completeness, and projected impact _before_ implementation begins.
 
 ### Caller Format
 
@@ -85,36 +91,40 @@ If provided, use them to supplement (not override) the embedded schema awareness
 ### Content Types & Key Fields
 
 **Risks** (`risks.yaml`):
+
 - Required: `id`, `title`, `description`, `category`
 - Relationships: mapped to controls that mitigate them
-- Categories: grouped by risk domain (e.g., `risksData`, `risksModel`, `risksInfrastructure`, `risksApplication`)
+- Categories (enum in `risks.schema.json`): `risksSupplyChainAndDevelopment`, `risksDeploymentAndInfrastructure`, `risksRuntimeInputSecurity`, `risksRuntimeDataSecurity`, `risksRuntimeOutputSecurity`
 - May include framework references: MITRE ATLAS, NIST AI RMF, OWASP Top 10 for LLM
 
 **Controls** (`controls.yaml`):
+
 - Required: `id`, `title`, `description`, `category`
 - Relationships: `risks` (which risks this control mitigates), `components` (which components this applies to), `personas` (relevant roles)
 - Special values: `risks: all`, `components: all`, `components: none` — valid but flagged for review
 - May include framework references: MITRE ATLAS, NIST AI RMF, OWASP Top 10 for LLM
 
 **Components** (`components.yaml`):
+
 - Required: `id`, `title`, `description`, `category`
 - Relationships: `to` and `from` edges (bidirectional, validated by external tooling)
 - Categories: `componentsData`, `componentsInfrastructure`, `componentsModel`, `componentsApplication`
 
 **Personas** (`personas.yaml`):
+
 - Required: `id`, `title`, `description`
 - Relationships: referenced by controls
 
 ### ID Conventions (Enforced — violations are FAIL)
 
-| Content Type | Format | Casing | Examples |
-|---|---|---|---|
-| **Risks** | `risk` prefix + descriptor | camelCase | `riskDataPoisoning`, `riskExcessiveDataHandling`, `riskAcceleratorAndSystemSideChannels` |
-| **Controls** | `control` prefix + descriptor | camelCase | `controlAccessControls`, `controlSecureMLTooling` |
-| **Components** | `component` prefix + descriptor | camelCase | `componentTrainingData`, `componentModelRegistry` |
-| **Personas** | `persona` prefix + descriptor | camelCase | `personaModelProvider`, `personaModelConsumer` |
+| Content Type   | Format                          | Casing    | Examples                                                                                 |
+| -------------- | ------------------------------- | --------- | ---------------------------------------------------------------------------------------- |
+| **Risks**      | `risk` prefix + descriptor      | camelCase | `riskDataPoisoning`, `riskExcessiveDataHandling`, `riskAcceleratorAndSystemSideChannels` |
+| **Controls**   | `control` prefix + descriptor   | camelCase | `controlAccessControls`, `controlSecureMLTooling`                                        |
+| **Components** | `component` prefix + descriptor | camelCase | `componentTrainingData`, `componentModelRegistry`                                        |
+| **Personas**   | `persona` prefix + descriptor   | camelCase | `personaModelProvider`, `personaApplicationDeveloper`                                    |
 
-**Category IDs** follow `{typePlural}{Domain}` in camelCase: `risksData`, `controlsInfrastructure`, `componentsModel`, `componentsApplication`.
+**Category IDs** follow `{typePlural}{Domain}` in camelCase. Examples: `risksRuntimeInputSecurity`, `controlsInfrastructure`, `componentsModel` (personas have no category enum). Authoritative enums live in the per-type `*.schema.json` files; consult those rather than inferring.
 
 ---
 
@@ -122,21 +132,21 @@ If provided, use them to supplement (not override) the embedded schema awareness
 
 ### 1. Structural Validation
 
-| Check | Severity | Assertion |
-|---|---|---|
-| Missing required fields | **FAIL** | Agent asserts |
-| ID convention violation | **FAIL** | Agent asserts |
+| Check                                         | Severity | Assertion     |
+| --------------------------------------------- | -------- | ------------- |
+| Missing required fields                       | **FAIL** | Agent asserts |
+| ID convention violation                       | **FAIL** | Agent asserts |
 | Dangling reference (points to nonexistent ID) | **FAIL** | Agent asserts |
-| Bidirectional inconsistency (risk↔control) | **FAIL** | Agent asserts |
-| Unknown/invalid field names | **WARN** | Agent asserts |
+| Bidirectional inconsistency (risk↔control)    | **FAIL** | Agent asserts |
+| Unknown/invalid field names                   | **WARN** | Agent asserts |
 
 ### 2. Duplication Detection
 
-| Check | Severity | Assertion |
-|---|---|---|
-| Exact ID collision | **FAIL** | Agent asserts |
-| Semantic near-duplicate within same content type (similar title/description) | **WARN** | Human review |
-| Cross-type semantic overlap (e.g., a risk description that restates a control) | **INFO** | Human review |
+| Check                                                                          | Severity | Assertion     |
+| ------------------------------------------------------------------------------ | -------- | ------------- |
+| Exact ID collision                                                             | **FAIL** | Agent asserts |
+| Semantic near-duplicate within same content type (similar title/description)   | **WARN** | Human review  |
+| Cross-type semantic overlap (e.g., a risk description that restates a control) | **INFO** | Human review  |
 
 When flagging semantic duplicates, cite the existing entry by ID and title, and briefly explain the overlap.
 
@@ -144,29 +154,29 @@ When flagging semantic duplicates, cite the existing entry by ID and title, and 
 
 These are **always flagged for human review** — the agent does not assert pass/fail on content quality.
 
-| Check | Severity | Notes |
-|---|---|---|
-| **Under-specification**: vague or generic language | **WARN** | Priority concern. Flag descriptions that could apply to any software system without modification (e.g., "implement appropriate access controls"). Explain what AI-specific context is missing. |
-| **Over-specification**: implementation-prescriptive language | **WARN** | Flag descriptions that mandate specific technologies, vendors, or implementation patterns rather than security outcomes. |
-| **Scope creep**: a single entry covering multiple distinct concerns | **WARN** | Flag entries where the description addresses 2+ separable risks/controls that should be independent entries. |
+| Check                                                               | Severity | Notes                                                                                                                                                                                          |
+| ------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Under-specification**: vague or generic language                  | **WARN** | Priority concern. Flag descriptions that could apply to any software system without modification (e.g., "implement appropriate access controls"). Explain what AI-specific context is missing. |
+| **Over-specification**: implementation-prescriptive language        | **WARN** | Flag descriptions that mandate specific technologies, vendors, or implementation patterns rather than security outcomes.                                                                       |
+| **Scope creep**: a single entry covering multiple distinct concerns | **WARN** | Flag entries where the description addresses 2+ separable risks/controls that should be independent entries.                                                                                   |
 
 ### 4. Category Validation
 
-| Check | Severity | Assertion |
-|---|---|---|
-| Category matches existing category in current YAML | **PASS** | Agent asserts |
-| New category not present in current data | **INFO** | Human review — flag for governance, note whether justification is present |
+| Check                                              | Severity | Assertion                                                                 |
+| -------------------------------------------------- | -------- | ------------------------------------------------------------------------- |
+| Category matches existing category in current YAML | **PASS** | Agent asserts                                                             |
+| New category not present in current data           | **INFO** | Human review — flag for governance, note whether justification is present |
 
 ### 5. Cross-Content Integrity
 
-| Check | Severity | Assertion |
-|---|---|---|
-| Dangling references (any direction) | **FAIL** | Agent asserts |
-| Bidirectional inconsistency: control lists risk R but R does not reference control | **FAIL** | Agent asserts |
-| `all` or `none` special value used in components/risks list | **WARN** | Human review — may indicate under-specification |
-| Orphaned risk (no controls mitigate it) | **WARN** | Human review |
-| Orphaned control (maps to no risks) | **WARN** | Human review |
-| Unprotected component (no controls cover it) | **WARN** | Human review |
+| Check                                                                              | Severity | Assertion                                       |
+| ---------------------------------------------------------------------------------- | -------- | ----------------------------------------------- |
+| Dangling references (any direction)                                                | **FAIL** | Agent asserts                                   |
+| Bidirectional inconsistency: control lists risk R but R does not reference control | **FAIL** | Agent asserts                                   |
+| `all` or `none` special value used in components/risks list                        | **WARN** | Human review — may indicate under-specification |
+| Orphaned risk (no controls mitigate it)                                            | **WARN** | Human review                                    |
+| Orphaned control (maps to no risks)                                                | **WARN** | Human review                                    |
+| Unprotected component (no controls cover it)                                       | **WARN** | Human review                                    |
 
 **Component edge validation** (`to`/`from` bidirectional consistency): **Deferred to existing tooling** (`validate_component_edges.py`). Do not duplicate this check.
 
@@ -174,12 +184,13 @@ These are **always flagged for human review** — the agent does not assert pass
 
 When reviewed content includes fields governed by a style guide, load the guide and apply its reviewer checklist as additional review checks.
 
-| Content field | Style guide path | Trigger |
-|---|---|---|
+| Content field             | Style guide path                                                     | Trigger                                             |
+| ------------------------- | -------------------------------------------------------------------- | --------------------------------------------------- |
 | `identificationQuestions` | `risk-map/docs/contributing/identification-questions-style-guide.md` | Any persona with `identificationQuestions` in scope |
-| `mappings` | `risk-map/docs/contributing/framework-mappings-style-guide.md` | Any entity with `mappings` in scope |
+| `mappings`                | `risk-map/docs/contributing/framework-mappings-style-guide.md`       | Any entity with `mappings` in scope                 |
 
 **Procedure:**
+
 1. Use the Read tool to load the applicable style guide(s) when a trigger condition is met
 2. Apply the guide's **Reviewer Checklist** section to each relevant entity in the reviewed content
 3. Report violations as **WARN** severity with `assertion: "human_review"`
@@ -193,6 +204,7 @@ The style guides are the single source of truth for these conventions. Always re
 ### 7. Governance Awareness
 
 When content is flagged or known to be **under governance review**:
+
 - Modifications to such content are **not blocked** but receive elevated visibility
 - Severity of findings on governed content is reported at one level higher than normal (INFO→WARN, WARN→WARN with governance tag)
 - The output clearly tags findings on governed content with `[GOVERNANCE]`
@@ -201,30 +213,35 @@ When content is flagged or known to be **under governance review**:
 
 ## Issue Mode: Pre-Implementation Review
 
-When invoked in `issue` mode, the agent evaluates a *proposal* (not YAML content) across four dimensions:
+When invoked in `issue` mode, the agent evaluates a _proposal_ (not YAML content) across four dimensions:
 
 ### Fit
+
 - Does the proposed change align with the framework's scope and the target entity's existing definition?
 - Does it introduce concepts that belong in the CoSAI Risk Map, or does it stray into adjacent concerns (compliance, policy, operational process)?
 - For persona updates: do proposed identification questions clearly distinguish this persona from others?
 
 ### Overlap
+
 - Does the proposal duplicate or conflict with existing content in any content type?
 - Could the proposed change be addressed by modifying an existing entry rather than adding new content?
 - Are there existing risks, controls, or components that already cover the proposed concern?
 
 ### Completeness
+
 - Does the proposal specify enough detail for someone to implement it in YAML?
 - Are there gaps — e.g., a new control proposed without specifying which risks it mitigates or which components it applies to?
 - Does it reference dependencies (e.g., other issues like "assumes issue #143 is accepted") and are those dependencies clear?
 
 ### Impact Preview
+
 - What entities would be affected if this proposal is implemented?
 - Would it change risk-to-control coverage ratios?
 - Does it affect entries with MITRE ATLAS, NIST AI RMF, or OWASP mappings?
 - What cross-content updates would be required alongside this change?
 
 **Issue mode severity levels:**
+
 - **CONCERN** — The proposal has a potential problem that should be discussed before implementation
 - **GAP** — The proposal is missing information needed for implementation
 - **OBSERVATION** — Useful context (e.g., "this overlaps with existing control X — consider whether to merge or differentiate")
@@ -241,11 +258,13 @@ When invoked in `issue` mode, the agent evaluates a *proposal* (not YAML content
 ### Dimensions
 
 **Coverage Delta** (qualitative):
+
 - Assess whether the change increases, decreases, or shifts risk-to-control coverage
 - Flag severity levels: `coverage-increased`, `coverage-unchanged`, `coverage-reduced`, `coverage-significantly-reduced`
 - For removals: identify which risks lose mitigating controls and characterize the severity
 
 **Framework Reference Impact**:
+
 - Identify whether the change affects entries that carry MITRE ATLAS, NIST AI RMF, or OWASP Top 10 mappings
 - Flag if a removal or modification breaks alignment with external framework references
 - Note if a new entry should carry framework references but doesn't
@@ -253,6 +272,7 @@ When invoked in `issue` mode, the agent evaluates a *proposal* (not YAML content
 ### Removal Impact (Special Handling)
 
 When a risk or control is **removed**:
+
 1. **Structural trace**: List all entities that reference the removed ID (will become dangling references)
 2. **Semantic assessment**: Characterize the impact on framework coverage — which risks lose mitigation, which components lose coverage, and whether the removal creates a genuine gap or is offset by existing entries
 
@@ -276,12 +296,12 @@ For `issue` mode, the verdict vocabulary is:
 
 ### Severity Levels
 
-| Level | Meaning | Blocks? |
-|---|---|---|
-| **FAIL** | Structural/mechanical violation. Must fix. | Yes |
+| Level    | Meaning                                                        | Blocks?                                                      |
+| -------- | -------------------------------------------------------------- | ------------------------------------------------------------ |
+| **FAIL** | Structural/mechanical violation. Must fix.                     | Yes                                                          |
 | **WARN** | Potential quality issue or integrity concern. Needs attention. | No (but triggers `NEEDS_HUMAN_REVIEW` for semantic findings) |
-| **INFO** | Observation. Useful context, no action required. | No |
-| **PASS** | Explicit confirmation that a check succeeded. | No |
+| **INFO** | Observation. Useful context, no action required.               | No                                                           |
+| **PASS** | Explicit confirmation that a check succeeded.                  | No                                                           |
 
 ### Finding Structure
 
@@ -290,18 +310,18 @@ Findings are **grouped by affected entity** (all findings about a single risk/co
 Each finding contains:
 
 ```yaml
-entity_id: "controlAccessControls"
-entity_type: "control"
-entity_title: "Model and Data Access Controls"
+entity_id: 'controlAccessControls'
+entity_type: 'control'
+entity_title: 'Model and Data Access Controls'
 findings:
-  - check: "bidirectional_consistency"
-    severity: "FAIL"
-    assertion: "agent"          # "agent" | "human_review"
-    message: "Control lists risk riskModelExfiltration, but riskModelExfiltration does not reference this control"
+  - check: 'bidirectional_consistency'
+    severity: 'FAIL'
+    assertion: 'agent' # "agent" | "human_review"
+    message: 'Control lists risk riskModelExfiltration, but riskModelExfiltration does not reference this control'
     governance: false
-  - check: "under_specification"
-    severity: "WARN"
-    assertion: "human_review"
+  - check: 'under_specification'
+    severity: 'WARN'
+    assertion: 'human_review'
     message: "Description uses generic language ('implement appropriate controls') without AI-specific context"
     suggestion: "Consider specifying what 'appropriate' means for model access — e.g., role-based access scoped to training vs. inference pipelines"
     governance: false
@@ -310,32 +330,34 @@ findings:
 ### Output Format by Caller Mode
 
 **`agent` mode:**
+
 ```yaml
-verdict: "BLOCKING"
-mode: "diff"
+verdict: 'BLOCKING'
+mode: 'diff'
 summary:
   fail_count: 2
   warn_count: 3
   info_count: 1
   human_review_count: 2
 entities:
-  - entity_id: "controlAccessControls"
-    entity_type: "control"
+  - entity_id: 'controlAccessControls'
+    entity_type: 'control'
     findings:
-      - check: "bidirectional_consistency"
-        severity: "FAIL"
-        assertion: "agent"
-        message: "Control lists risk riskModelExfiltration, but riskModelExfiltration does not reference this control"
+      - check: 'bidirectional_consistency'
+        severity: 'FAIL'
+        assertion: 'agent'
+        message: 'Control lists risk riskModelExfiltration, but riskModelExfiltration does not reference this control'
         governance: false
 impact:
-  summary: "Change affects 1 control with 3 risk references and 2 component mappings"
-  detailed: null  # or populated object when blast radius >= 2 cross-type entities
+  summary: 'Change affects 1 control with 3 risk references and 2 component mappings'
+  detailed: null # or populated object when blast radius >= 2 cross-type entities
 ```
 
 **`human` mode:**
 Same structured data, plus:
+
 - Narrative introduction summarizing the review
-- Per-finding rationale explaining *why* this was flagged
+- Per-finding rationale explaining _why_ this was flagged
 - Suggestions for improvement on WARN/INFO findings (marked `human_review`)
 - Impact analysis with narrative interpretation
 - Closing summary with recommended next steps
@@ -347,6 +369,7 @@ Same structured data, plus:
 ### Example 1: `diff` mode / `human` format — Adding a new control
 
 **Input:**
+
 ```
 mode: diff
 format: human
@@ -362,7 +385,7 @@ proposed_change: |
       components:
         - componentModelRegistry
       personas:
-        - personaModelConsumer
+        - personaApplicationDeveloper
 ```
 
 **Expected output (abbreviated):**
@@ -373,11 +396,11 @@ Verdict: NEEDS_HUMAN_REVIEW
 ## Review: controlModelCardValidation (control)
 
 ### Structural Checks
-✅ PASS — ID follows convention (control + camelCase descriptor)
+✅ PASS — Derived ID follows convention (control + camelCase descriptor from title)
 ✅ PASS — All required fields present
 ✅ PASS — Risk references riskModelDeploymentTampering, riskModelSourceTampering exist in risks.yaml
 ✅ PASS — Component reference componentModelRegistry exists
-✅ PASS — Persona reference personaModelConsumer exists
+✅ PASS — Persona reference personaApplicationDeveloper exists
 ⚠️ FAIL — Bidirectional inconsistency: this control lists risks riskModelDeploymentTampering
 and riskModelSourceTampering, but neither risk references controlModelCardValidation.
 Both risks.yaml entries must be updated to include this control.
@@ -411,6 +434,7 @@ NIST AI RMF governance functions.
 ### Example 2: `issue` mode / `human` format — Persona uplift proposal
 
 **Input:**
+
 ```
 mode: issue
 format: human
@@ -452,7 +476,7 @@ be out of scope for this persona.
 ### Overlap
 ⚠️ OBSERVATION — The question about evaluating models and providing
 information "for the purpose of deciding between different models"
-may overlap with personaModelConsumer responsibilities. Review
+may overlap with personaApplicationDeveloper responsibilities. Review
 whether model evaluation for selection purposes belongs to the
 provider or consumer persona, or whether the boundary needs
 explicit clarification.
@@ -484,7 +508,7 @@ may also need review.
 1. Resolve dependency on issue #143 before implementing the
    marketplace-related questions
 2. Define the YAML field structure for identification questions
-3. Review overlap with personaModelConsumer on model evaluation
+3. Review overlap with personaApplicationDeveloper on model evaluation
 4. Assess whether controls referencing personaModelProvider need
    scope review after this change
 ```
@@ -492,6 +516,7 @@ may also need review.
 ### Example 3: `diff` mode / `agent` format — Removing a risk
 
 **Input:**
+
 ```
 mode: diff
 format: agent
@@ -505,41 +530,41 @@ proposed_change: |
 **Expected output:**
 
 ```yaml
-verdict: "BLOCKING"
-mode: "diff"
+verdict: 'BLOCKING'
+mode: 'diff'
 summary:
   fail_count: 1
   warn_count: 1
   info_count: 0
   human_review_count: 1
 entities:
-  - entity_id: "riskRetrievalVectorStorePoisoning"
-    entity_type: "risk"
-    entity_title: "Runtime Vulnerability and Performance"
+  - entity_id: 'riskRetrievalVectorStorePoisoning'
+    entity_type: 'risk'
+    entity_title: 'Runtime Vulnerability and Performance'
     findings:
-      - check: "removal_structural_trace"
-        severity: "FAIL"
-        assertion: "agent"
-        message: "Removing riskRetrievalVectorStorePoisoning creates dangling references in controls: controlRuntimeMonitoring, controlPerformanceTesting, controlAnomalyDetection"
+      - check: 'removal_structural_trace'
+        severity: 'FAIL'
+        assertion: 'agent'
+        message: 'Removing riskRetrievalVectorStorePoisoning creates dangling references in controls: controlRuntimeMonitoring, controlPerformanceTesting, controlAnomalyDetection'
         governance: false
-      - check: "removal_semantic_impact"
-        severity: "WARN"
-        assertion: "human_review"
-        message: "Removal of riskRetrievalVectorStorePoisoning leaves no risk entry covering runtime performance degradation as a security concern. controlRuntimeMonitoring would become an orphaned control (no risks). Coverage assessment: coverage-significantly-reduced."
+      - check: 'removal_semantic_impact'
+        severity: 'WARN'
+        assertion: 'human_review'
+        message: 'Removal of riskRetrievalVectorStorePoisoning leaves no risk entry covering runtime performance degradation as a security concern. controlRuntimeMonitoring would become an orphaned control (no risks). Coverage assessment: coverage-significantly-reduced.'
         governance: false
 impact:
-  summary: "Removal affects 3 controls that reference riskRetrievalVectorStorePoisoning. 1 control (controlRuntimeMonitoring) becomes orphaned. Framework references on riskRetrievalVectorStorePoisoning include MITRE ATLAS mapping — this mapping would be lost."
+  summary: 'Removal affects 3 controls that reference riskRetrievalVectorStorePoisoning. 1 control (controlRuntimeMonitoring) becomes orphaned. Framework references on riskRetrievalVectorStorePoisoning include MITRE ATLAS mapping — this mapping would be lost.'
   detailed:
-    coverage_delta: "coverage-significantly-reduced"
+    coverage_delta: 'coverage-significantly-reduced'
     affected_controls:
-      - "controlRuntimeMonitoring"
-      - "controlPerformanceTesting"
-      - "controlAnomalyDetection"
-    framework_reference_impact: "MITRE ATLAS mapping on riskRetrievalVectorStorePoisoning would be removed"
+      - 'controlRuntimeMonitoring'
+      - 'controlPerformanceTesting'
+      - 'controlAnomalyDetection'
+    framework_reference_impact: 'MITRE ATLAS mapping on riskRetrievalVectorStorePoisoning would be removed'
     orphaned_after_removal:
-      - entity_id: "controlRuntimeMonitoring"
-        entity_type: "control"
-        reason: "riskRetrievalVectorStorePoisoning was its only mapped risk"
+      - entity_id: 'controlRuntimeMonitoring'
+        entity_type: 'control'
+        reason: 'riskRetrievalVectorStorePoisoning was its only mapped risk'
 ```
 
 ---
@@ -548,12 +573,12 @@ impact:
 
 **Adaptive** — scale output to complexity:
 
-| Change Complexity | Target Budget | Trigger |
-|---|---|---|
-| Simple (single field edit, no cross-content impact) | ~1-2K tokens | Isolated text change |
-| Standard (new entity or modified entity with cross-content refs) | ~3-5K tokens | Adds/modifies with references |
-| Complex (multiple entities, removals, cross-type impact) | ~6-10K tokens | Removals, multi-entity changes |
-| Maximum | ~12K tokens | Never exceed — recommend splitting PR if needed |
+| Change Complexity                                                | Target Budget | Trigger                                         |
+| ---------------------------------------------------------------- | ------------- | ----------------------------------------------- |
+| Simple (single field edit, no cross-content impact)              | ~1-2K tokens  | Isolated text change                            |
+| Standard (new entity or modified entity with cross-content refs) | ~3-5K tokens  | Adds/modifies with references                   |
+| Complex (multiple entities, removals, cross-type impact)         | ~6-10K tokens | Removals, multi-entity changes                  |
+| Maximum                                                          | ~12K tokens   | Never exceed — recommend splitting PR if needed |
 
 For `issue` mode, budget is typically 2-4K (proposals are less detailed than YAML).
 

--- a/scripts/agents/issue-response-reviewer.md
+++ b/scripts/agents/issue-response-reviewer.md
@@ -1,0 +1,299 @@
+# CoSAI-RM Issue Response Reviewer Sub-Agent Definition
+
+**Version:** 0.1.0-draft
+**Scope:** Generate structured review comments for GitHub issues proposing new or updated content in the CoSAI Risk Map framework (`secure-ai-tooling` repository)
+
+---
+
+## Agent
+
+- **Name:** issue-response-reviewer
+- **Description:** Use this agent to produce a draft maintainer review comment for a CoSAI-RM issue that proposes a new risk, control, component, or persona — or an update to an existing one. The output is a structured review a human maintainer can edit and post.
+- **Dependencies:** `content-reviewer` (invoked in `issue` mode for overlap, integrity, and style-guide checks).
+- **Examples:**
+  - User: "Review issue #188 and draft a response."
+    Assistant: "I'll use the issue-response-reviewer agent to produce a draft review comment."
+    <invoke issue-response-reviewer agent>
+  - User: "Here's a new-control proposal. Is it ready to implement, and if not, what's missing?"
+    Assistant: "I'll invoke issue-response-reviewer to analyze the proposal and produce the review draft."
+    <invoke issue-response-reviewer agent>
+
+---
+
+## Identity & Purpose
+
+You are the **CoSAI-RM Issue Response Reviewer** — a specialized agent that reads a GitHub issue proposing content and produces a structured review comment for a human maintainer.
+
+You compose the vendor-neutral `content-reviewer` agent (issue mode) with field-level feedback, quality gate verification, and — when a control is proposed — a drafted YAML entry. Your output is **a draft for human review**, never a final verdict posted automatically.
+
+You are an **analyst and drafter**, not an approver. You surface concerns, gaps, and overlap with citations so the maintainer can respond authoritatively.
+
+---
+
+## Invocation
+
+### Input Contract
+
+**Required:**
+
+1. **Issue content** — title, body, author, creation date, labels, and any pre-existing comments on the issue.
+2. **Issue type** — one of `risk`, `control`, `component`, or `persona`. This is typically derivable from the issue template label or the issue title prefix, but the caller may specify it explicitly.
+3. **Current framework state** — the current versions of:
+   - `risk-map/yaml/risks.yaml`
+   - `risk-map/yaml/controls.yaml`
+   - `risk-map/yaml/components.yaml`
+   - `risk-map/yaml/personas.yaml`
+
+**Optional:**
+
+4. **Prior review analysis** — a previous `content-reviewer` run on the same issue, or a batch review covering this issue.
+5. **Schema files** — `risk-map/schemas/*.schema.json`. Schema awareness is embedded below; schema files supplement but do not override.
+
+### Output Contract
+
+A single structured review comment (Markdown), suitable for the maintainer to edit and post on the GitHub issue. The comment ends with an explicit **Verdict** line and a **Summary of Required Changes** table.
+
+You do **not** post the comment yourself. You do not modify the issue. You do not open PRs.
+
+---
+
+## Schema Awareness
+
+The `content-reviewer` agent is the source of truth for CoSAI-RM schema structure. See `scripts/agents/content-reviewer.md` → "Schema Awareness" for the full reference. This agent relies on that shared knowledge.
+
+Key conventions that anchor field-by-field analysis:
+
+- IDs use `<prefix>` + camelCase(title): `riskDataPoisoning`, `controlRedTeaming`, `componentModelStorage`, `personaModelProvider`.
+- `personaGovernance` is **controls-only** — never valid on a risk.
+- Seven controls carry `risks: all` (universal controls). Risks must not list universal controls explicitly.
+- Risks map to MITRE ATLAS **techniques** (`AML.T####`); controls map to MITRE ATLAS **mitigations** (`AML.M####`).
+- STRIDE categories are lowercase. OWASP LLM IDs are `LLM##`. NIST AI RMF mappings on controls use subcategory-level IDs.
+
+See `risk-map/docs/contributing/submission-readiness-guide.md` for the contributor-facing statement of these rules.
+
+---
+
+## Processing Steps
+
+### 1. Context Gathering
+
+1. Determine entity type (`risk` | `control` | `component` | `persona`) from the issue label, template, or explicit input.
+2. Load the relevant current YAML file(s) for the target entity type and any referenced entity types.
+3. Load applicable style guides based on the fields present in the proposal:
+   - Title → `risk-titles-style-guide.md` / `control-titles-style-guide.md` / `component-titles-style-guide.md`
+   - `identificationQuestions` → `identification-questions-style-guide.md`
+   - `mappings` → `framework-mappings-style-guide.md`
+4. Load `risk-map/docs/contributing/submission-readiness-guide.md` to apply the contributor-facing checklist as a review framework.
+5. Read any existing comments on the issue. Integrate prior reviewer guidance rather than restating it.
+
+### 2. Field-by-Field Analysis
+
+For each field present in the proposal, evaluate the following. Missing fields that are required by the issue template or schema are **GAP** findings.
+
+| Field                                  | Checks                                                                                                                                                                  |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id` (derived from title)              | The submitter does not enter an ID — it is mechanically derived from the title. Verify the derived ID is well-formed (prefix + camelCase) and does not collide with existing IDs. If it would collide or be malformed, the fix is in the title, not a separate ID field. |
+| `title`                                | Style-guide compliance (length, form, noun-phrase, no "via/through" clauses, no "insufficient/missing/failure to").                                                     |
+| `shortDescription`                     | 1-2 sentences; complete; not a restatement of the title.                                                                                                                |
+| `description` (long)                   | Classical security equivalent named; AI-specific amplifier stated; neither under- nor over-specified.                                                                   |
+| `category`                             | Matches schema enum; consistent with existing categories for the entity type.                                                                                           |
+| `personas`                             | Correct model: risks list **impacted** personas; controls list **implementer** personas. `personaGovernance` is controls-only. `personaEndUser` expected on most risks. |
+| `controls` / `risks`                   | Referenced IDs exist. Universal controls not listed on risks.                                                                                                           |
+| `components`                           | Referenced IDs exist. `all` / `none` sentinels flagged for review.                                                                                                      |
+| `examples`                             | Real incidents/research/vulnerabilities; verifiable URLs; not vendor announcements or hypotheticals.                                                                    |
+| `mappings`                             | Valid framework IDs; correct entity-type alignment (technique vs. mitigation); no parent + sub-technique duplication.                                                   |
+| `identificationQuestions` (personas)   | Yes/no answerable; second-person framing; activity-based; scoping clauses when overlap with another persona exists.                                                     |
+| `lifecycle` / `impact` / `actorAccess` | Schema enum values.                                                                                                                                                     |
+
+### 3. Overlap Analysis
+
+Delegate to `content-reviewer` in `issue` mode for:
+
+- Exact and near-duplicate detection within the same entity type.
+- Cross-type semantic overlap (e.g., a proposed risk whose description restates an existing control).
+- Determination of whether the proposal is genuinely new content versus an update to an existing entry.
+
+Integrate the content-reviewer findings into the **Overlap Analysis** section of your output. Cite matched entries by ID and title.
+
+### 4. Quality Gates
+
+Apply the gates below as **declarative checks**. Each gate yields PASS / FAIL / N/A. Failed gates contribute to a DISCUSS or RETHINK verdict. Gates are defined as _what_ to check; specific verification methods are left to the implementation.
+
+**Gate 1 — Classical Risk Mapping** (risks only)
+
+- The long description maps the risk to a pre-AI security concept (supply chain, access control, input validation, DoS, etc.).
+- The AI-specific amplifier is clearly stated (why this is not just the classical version).
+
+**Gate 2 — Example Validation**
+
+- Every example cites a real incident, research finding, vulnerability disclosure, or documented bug.
+- Every example includes a verifiable URL.
+- No vendor product launches and no hypothetical scenarios.
+
+**Gate 3 — Framework Mapping Validation**
+
+- STRIDE categories are valid lowercase values.
+- MITRE ATLAS IDs match the entity type: techniques (`AML.T####`) on risks, mitigations (`AML.M####`) on controls.
+- OWASP LLM IDs are valid `LLM##` entries from the current edition.
+- NIST AI RMF mappings (controls only) are at subcategory level.
+- No parent + sub-technique pair listed together.
+- No mapping to the wrong entity type (e.g., a mitigation listed under a risk).
+
+**Gate 4 — Persona Model Consistency**
+
+- Risks list impacted personas; controls list implementer personas.
+- `personaGovernance` appears only on controls.
+- If the proposal includes `identificationQuestions`, they pass the identification-questions style guide checklist.
+
+**Gate 5 — Universal Control Hygiene**
+
+- No risk lists any of the 7 universal controls (`controlRedTeaming`, `controlVulnerabilityManagement`, `controlThreatDetection`, `controlIncidentResponseManagement`, `controlInternalPoliciesAndEducation`, `controlProductGovernance`, `controlRiskGovernance`).
+- Universal controls do not list specific risks; they must remain `risks: all`.
+
+### 5. YAML Generation (when applicable)
+
+When the proposal is fit to proceed with minor corrections, draft a proposed YAML entry:
+
+- Apply the corrections identified in field-by-field analysis.
+- Preserve the contributor's wording where possible; flag any reviewer rewrites in the proposal.
+- If the proposal introduces a new control, draft a **companion YAML** block showing the control entry with inferred `risks`, `components`, and `personas`.
+- Do not include fields the contributor did not provide unless they are required by schema — in that case, include the field with a clear `TODO:` placeholder and flag it as a GAP.
+
+### 6. Draft Review Comment
+
+Assemble the findings into the output structure below.
+
+---
+
+## Output Structure
+
+The output is a single Markdown comment with these sections, in order:
+
+### 1. Header
+
+```
+## Review Feedback: <entity-type> <short-descriptor>
+
+- **Issue:** #<number> — <title>
+- **Author:** @<github-handle>
+- **Reviewer:** <maintainer name or handle>
+- **Date:** <YYYY-MM-DD>
+- **Verdict:** PROCEED | DISCUSS | RETHINK
+```
+
+### 2. Overall Assessment
+
+A 2-4 sentence summary of the proposal's fit and the top concerns. If the verdict is PROCEED, state what (if anything) needs editing before implementation. If DISCUSS, name the two or three most important items to resolve. If RETHINK, state the fundamental issue.
+
+### 3. Field-by-Field Feedback
+
+A section per field that has findings. Use this format:
+
+```
+### `<field-name>`
+
+- **Current proposal:** <short quote or summary>
+- **Finding:** <what's wrong or flagged>
+- **Guidance:** <what the contributor should change, with a pointer to the relevant style guide or readiness-guide section>
+```
+
+Omit fields with no findings (no need to confirm every PASS).
+
+### 4. Overlap Analysis
+
+Summarize content-reviewer's overlap findings. For each matched existing entry, cite its ID and title and state whether you recommend (a) modifying the proposal to differentiate, (b) reframing as an update, or (c) consolidating with the existing entry.
+
+If no overlap, state that explicitly in one sentence.
+
+### 5. Control Proposals (if applicable)
+
+When a new risk is proposed and the contributor has not listed existing mitigating controls, surface the non-universal controls that plausibly apply based on description. When a new control is proposed, surface the risks it may apply to. Use a bulleted list with a one-line justification per entry.
+
+### 6. Proposed YAML (if applicable)
+
+A fenced YAML block with the corrected entry. Mark reviewer edits with inline comments (`# reviewer: rephrased for style-guide compliance`). Include `TODO:` placeholders for required fields the contributor did not provide.
+
+### 7. Summary of Required Changes
+
+A table the contributor can work through:
+
+| #   | Change                                           | Priority    | Reference                        |
+| --- | ------------------------------------------------ | ----------- | -------------------------------- |
+| 1   | Rename title from X to Y                         | Required    | risk-titles-style-guide.md       |
+| 2   | Remove `personaGovernance` from personas list    | Required    | submission-readiness-guide.md §3 |
+| 3   | Replace hypothetical example with cited incident | Recommended | common-review-findings.md #7     |
+
+**Priority values:** `Required` (blocks PROCEED), `Recommended` (should address but not blocking), `Optional` (reviewer suggestion).
+
+---
+
+## Verdict Criteria
+
+- **PROCEED** — No FAIL findings from content-reviewer. All quality gates pass or are N/A. Field-by-field findings are at most `Recommended` / `Optional` priority. Proposal is ready for implementation (possibly with minor copy edits).
+- **DISCUSS** — One or more quality gate failures, significant field-level gaps, or overlap concerns requiring contributor input. Proposal has merit but needs rework before implementation.
+- **RETHINK** — Fundamental fit issue (out of scope, clear duplicate with no differentiation, or framing that conflicts with CoSAI-RM's persona/universal-control model). The contributor should reconsider the approach rather than iterate on details.
+
+A verdict reflects the **current state of the proposal**, not the underlying idea. A DISCUSS verdict on a fixable proposal is common and expected.
+
+---
+
+## Composition with Content Reviewer
+
+`issue-response-reviewer` depends on `content-reviewer` for:
+
+- Overlap detection (exact and near-duplicate).
+- Cross-content integrity concerns (dangling references in proposed relationships).
+- Style-guide checklist application (`identificationQuestions`, `mappings`).
+
+Invoke `content-reviewer` in `issue` mode with `format: human` when the output will be integrated into a contributor-facing review. Use `format: agent` when consuming findings programmatically inside this agent's pipeline.
+
+Do not duplicate `content-reviewer`'s overlap analysis — cite it. Do add field-by-field feedback, quality-gate assertions, proposed YAML, and the summary table; those are this agent's contribution.
+
+---
+
+## Rules
+
+1. IDs are mechanically derived from titles; submitters do not enter them. When commenting on the derived ID, confirm it follows the current `risk`/`control`/`component`/`persona` + camelCase convention. Do not endorse legacy uppercase-abbreviation IDs (e.g., `riskMCP...`); if the title would yield one, fix the title. **If the derived ID collides with an existing entry, or yields a malformed/unreadable ID, propose a specific replacement title** that (a) preserves the proposal's semantic intent, (b) disambiguates from the colliding entry by adding the discriminating dimension (surface, technique, scope), and (c) derives to a clean camelCase ID. Do not suggest numeric suffixes, abbreviations, or hand-edited IDs — the title is the only knob.
+2. Always consult the title style guide that applies to the entity type before commenting on a title.
+3. Apply the persona model strictly: risks = impacted personas, controls = implementer personas.
+4. `personaGovernance` is controls-only. Flag any appearance on a risk as a REQUIRED change.
+5. `personaEndUser` is expected on most risks. Flag its absence for review.
+6. Examples must cite real incidents, research, or vulnerabilities. Hypotheticals and vendor blog posts are flagged as REQUIRED fixes.
+7. When proposing a new control, include complete YAML with `id`, `title`, `description`, `category`, and relationship fields (`risks`, `components`, `personas`).
+8. Verify every framework mapping ID against the referenced framework. If you cannot verify, flag the mapping as a GAP rather than asserting it is invalid.
+9. Never list both a MITRE ATLAS parent technique and one of its sub-techniques.
+10. The output is **a draft for human maintainer review**, never a final verdict posted to the issue.
+
+---
+
+## Principles
+
+1. **Vendor neutrality.** No references to specific LLM APIs, agent harnesses, or commercial tools. Logic is portable across implementations.
+2. **Declarative quality gates.** Define _what_ must be true, not _how_ the verification must be performed. Implementations choose the method.
+3. **Composability.** Delegate to `content-reviewer` for overlap, integrity, and style-guide checks. Add value on top (field-by-field, gates, YAML drafting, summary table).
+4. **Draft, not decision.** Always produce a draft a human will edit. Never imply that posting the draft is automatic or authoritative.
+5. **Proportional feedback.** A well-scoped single-field update doesn't need a five-page review. A net-new risk with broad scope does. Scale the review to the proposal's complexity.
+6. **Cite the rules.** Every REQUIRED finding names a style guide, the readiness guide, or `common-review-findings.md` so the contributor can self-educate.
+
+---
+
+## Token Budget
+
+| Proposal Complexity                                              | Target Budget                                                         |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Single-field update to an existing entry                         | ~1-2K tokens                                                          |
+| New entry with standard detail                                   | ~3-5K tokens                                                          |
+| New entry with broad scope, many mappings, or cross-type overlap | ~6-10K tokens                                                         |
+| Maximum                                                          | ~12K tokens — recommend splitting the proposal if review exceeds this |
+
+---
+
+## Related Documentation
+
+- **Depends on:** `scripts/agents/content-reviewer.md` (invoked in `issue` mode)
+- **Contributor-facing references the output cites:**
+  - `risk-map/docs/contributing/submission-readiness-guide.md`
+  - `risk-map/docs/contributing/common-review-findings.md`
+  - Per-entity title style guides
+  - `risk-map/docs/contributing/framework-mappings-style-guide.md`
+  - `risk-map/docs/contributing/identification-questions-style-guide.md`

--- a/scripts/docs/template-generation.md
+++ b/scripts/docs/template-generation.md
@@ -1,0 +1,199 @@
+# Issue Template Generation
+
+GitHub issue templates in `.github/ISSUE_TEMPLATE/` are generated artifacts. Some are produced from source templates; others are hand-authored and committed directly. This document explains the two-tier model, which files are generated vs. hand-authored, how to edit them safely, and how the placeholder system works.
+
+**Audience:** Repository maintainers. For contributor-facing guidance on filling out the templates, see [issue-templates-guide.md](../../risk-map/docs/contributing/issue-templates-guide.md).
+
+---
+
+## Two-tier model
+
+```
+scripts/TEMPLATES/*.template.yml     <-- authored here
+            |
+            | python3 scripts/generate_issue_templates.py
+            v
+.github/ISSUE_TEMPLATE/*.yml         <-- generated artifacts
+```
+
+Template sources live in `scripts/TEMPLATES/` and contain `{{PLACEHOLDER}}` tokens. The generator resolves each token against JSON schema enum values, applies filters, and writes the result to `.github/ISSUE_TEMPLATE/`. The generated files are committed to the repo so GitHub picks them up without a build step.
+
+---
+
+## Inventory
+
+### Generated from source templates (5)
+
+| Source template | Generated file | Entity type |
+|---|---|---|
+| `new_risk.template.yml` | `new_risk.yml` | risks |
+| `update_risk.template.yml` | `update_risk.yml` | risks |
+| `new_control.template.yml` | `new_control.yml` | controls |
+| `update_control.template.yml` | `update_control.yml` | controls |
+| `new_component.template.yml` | `new_component.yml` | components |
+
+### Hand-authored (committed directly, no source template)
+
+These four files **have no entry in `scripts/TEMPLATES/` and are not regenerated.** Edit them directly in `.github/ISSUE_TEMPLATE/`:
+
+| File | Notes |
+|---|---|
+| `new_persona.yml` | Owned by `.github/ISSUE_TEMPLATE/`; not regenerated |
+| `update_persona.yml` | Owned by `.github/ISSUE_TEMPLATE/`; not regenerated |
+| `update_component.yml` | Owned by `.github/ISSUE_TEMPLATE/`; not regenerated |
+| `infrastructure.yml` | One-off template; no placeholders; not regenerated |
+
+The asymmetry exists for historical reasons. The five generated templates have placeholders whose values change as schemas evolve; the others were authored once and have remained stable. Any of the hand-authored files can be given a source template later if that changes — see [Adding a new generated template](#adding-a-new-generated-template).
+
+---
+
+## Editing rules
+
+**DO NOT edit `.github/ISSUE_TEMPLATE/*.yml` files that have a source template.**
+
+Any hand-edit to a generated file is silently overwritten the next time generation runs. That next run could be seconds away: the pre-commit hook regenerates templates automatically whenever a schema file (`risk-map/schemas/*.schema.json`), a template source (`scripts/TEMPLATES/*.template.yml`), or `risk-map/yaml/frameworks.yaml` is staged for commit.
+
+The correct workflow for a generated template:
+
+1. Edit the corresponding source in `scripts/TEMPLATES/<name>.template.yml`.
+2. Run `python3 scripts/generate_issue_templates.py` to preview the result.
+3. Stage both the source and the generated file.
+
+For hand-authored templates (`new_persona.yml`, `update_persona.yml`, `update_component.yml`, `infrastructure.yml`), edit the file in `.github/ISSUE_TEMPLATE/` directly — there is no source to update.
+
+---
+
+## Regenerating templates
+
+```bash
+# Generate all templates (from repo root)
+python3 scripts/generate_issue_templates.py
+
+# Preview changes without writing
+python3 scripts/generate_issue_templates.py --dry-run
+
+# Generate a single template
+python3 scripts/generate_issue_templates.py --template new_risk
+
+# Validate rendered content without writing
+python3 scripts/generate_issue_templates.py --validate
+
+# Verbose output
+python3 scripts/generate_issue_templates.py --verbose
+```
+
+The pre-commit hook auto-regenerates and stages the affected templates when any of the following files are staged:
+
+- `risk-map/schemas/*.schema.json` — enum values used in dropdowns and checkboxes
+- `scripts/TEMPLATES/*.template.yml` — template source changed
+- `risk-map/yaml/frameworks.yaml` — framework applicability changed
+
+---
+
+## Placeholder system
+
+Placeholders in source templates take the form `{{PLACEHOLDER_NAME}}`. The generator replaces each token with a YAML block rendered from schema enum values.
+
+Current placeholders and their schema sources:
+
+| Placeholder | Schema source | Field type | Notes |
+|---|---|---|---|
+| `{{PERSONAS}}` | `personas.schema.json` → `definitions.persona.properties.id` | checkbox | Full persona list; includes `personaGovernance`. For controls templates. |
+| `{{PERSONAS_FOR_RISKS}}` | `personas.schema.json` → `definitions.persona.properties.id` | checkbox | Excludes `personaGovernance`. For risk templates. See [Why two persona placeholders](#why-two-persona-placeholders). |
+| `{{LIFECYCLE_STAGE}}` | `lifecycle-stage.schema.json` → `definitions.lifecycleStage.properties.id` | checkbox | |
+| `{{IMPACT_TYPE}}` | `impact-type.schema.json` → `definitions.impactType.properties.id` | checkbox | |
+| `{{ACTOR_ACCESS}}` | `actor-access.schema.json` → `definitions.actorAccessLevel.properties.id` | checkbox | |
+| `{{CONTROL_CATEGORIES}}` | `controls.schema.json` → `definitions.category.properties.id` | dropdown | |
+| `{{RISK_CATEGORIES}}` | `risks.schema.json` → `definitions.risk.properties.category` | dropdown | |
+| `{{COMPONENT_CATEGORIES}}` | `components.schema.json` → `definitions.category.properties.id` | dropdown | |
+| `{{CONTROL_FRAMEWORKS_LIST}}` | `risk-map/yaml/frameworks.yaml` (entries with `controls` in `appliesTo`) | inline text | Comma-separated framework IDs for the framework-mappings field description. |
+| `{{RISK_FRAMEWORKS_LIST}}` | `risk-map/yaml/frameworks.yaml` (entries with `risks` in `appliesTo`) | inline text | Comma-separated framework IDs for the framework-mappings field description. |
+| `{{FRAMEWORK_MAPPINGS}}` | `risk-map/yaml/frameworks.yaml` | textarea blocks | Expands into one textarea per applicable framework. Reserved for future template surfaces; not currently used in the five active sources. |
+
+`{{*_FRAMEWORKS_LIST}}` and `{{FRAMEWORK_MAPPINGS}}` read from `frameworks.yaml`, not a JSON schema. The other placeholders are `PLACEHOLDER_MAPPINGS` entries in `scripts/hooks/issue_template_generator/template_renderer.py`; framework placeholders are handled by dedicated branches in `expand_placeholders`.
+
+---
+
+## Filtering
+
+Two independent filter mechanisms reduce the raw schema enum before rendering.
+
+### Deprecated filter (`yaml_source`)
+
+When a mapping declares `yaml_source: (filename, collection_key)`, the generator loads the named YAML data file from `risk-map/yaml/` and removes any enum ID whose entry carries `deprecated: true`. This keeps the issue form current when personas or other entities are retired.
+
+Example: `personaModelCreator` and `personaModelConsumer` are marked `deprecated: true` in `personas.yaml` and are therefore absent from all rendered persona checkbox lists.
+
+### Context exclusion (`exclude_ids`)
+
+When a mapping declares `exclude_ids: (id, ...)`, those IDs are unconditionally removed from the rendered output regardless of their deprecated status. Use this when a value is valid in one context (e.g., controls) but should never appear in another (e.g., risks).
+
+### Compose order
+
+Both filters apply in sequence, preserving original schema enum ordering:
+
+```
+final_ids = enum_ids - deprecated_ids (yaml_source) - exclude_ids
+```
+
+---
+
+## Why two persona placeholders
+
+`personaGovernance` belongs to the controls side of the persona model. Governance actors define policy and evaluate compliance; they implement security controls. Risks, by contrast, track which personas are **harmed** by a threat — governance personas are not typically in the threat path.
+
+- `{{PERSONAS}}` — used in control templates; includes `personaGovernance`.
+- `{{PERSONAS_FOR_RISKS}}` — used in risk templates; excludes `personaGovernance` via `exclude_ids: ("personaGovernance",)`.
+
+See [submission-readiness-guide.md §3](../../risk-map/docs/contributing/submission-readiness-guide.md) for the authoritative persona usage rules.
+
+---
+
+## Adding a new placeholder or variant
+
+1. Open `scripts/hooks/issue_template_generator/template_renderer.py`.
+2. Add an entry to `PLACEHOLDER_MAPPINGS`:
+
+   ```python
+   "MY_NEW_PLACEHOLDER": {
+       "schema_paths": [("myschema.schema.json", "definitions.thing.properties.id")],
+       "field_type": "checkbox",          # or "dropdown" or None
+       # Optional:
+       "yaml_source": ("mydata.yaml", "things"),   # enables deprecated-filter
+       "exclude_ids": ("thingToOmit",),             # per-context exclusion
+   },
+   ```
+
+3. Add tests in `scripts/hooks/issue_template_generator/tests/test_template_renderer.py`.
+4. Reference the placeholder in a source template via `{{MY_NEW_PLACEHOLDER}}`.
+5. Run `python3 scripts/generate_issue_templates.py` and review the output.
+6. Commit the source template and the regenerated artifact together.
+
+---
+
+## Adding a new generated template
+
+1. Create `scripts/TEMPLATES/<name>.template.yml`. The generator discovers all `*.template.yml` files via glob — no registration needed.
+2. Determine the entity type (`risks`, `controls`, `components`, or `personas`) and confirm that `IssueTemplateGenerator._get_entity_type()` in `scripts/hooks/issue_template_generator/generator.py` maps the new filename to the right type. Add a mapping there if needed.
+3. Use `{{PLACEHOLDER_NAME}}` tokens where dynamic values belong.
+4. Run `python3 scripts/generate_issue_templates.py` to generate the first version.
+5. Commit the source template and the generated file together.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Regeneration produces an unexpected diff in a generated file | The source template was not updated; only the generated file was edited | Discard the generated change, edit the source template instead, then regenerate |
+| A deprecated entry still appears in a rendered checkbox | The mapping has no `yaml_source` configured | Add `yaml_source` to the entry in `PLACEHOLDER_MAPPINGS` |
+| Wrong personas in the risk template | Template uses `{{PERSONAS}}` instead of `{{PERSONAS_FOR_RISKS}}` | Replace `{{PERSONAS}}` with `{{PERSONAS_FOR_RISKS}}` in `new_risk.template.yml` |
+| Hook says "validator not found in worktree" | Stale `.git/hooks/pre-commit` from before commit `d535dd4` | Reinstall the hook with `scripts/install-precommit-hook.sh` |
+| `check-jsonschema` fails after regeneration | Generated template has a structural issue | Run `python3 scripts/generate_issue_templates.py --validate` and inspect the error |
+
+---
+
+**Related:**
+- [Hook Validations](hook-validations.md) — Issue template generation step in the pre-commit hook
+- [Validation Flow](validation-flow.md) — When each hook step runs
+- [issue-templates-guide.md](../../risk-map/docs/contributing/issue-templates-guide.md) — Contributor-facing guide (different audience)

--- a/scripts/hooks/README.md
+++ b/scripts/hooks/README.md
@@ -387,6 +387,7 @@ Follow these principles when modifying hook utilities:
 ## Related Documentation
 
 - **CONTRIBUTING.md** - Contribution guidelines
+- **[Template Generation](../docs/template-generation.md)** - How issue templates are generated, placeholder system, and editing rules
 
 ## Support
 

--- a/scripts/hooks/issue_template_generator/generator.py
+++ b/scripts/hooks/issue_template_generator/generator.py
@@ -97,7 +97,8 @@ class IssueTemplateGenerator:
             raise ValueError("frameworks.yaml must contain 'frameworks' key")
 
         # Create SchemaParser and TemplateRenderer instances
-        self.schema_parser = SchemaParser(self.schemas_dir)
+        yaml_data_dir = repo_root / "risk-map" / "yaml"
+        self.schema_parser = SchemaParser(self.schemas_dir, yaml_data_dir=yaml_data_dir)
         self.template_renderer = TemplateRenderer(self.schema_parser, self.frameworks_data)
 
     def get_available_templates(self) -> list[str]:

--- a/scripts/hooks/issue_template_generator/schema_parser.py
+++ b/scripts/hooks/issue_template_generator/schema_parser.py
@@ -9,6 +9,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 
 class SchemaParser:
     """
@@ -20,14 +22,17 @@ class SchemaParser:
 
     Attributes:
         schema_dir: Path to directory containing JSON schema files
+        yaml_data_dir: Optional path to directory containing YAML data files
     """
 
-    def __init__(self, schema_dir: Path) -> None:
+    def __init__(self, schema_dir: Path, yaml_data_dir: Path | None = None) -> None:
         """
         Initialize SchemaParser with schema directory.
 
         Args:
             schema_dir: Path to directory containing JSON schema files
+            yaml_data_dir: Optional path to directory containing YAML data files
+                           (required only if load_deprecated_ids() will be called)
 
         Raises:
             FileNotFoundError: If schema_dir doesn't exist
@@ -40,6 +45,8 @@ class SchemaParser:
             raise NotADirectoryError(f"'{schema_dir}' is not a directory")
 
         self.schema_dir = schema_dir
+        self.yaml_data_dir = yaml_data_dir
+        self._deprecated_ids_cache: dict[tuple[str, str], set[str]] = {}
 
     def load_schema(self, schema_name: str) -> dict[str, Any]:
         """
@@ -62,6 +69,45 @@ class SchemaParser:
 
         with open(schema_path, "r", encoding="utf-8") as f:
             return json.load(f)
+
+    def load_deprecated_ids(self, yaml_filename: str, list_key: str) -> set[str]:
+        """
+        Load IDs of deprecated entries from a YAML data file.
+
+        Opens yaml_data_dir / yaml_filename, iterates data[list_key], and
+        returns the set of entry["id"] values where entry.get("deprecated") is True.
+        Results are cached per-instance keyed by (yaml_filename, list_key).
+
+        Args:
+            yaml_filename: Name of the YAML file (e.g., "personas.yaml")
+            list_key: Top-level key whose value is a list of entries (e.g., "personas")
+
+        Returns:
+            Set of deprecated IDs; empty set if none are deprecated
+
+        Raises:
+            ValueError: If yaml_data_dir was not configured on this instance
+            FileNotFoundError: If yaml_filename does not exist in yaml_data_dir
+        """
+        if self.yaml_data_dir is None:
+            raise ValueError("yaml_data_dir not configured on SchemaParser")
+
+        cache_key = (yaml_filename, list_key)
+        if cache_key in self._deprecated_ids_cache:
+            return self._deprecated_ids_cache[cache_key]
+
+        yaml_path = self.yaml_data_dir / yaml_filename
+        # Let FileNotFoundError propagate naturally if the file is missing
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+
+        deprecated: set[str] = set()
+        for entry in data.get(list_key, []):
+            if entry.get("deprecated") is True:
+                deprecated.add(entry["id"])
+
+        self._deprecated_ids_cache[cache_key] = deprecated
+        return deprecated
 
     def extract_enum_values(self, schema_data: dict[str, Any], field_path: str) -> list[str]:
         """

--- a/scripts/hooks/issue_template_generator/template_renderer.py
+++ b/scripts/hooks/issue_template_generator/template_renderer.py
@@ -29,11 +29,27 @@ class TemplateRenderer:
     # Valid entity types
     VALID_ENTITY_TYPES = {"controls", "risks", "components", "personas"}
 
-    # Placeholder mappings to schema paths with field type metadata
+    # Placeholder mappings to schema paths with field type metadata.
+    #
     # Field types match GitHub form input requirements:
     # - "dropdown": Plain string lists (e.g., ["controlsData", "controlsModel"])
     # - "checkbox": Label-only objects (e.g., [{"label": "personaModelCreator"}])
     # - None: Fallback format with label and value (for textarea/markdown context)
+    #
+    # Optional keys per entry:
+    # - "yaml_source": (filename, collection_key) — enables deprecated-id filtering
+    #   by loading YAML data and excluding entries with deprecated: true.
+    # - "exclude_ids": tuple[str, ...] — per-mapping context exclusion; IDs listed
+    #   here are always omitted regardless of deprecated status.
+    #
+    # Persona split:
+    # - PERSONAS          — for controls templates; includes personaGovernance
+    #   (governance is a controls-only persona per the persona model).
+    # - PERSONAS_FOR_RISKS — for risk templates; excludes personaGovernance because
+    #   risks track personas harmed by a threat, not personas who implement defenses.
+    #   See risk-map/docs/contributing/submission-readiness-guide.md §3.
+    #
+    # Filter compose order: enum_ids - deprecated_ids (yaml_source) - exclude_ids
     PLACEHOLDER_MAPPINGS = {
         # Dropdowns - plain string format required
         "CONTROL_CATEGORIES": {
@@ -52,9 +68,18 @@ class TemplateRenderer:
             "field_type": "dropdown",
         },
         # Checkboxes - label-only object format required
+        # PERSONAS: full list for controls (governance is controls-only)
         "PERSONAS": {
             "schema_paths": [("personas.schema.json", "definitions.persona.properties.id")],
             "field_type": "checkbox",
+            "yaml_source": ("personas.yaml", "personas"),
+        },
+        # PERSONAS_FOR_RISKS: excludes personaGovernance (controls-only persona)
+        "PERSONAS_FOR_RISKS": {
+            "schema_paths": [("personas.schema.json", "definitions.persona.properties.id")],
+            "field_type": "checkbox",
+            "yaml_source": ("personas.yaml", "personas"),
+            "exclude_ids": ("personaGovernance",),
         },
         "LIFECYCLE_STAGE": {
             "schema_paths": [("lifecycle-stage.schema.json", "definitions.lifecycleStage.properties.id")],
@@ -210,6 +235,24 @@ class TemplateRenderer:
 
             if not enum_values:
                 # Empty enum - return empty string
+                return ""
+
+            # Remove deprecated entries when the mapping declares a yaml_source
+            # and the schema_parser has a yaml_data_dir configured
+            yaml_source = mapping.get("yaml_source")
+            if yaml_source is not None and self.schema_parser.yaml_data_dir is not None:
+                deprecated_ids = self.schema_parser.load_deprecated_ids(*yaml_source)
+                enum_values = [v for v in enum_values if v not in deprecated_ids]
+
+            # Remove explicitly excluded IDs (per-mapping context exclusion).
+            # Applies after deprecated-filter; compose order:
+            #   enum_ids - deprecated_ids - exclude_ids
+            exclude_ids = mapping.get("exclude_ids", ())
+            if exclude_ids:
+                enum_values = [v for v in enum_values if v not in exclude_ids]
+
+            if not enum_values:
+                # All values were filtered out - return empty string
                 return ""
 
             # Format based on field type

--- a/scripts/hooks/issue_template_generator/tests/fixtures/personas_abc_synthetic.yaml
+++ b/scripts/hooks/issue_template_generator/tests/fixtures/personas_abc_synthetic.yaml
@@ -1,0 +1,13 @@
+# Synthetic personas fixture for exclude_ids composition tests.
+# Used by test_expand_placeholders_composes_exclude_with_deprecated.
+# personaA is deprecated; personaB and personaC are active.
+personas:
+  - id: personaA
+    title: Persona A
+    deprecated: true
+
+  - id: personaB
+    title: Persona B
+
+  - id: personaC
+    title: Persona C

--- a/scripts/hooks/issue_template_generator/tests/fixtures/personas_mixed_deprecated.yaml
+++ b/scripts/hooks/issue_template_generator/tests/fixtures/personas_mixed_deprecated.yaml
@@ -1,0 +1,16 @@
+# Synthetic personas fixture: mix of active and deprecated entries.
+# Used by test_load_deprecated_ids_returns_set_of_deprecated_entries.
+personas:
+  - id: personaActive1
+    title: Active Persona One
+
+  - id: personaActive2
+    title: Active Persona Two
+
+  - id: personaDeprecatedA
+    title: Deprecated Persona A
+    deprecated: true
+
+  - id: personaDeprecatedB
+    title: Deprecated Persona B
+    deprecated: true

--- a/scripts/hooks/issue_template_generator/tests/fixtures/personas_no_deprecated_field.yaml
+++ b/scripts/hooks/issue_template_generator/tests/fixtures/personas_no_deprecated_field.yaml
@@ -1,0 +1,9 @@
+# Synthetic personas fixture: entries that omit the deprecated field entirely.
+# Used by test_load_deprecated_ids_handles_entries_without_deprecated_field.
+personas:
+  - id: personaNoFlag1
+    title: Persona Without Deprecated Field One
+
+  - id: personaNoFlag2
+    title: Persona Without Deprecated Field Two
+    # deliberately no 'deprecated' key — should be treated as active

--- a/scripts/hooks/issue_template_generator/tests/fixtures/personas_none_deprecated.yaml
+++ b/scripts/hooks/issue_template_generator/tests/fixtures/personas_none_deprecated.yaml
@@ -1,0 +1,11 @@
+# Synthetic personas fixture: no deprecated entries at all.
+# Used by test_load_deprecated_ids_returns_empty_set_when_none_deprecated.
+personas:
+  - id: personaActive1
+    title: Active Persona One
+
+  - id: personaActive2
+    title: Active Persona Two
+
+  - id: personaActive3
+    title: Active Persona Three

--- a/scripts/hooks/issue_template_generator/tests/test_generator.py
+++ b/scripts/hooks/issue_template_generator/tests/test_generator.py
@@ -1161,3 +1161,251 @@ class TestErrorHandlingAndEdgeCases:
 
         assert result1.exists()
         assert result2.exists()
+
+
+# ============================================================================
+# End-to-end generator tests for deprecated-persona filtering — TDD red phase
+#
+# These tests target the not-yet-built behaviour where IssueTemplateGenerator
+# passes yaml_data_dir into SchemaParser, and the rendered templates therefore
+# exclude deprecated persona IDs.
+#
+# ALL tests MUST FAIL until the implementation lands in generator.py,
+# schema_parser.py, and template_renderer.py.
+# ============================================================================
+
+
+class TestGeneratorExcludesDeprecatedPersonas:
+    """
+    End-to-end tests verifying deprecated personas are absent from generated templates.
+
+    Contract under test (NOT YET IMPLEMENTED):
+        IssueTemplateGenerator.__init__ constructs SchemaParser with:
+            yaml_data_dir=repo_root / "risk-map" / "yaml"
+
+        This causes expand_placeholders() to filter deprecated persona IDs
+        (personaModelCreator, personaModelConsumer) from generated checkboxes
+        in any template that includes {{PERSONAS}}.
+    """
+
+    @pytest.fixture
+    def full_repo_root_with_personas(self, tmp_path: Path) -> Path:
+        """
+        Build a minimal but complete fake repo root that includes:
+        - risk-map/schemas/ with personas.schema.json listing two deprecated IDs
+        - risk-map/yaml/personas.yaml marking those two IDs deprecated: true
+        - risk-map/yaml/frameworks.yaml (empty frameworks list)
+        - scripts/TEMPLATES/ with new_risk and new_control templates that use {{PERSONAS}}
+        - .github/ISSUE_TEMPLATE/ output directory
+
+        The schema intentionally still lists personaModelCreator and personaModelConsumer
+        so that the test proves the YAML-based filtering is the removal mechanism.
+        """
+        repo_root = tmp_path
+
+        # ── schemas ──────────────────────────────────────────────────────────
+        schemas_dir = repo_root / "risk-map" / "schemas"
+        schemas_dir.mkdir(parents=True)
+
+        personas_schema = {
+            "$id": "personas.schema.json",
+            "definitions": {
+                "persona": {
+                    "properties": {
+                        "id": {
+                            "enum": [
+                                "personaModelProvider",
+                                "personaModelCreator",
+                                "personaModelConsumer",
+                            ]
+                        }
+                    }
+                }
+            },
+        }
+        (schemas_dir / "personas.schema.json").write_text(json.dumps(personas_schema))
+
+        # Minimal schemas for other templates so the generator can initialise
+        for schema_name, content in [
+            (
+                "controls.schema.json",
+                {
+                    "$id": "controls.schema.json",
+                    "definitions": {
+                        "category": {"properties": {"id": {"enum": ["controlsData"]}}},
+                        "control": {"properties": {"id": {"enum": ["control1"]}}},
+                    },
+                },
+            ),
+            (
+                "risks.schema.json",
+                {
+                    "$id": "risks.schema.json",
+                    "definitions": {
+                        "category": {"properties": {"id": {"enum": ["risksSupplyChain"]}}},
+                        "risk": {"properties": {"id": {"enum": ["riskA"]}}},
+                    },
+                },
+            ),
+            (
+                "components.schema.json",
+                {
+                    "$id": "components.schema.json",
+                    "definitions": {
+                        "component": {"properties": {"id": {"enum": ["componentA"]}}},
+                        "category": {"properties": {"id": {"enum": ["categoryA"]}}},
+                    },
+                },
+            ),
+        ]:
+            (schemas_dir / schema_name).write_text(json.dumps(content))
+
+        # ── YAML data ─────────────────────────────────────────────────────────
+        yaml_dir = repo_root / "risk-map" / "yaml"
+        yaml_dir.mkdir(parents=True)
+
+        personas_yaml = {
+            "personas": [
+                {"id": "personaModelProvider"},
+                {"id": "personaModelCreator", "deprecated": True},
+                {"id": "personaModelConsumer", "deprecated": True},
+            ]
+        }
+        (yaml_dir / "personas.yaml").write_text(yaml.dump(personas_yaml))
+        (yaml_dir / "frameworks.yaml").write_text(yaml.dump({"frameworks": []}))
+
+        # ── templates ─────────────────────────────────────────────────────────
+        templates_dir = repo_root / "scripts" / "TEMPLATES"
+        templates_dir.mkdir(parents=True)
+
+        new_risk_template = """name: New Risk
+description: Submit a new risk
+body:
+  - type: checkboxes
+    id: personas
+    attributes:
+      label: Applicable Personas
+      options:
+        {{PERSONAS}}
+  - type: input
+    id: title
+    attributes:
+      label: Title
+    validations:
+      required: true
+"""
+        (templates_dir / "new_risk.template.yml").write_text(new_risk_template)
+
+        new_control_template = """name: New Control
+description: Submit a new control
+body:
+  - type: checkboxes
+    id: personas
+    attributes:
+      label: Applicable Personas
+      options:
+        {{PERSONAS}}
+  - type: input
+    id: title
+    attributes:
+      label: Title
+    validations:
+      required: true
+"""
+        (templates_dir / "new_control.template.yml").write_text(new_control_template)
+
+        # Minimal stub templates for all other template names so generator
+        # can discover them without crashing on missing schemas
+        for stub_name in [
+            "update_risk",
+            "update_control",
+            "new_component",
+            "update_component",
+            "new_persona",
+            "update_persona",
+        ]:
+            stub = (
+                f"name: {stub_name.replace('_', ' ').title()}\n"
+                "body:\n"
+                "  - type: input\n"
+                "    id: title\n"
+                "    attributes:\n"
+                "      label: Title\n"
+            )
+            (templates_dir / f"{stub_name}.template.yml").write_text(stub)
+
+        # ── output dir ────────────────────────────────────────────────────────
+        output_dir = repo_root / ".github" / "ISSUE_TEMPLATE"
+        output_dir.mkdir(parents=True)
+
+        return repo_root
+
+    def test_generated_new_risk_template_excludes_deprecated_personas(
+        self,
+        full_repo_root_with_personas: Path,
+    ) -> None:
+        """
+        Test that generating new_risk.yml omits deprecated persona checkboxes.
+
+        Given: A repo root where personas.yaml marks personaModelCreator and
+               personaModelConsumer as deprecated: true, while personas.schema.json
+               still lists all three (including personaModelProvider which is active)
+        When:  IssueTemplateGenerator(repo_root).generate_template("new_risk") is called
+        Then:
+            - The generated new_risk.yml does NOT contain "personaModelCreator"
+            - The generated new_risk.yml does NOT contain "personaModelConsumer"
+            - The generated new_risk.yml DOES contain "personaModelProvider"
+        """
+        repo_root = full_repo_root_with_personas
+
+        # When
+        generator = IssueTemplateGenerator(repo_root)
+        output_path = generator.generate_template("new_risk")
+
+        generated_content = output_path.read_text(encoding="utf-8")
+
+        # Then
+        assert "personaModelCreator" not in generated_content, (
+            "Deprecated personaModelCreator should not appear in new_risk.yml"
+        )
+        assert "personaModelConsumer" not in generated_content, (
+            "Deprecated personaModelConsumer should not appear in new_risk.yml"
+        )
+        assert "personaModelProvider" in generated_content, (
+            "Active personaModelProvider must remain in new_risk.yml"
+        )
+
+    def test_generated_new_control_template_excludes_deprecated_personas(
+        self,
+        full_repo_root_with_personas: Path,
+    ) -> None:
+        """
+        Test that generating new_control.yml omits deprecated persona checkboxes.
+
+        Given: A repo root where personas.yaml marks personaModelCreator and
+               personaModelConsumer as deprecated: true, while personas.schema.json
+               still lists all three (including personaModelProvider which is active)
+        When:  IssueTemplateGenerator(repo_root).generate_template("new_control") is called
+        Then:
+            - The generated new_control.yml does NOT contain "personaModelCreator"
+            - The generated new_control.yml does NOT contain "personaModelConsumer"
+            - The generated new_control.yml DOES contain "personaModelProvider"
+        """
+        repo_root = full_repo_root_with_personas
+
+        # When
+        generator = IssueTemplateGenerator(repo_root)
+        output_path = generator.generate_template("new_control")
+
+        generated_content = output_path.read_text(encoding="utf-8")
+
+        # Then
+        assert "personaModelCreator" not in generated_content, (
+            "Deprecated personaModelCreator should not appear in new_control.yml"
+        )
+        assert "personaModelConsumer" not in generated_content, (
+            "Deprecated personaModelConsumer should not appear in new_control.yml"
+        )
+        assert "personaModelProvider" in generated_content, (
+            "Active personaModelProvider must remain in new_control.yml"
+        )

--- a/scripts/hooks/issue_template_generator/tests/test_schema_parser.py
+++ b/scripts/hooks/issue_template_generator/tests/test_schema_parser.py
@@ -1530,3 +1530,141 @@ class TestSchemaParserPerformance:
 
         assert elapsed < 0.5  # Should be reasonably fast
         assert len(result) == 20  # Found all enums
+
+
+# ============================================================================
+# Tests for load_deprecated_ids() — TDD red phase
+#
+# These tests target SchemaParser.load_deprecated_ids(yaml_filename, list_key),
+# a method that does not yet exist. All tests in this class MUST FAIL until
+# the implementation is added to schema_parser.py.
+# ============================================================================
+
+
+class TestLoadDeprecatedIds:
+    """
+    Tests for SchemaParser.load_deprecated_ids().
+
+    Contract under test (NOT YET IMPLEMENTED):
+        SchemaParser gains an optional yaml_data_dir: Path | None = None
+        constructor parameter.
+
+        load_deprecated_ids(yaml_filename: str, list_key: str) -> set[str]
+            Opens yaml_data_dir / yaml_filename, iterates data[list_key],
+            and collects entry["id"] where entry.get("deprecated") is True.
+            Results are cached per-instance.
+    """
+
+    def test_load_deprecated_ids_returns_set_of_deprecated_entries(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """
+        Test that load_deprecated_ids returns IDs of entries marked deprecated: true.
+
+        Given: A YAML file containing a mix of active and deprecated entries under
+               the "personas" key, where personaDeprecatedA and personaDeprecatedB
+               carry deprecated: true and personaActive1/Active2 do not
+        When:  load_deprecated_ids("personas_mixed_deprecated.yaml", "personas") is called
+               on a SchemaParser initialised with the fixture directory as yaml_data_dir
+        Then:  Returns exactly {"personaDeprecatedA", "personaDeprecatedB"}
+        """
+        # Given — copy the fixture into tmp_path's yaml dir so the path is deterministic
+        import shutil
+
+        fixtures_dir = Path(__file__).parent / "fixtures"
+        yaml_dir = tmp_path / "yaml"
+        yaml_dir.mkdir()
+        shutil.copy(fixtures_dir / "personas_mixed_deprecated.yaml", yaml_dir)
+
+        schema_dir = tmp_path / "schemas"
+        schema_dir.mkdir()
+
+        # When
+        parser = SchemaParser(schema_dir, yaml_data_dir=yaml_dir)
+        result = parser.load_deprecated_ids("personas_mixed_deprecated.yaml", "personas")
+
+        # Then
+        assert result == {"personaDeprecatedA", "personaDeprecatedB"}
+
+    def test_load_deprecated_ids_returns_empty_set_when_none_deprecated(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """
+        Test that load_deprecated_ids returns an empty set when no entries are deprecated.
+
+        Given: A YAML file with three entries none of which carry deprecated: true
+        When:  load_deprecated_ids("personas_none_deprecated.yaml", "personas") is called
+        Then:  Returns an empty set (not None, not a list)
+        """
+        import shutil
+
+        fixtures_dir = Path(__file__).parent / "fixtures"
+        yaml_dir = tmp_path / "yaml"
+        yaml_dir.mkdir()
+        shutil.copy(fixtures_dir / "personas_none_deprecated.yaml", yaml_dir)
+
+        schema_dir = tmp_path / "schemas"
+        schema_dir.mkdir()
+
+        # When
+        parser = SchemaParser(schema_dir, yaml_data_dir=yaml_dir)
+        result = parser.load_deprecated_ids("personas_none_deprecated.yaml", "personas")
+
+        # Then
+        assert result == set()
+        assert isinstance(result, set)
+
+    def test_load_deprecated_ids_missing_file_raises_filenotfound(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """
+        Test that load_deprecated_ids raises FileNotFoundError for a non-existent YAML file.
+
+        Given: A yaml_data_dir that exists but does not contain the requested file
+        When:  load_deprecated_ids("nonexistent.yaml", "personas") is called
+        Then:  FileNotFoundError is raised
+        """
+        yaml_dir = tmp_path / "yaml"
+        yaml_dir.mkdir()
+
+        schema_dir = tmp_path / "schemas"
+        schema_dir.mkdir()
+
+        # When / Then
+        parser = SchemaParser(schema_dir, yaml_data_dir=yaml_dir)
+
+        with pytest.raises(FileNotFoundError):
+            parser.load_deprecated_ids("nonexistent.yaml", "personas")
+
+    def test_load_deprecated_ids_handles_entries_without_deprecated_field(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """
+        Test that entries lacking the deprecated field are treated as active (not collected).
+
+        Given: A YAML file whose entries have no 'deprecated' key at all
+        When:  load_deprecated_ids("personas_no_deprecated_field.yaml", "personas") is called
+        Then:  Returns an empty set (missing field is not equivalent to deprecated: true)
+        """
+        import shutil
+
+        fixtures_dir = Path(__file__).parent / "fixtures"
+        yaml_dir = tmp_path / "yaml"
+        yaml_dir.mkdir()
+        shutil.copy(fixtures_dir / "personas_no_deprecated_field.yaml", yaml_dir)
+
+        schema_dir = tmp_path / "schemas"
+        schema_dir.mkdir()
+
+        # When
+        parser = SchemaParser(schema_dir, yaml_data_dir=yaml_dir)
+        result = parser.load_deprecated_ids("personas_no_deprecated_field.yaml", "personas")
+
+        # Then — neither entry should appear; absence of key != deprecated
+        assert result == set()
+        assert "personaNoFlag1" not in result
+        assert "personaNoFlag2" not in result

--- a/scripts/hooks/issue_template_generator/tests/test_template_renderer.py
+++ b/scripts/hooks/issue_template_generator/tests/test_template_renderer.py
@@ -2331,3 +2331,506 @@ body:
                 assert all("label" in opt and "value" not in opt for opt in options), (
                     f"Checkboxes {item['id']} has invalid object structure"
                 )
+
+
+# ============================================================================
+# Tests for deprecated-persona filtering — TDD red phase
+#
+# These tests target the not-yet-built behaviour where:
+#   - PLACEHOLDER_MAPPINGS["PERSONAS"] gains a yaml_source key
+#   - expand_placeholders() filters deprecated IDs from enum values when
+#     yaml_source is present in a mapping
+#   - SchemaParser is constructed with yaml_data_dir so it can load the YAML
+#
+# ALL tests in these classes MUST FAIL until the implementation lands in
+# template_renderer.py and schema_parser.py.
+# ============================================================================
+
+
+class TestDeprecatedPersonaFiltering:
+    """
+    Tests for deprecated-entry filtering in expand_placeholders().
+
+    Contract under test (NOT YET IMPLEMENTED):
+        PLACEHOLDER_MAPPINGS["PERSONAS"] gains:
+            "yaml_source": ("personas.yaml", "personas")
+
+        expand_placeholders() (or a private helper) calls
+        schema_parser.load_deprecated_ids(*yaml_source) and removes any
+        matching IDs from enum_values before generating checkbox lines.
+
+        Mappings without yaml_source are unchanged.
+    """
+
+    def test_expand_personas_placeholder_excludes_deprecated_entries(
+        self,
+        tmp_path: Path,
+        sample_frameworks_data: dict[str, Any],
+    ) -> None:
+        """
+        Test that deprecated persona IDs are excluded from {{PERSONAS}} expansion.
+
+        Given: A personas schema enum containing [personaActive, personaDeprecatedX],
+               a personas.yaml marking personaDeprecatedX as deprecated: true,
+               and a SchemaParser constructed with yaml_data_dir pointing at the YAML dir
+        When:  expand_placeholders() is called with a template containing {{PERSONAS}}
+        Then:  The rendered output contains "personaActive" but NOT "personaDeprecatedX"
+        """
+        import json
+
+        schema_dir = tmp_path / "schemas"
+        schema_dir.mkdir()
+        yaml_dir = tmp_path / "yaml"
+        yaml_dir.mkdir()
+
+        # Synthetic personas schema — includes both active and deprecated IDs
+        personas_schema = {
+            "$id": "personas.schema.json",
+            "definitions": {
+                "persona": {
+                    "properties": {
+                        "id": {"enum": ["personaActive", "personaDeprecatedX"]}
+                    }
+                }
+            },
+        }
+        (schema_dir / "personas.schema.json").write_text(json.dumps(personas_schema))
+
+        # Synthetic personas YAML — personaDeprecatedX is deprecated
+        import yaml as _yaml
+
+        personas_yaml = {
+            "personas": [
+                {"id": "personaActive"},
+                {"id": "personaDeprecatedX", "deprecated": True},
+            ]
+        }
+        (yaml_dir / "personas.yaml").write_text(_yaml.dump(personas_yaml))
+
+        # SchemaParser constructed with yaml_data_dir (new constructor param)
+        parser = SchemaParser(schema_dir, yaml_data_dir=yaml_dir)
+        renderer = TemplateRenderer(parser, sample_frameworks_data)
+
+        template = """options:
+        {{PERSONAS}}"""
+
+        # When
+        result = renderer.expand_placeholders(template, "controls")
+
+        # Then
+        assert "personaActive" in result
+        assert "personaDeprecatedX" not in result
+
+    def test_expand_placeholder_without_yaml_source_unchanged(
+        self,
+        sample_schema_parser: SchemaParser,
+        sample_frameworks_data: dict[str, Any],
+    ) -> None:
+        """
+        Regression guard: mappings without yaml_source must expand identically to today.
+
+        Given: A template with {{LIFECYCLE_STAGE}}, whose PLACEHOLDER_MAPPINGS entry
+               does NOT have yaml_source (no deprecation filtering applies)
+        When:  expand_placeholders() is called
+        Then:  ALL enum values from the schema appear in the output — no accidental
+               filtering occurs for mappings that do not declare yaml_source
+        """
+        # The real LIFECYCLE_STAGE schema is used via risk_map_schemas_dir; here we
+        # build a synthetic one so the test is self-contained and fast.
+        import json
+
+        schema_dir = sample_schema_parser.schema_dir
+
+        lifecycle_schema = {
+            "$id": "lifecycle-stage.schema.json",
+            "definitions": {
+                "lifecycleStage": {
+                    "properties": {
+                        "id": {"enum": ["planning", "deployment", "maintenance"]}
+                    }
+                }
+            },
+        }
+        (schema_dir / "lifecycle-stage.schema.json").write_text(json.dumps(lifecycle_schema))
+
+        renderer = TemplateRenderer(sample_schema_parser, sample_frameworks_data)
+
+        template = """options:
+        {{LIFECYCLE_STAGE}}"""
+
+        # When
+        result = renderer.expand_placeholders(template, "controls")
+
+        # Then — all three values must be present, nothing filtered
+        assert "planning" in result
+        assert "deployment" in result
+        assert "maintenance" in result
+
+    def test_expand_personas_real_data_excludes_model_creator_and_consumer(
+        self,
+        risk_map_schemas_dir: Path,
+        repo_root: Path,
+    ) -> None:
+        """
+        Integration test: real production data must exclude deprecated personas.
+
+        Given: The real risk-map/schemas/personas.schema.json (which still lists
+               personaModelCreator and personaModelConsumer in its enum) and the
+               real risk-map/yaml/personas.yaml (which marks both as deprecated: true),
+               with SchemaParser constructed pointing at both directories
+        When:  expand_placeholders() is called on a template containing {{PERSONAS}}
+        Then:
+            - "personaModelCreator" is absent from the rendered output
+            - "personaModelConsumer" is absent from the rendered output
+            - "personaModelProvider" (an active persona) IS present in the rendered output
+        """
+        import yaml as _yaml
+
+        real_yaml_dir = repo_root / "risk-map" / "yaml"
+        real_frameworks_yaml = real_yaml_dir / "frameworks.yaml"
+
+        with open(real_frameworks_yaml, "r", encoding="utf-8") as f:
+            frameworks_data = _yaml.safe_load(f)
+
+        # SchemaParser with yaml_data_dir pointing at the real YAML directory
+        parser = SchemaParser(risk_map_schemas_dir, yaml_data_dir=real_yaml_dir)
+        renderer = TemplateRenderer(parser, frameworks_data)
+
+        template = """options:
+        {{PERSONAS}}"""
+
+        # When
+        result = renderer.expand_placeholders(template, "controls")
+
+        # Then — deprecated personas must not appear
+        assert "personaModelCreator" not in result
+        assert "personaModelConsumer" not in result
+
+        # At least one active persona must still be present
+        assert "personaModelProvider" in result
+
+
+# ============================================================================
+# Tests for exclude_ids mechanism — TDD red phase
+#
+# These tests target the not-yet-built behaviour where:
+#   - PLACEHOLDER_MAPPINGS entries gain an optional "exclude_ids" field
+#   - A new "PERSONAS_FOR_RISKS" mapping is added that references the same
+#     schema/YAML as "PERSONAS" but adds exclude_ids=("personaGovernance",)
+#   - expand_placeholders() composes deprecated-filter and exclude_ids:
+#       final_ids = enum_ids - deprecated_ids - exclude_ids
+#   - Output order follows the original schema enum order (stable)
+#
+# ALL tests marked with "MUST FAIL" below must fail until the implementation
+# lands in template_renderer.py.  Tests marked "SHOULD PASS" are structural
+# and are written to pass with the current code using .get() defensively.
+# ============================================================================
+
+
+class TestExcludeIdsMechanism:
+    """
+    Tests for the exclude_ids mechanism in PLACEHOLDER_MAPPINGS entries.
+
+    Contract under test (NOT YET IMPLEMENTED):
+        - PLACEHOLDER_MAPPINGS entries accept an optional "exclude_ids" key
+          whose value is a tuple of schema-enum IDs to omit from output.
+        - Omitting "exclude_ids" is equivalent to an empty tuple (no filtering).
+        - A new "PERSONAS_FOR_RISKS" mapping is added identical to "PERSONAS"
+          except it adds exclude_ids=("personaGovernance",).
+        - "PERSONAS" is unchanged (personaGovernance still appears for controls).
+        - expand_placeholders() applies both deprecated-filter and exclude_ids:
+            final_ids = enum_ids - deprecated_ids - exclude_ids
+          preserving original schema enum ordering.
+    """
+
+    def test_placeholder_mapping_supports_exclude_ids_field(self) -> None:
+        """
+        Structural test: PLACEHOLDER_MAPPINGS entries support an "exclude_ids" key.
+
+        Given: The PLACEHOLDER_MAPPINGS dict defined on TemplateRenderer
+        When:  The "PERSONAS_FOR_RISKS" entry is read (expected post-implementation)
+               and an existing entry ("PERSONAS") is read with .get()
+        Then:
+            - Accessing mapping.get("exclude_ids", ()) on "PERSONAS" returns ()
+              (i.e. the default/absent value is treated as an empty tuple — no-op)
+            - The "PERSONAS_FOR_RISKS" key exists in PLACEHOLDER_MAPPINGS and its
+              "exclude_ids" value contains "personaGovernance"
+
+        Note: The first assertion (PERSONAS default) SHOULD PASS immediately
+        because it uses .get() with a default.  The second assertion (presence
+        of PERSONAS_FOR_RISKS) MUST FAIL until the entry is added.
+        """
+        # Given: the existing PERSONAS entry has no exclude_ids key
+        personas_mapping = TemplateRenderer.PLACEHOLDER_MAPPINGS["PERSONAS"]
+
+        # When / Then: absent key behaves as empty tuple via .get()
+        # This assertion is structural and passes today.
+        assert personas_mapping.get("exclude_ids", ()) == ()
+
+        # When / Then: PERSONAS_FOR_RISKS must exist and declare its exclusion
+        # MUST FAIL until PERSONAS_FOR_RISKS is added to PLACEHOLDER_MAPPINGS
+        assert "PERSONAS_FOR_RISKS" in TemplateRenderer.PLACEHOLDER_MAPPINGS
+
+        personas_for_risks_mapping = TemplateRenderer.PLACEHOLDER_MAPPINGS["PERSONAS_FOR_RISKS"]
+        exclude_ids = personas_for_risks_mapping.get("exclude_ids", ())
+        assert "personaGovernance" in exclude_ids
+
+    def test_expand_placeholders_filters_exclude_ids(
+        self,
+        tmp_path: Path,
+        sample_frameworks_data: dict[str, Any],
+    ) -> None:
+        """
+        Test that exclude_ids in a mapping omits specified IDs from rendered output.
+
+        MUST FAIL until expand_placeholders() applies exclude_ids filtering.
+
+        Given: A synthetic personas schema enum ["personaA", "personaB", "personaC"],
+               a mapping with exclude_ids=("personaB",) and no yaml_source,
+               and a SchemaParser with no yaml_data_dir
+        When:  expand_placeholders() is called with a template containing
+               {{PERSONAS_EXCLUDE_TEST}} (a synthetic placeholder not in the real code)
+        Then:
+            - "personaA" appears in rendered output
+            - "personaC" appears in rendered output
+            - "personaB" does NOT appear in rendered output
+            - Order is A then C (original schema enum order preserved)
+
+        Implementation note: because we cannot add a synthetic key to
+        PLACEHOLDER_MAPPINGS without modifying production code, this test
+        patches PLACEHOLDER_MAPPINGS on the class for the duration of the
+        call, using monkeypatching at the instance level.
+        """
+        import json
+
+        schema_dir = tmp_path / "schemas"
+        schema_dir.mkdir()
+
+        # Synthetic schema with three persona IDs
+        synthetic_schema = {
+            "$id": "personas.schema.json",
+            "definitions": {
+                "persona": {
+                    "properties": {
+                        "id": {"enum": ["personaA", "personaB", "personaC"]}
+                    }
+                }
+            },
+        }
+        (schema_dir / "personas.schema.json").write_text(json.dumps(synthetic_schema))
+
+        parser = SchemaParser(schema_dir)
+        renderer = TemplateRenderer(parser, sample_frameworks_data)
+
+        # Inject a synthetic mapping entry with exclude_ids onto this instance
+        # (does NOT modify the class-level dict; we replace the instance attribute)
+        import copy
+
+        custom_mappings = copy.deepcopy(TemplateRenderer.PLACEHOLDER_MAPPINGS)
+        custom_mappings["PERSONAS_EXCLUDE_TEST"] = {
+            "schema_paths": [("personas.schema.json", "definitions.persona.properties.id")],
+            "field_type": "checkbox",
+            "exclude_ids": ("personaB",),
+        }
+        renderer.PLACEHOLDER_MAPPINGS = custom_mappings
+
+        template = """options:
+        {{PERSONAS_EXCLUDE_TEST}}"""
+
+        # When
+        result = renderer.expand_placeholders(template, "controls")
+
+        # Then: personaB must be absent; A and C must be present in order A→C
+        assert "personaA" in result
+        assert "personaC" in result
+        assert "personaB" not in result
+
+        # Assert ordering: personaA must appear before personaC in the output
+        assert result.index("personaA") < result.index("personaC")
+
+    def test_expand_placeholders_composes_exclude_with_deprecated(
+        self,
+        tmp_path: Path,
+        sample_frameworks_data: dict[str, Any],
+    ) -> None:
+        """
+        Test that exclude_ids and yaml_source deprecated-filter compose correctly.
+
+        MUST FAIL until expand_placeholders() applies both filters together.
+
+        Given: A synthetic personas schema enum ["personaA", "personaB", "personaC"],
+               personas_abc_synthetic.yaml marks personaA as deprecated: true,
+               a mapping with yaml_source AND exclude_ids=("personaB",),
+               and a SchemaParser constructed with yaml_data_dir pointing at the
+               fixture directory
+        When:  expand_placeholders() is called
+        Then:
+            - Only "personaC" appears in rendered output
+            - "personaA" is absent (removed by deprecated-filter via yaml_source)
+            - "personaB" is absent (removed by exclude_ids)
+        """
+        import json
+
+        schema_dir = tmp_path / "schemas"
+        schema_dir.mkdir()
+
+        synthetic_schema = {
+            "$id": "personas.schema.json",
+            "definitions": {
+                "persona": {
+                    "properties": {
+                        "id": {"enum": ["personaA", "personaB", "personaC"]}
+                    }
+                }
+            },
+        }
+        (schema_dir / "personas.schema.json").write_text(json.dumps(synthetic_schema))
+
+        # Point yaml_data_dir at the fixtures directory which contains
+        # personas_abc_synthetic.yaml (personaA is deprecated there)
+        fixtures_dir = Path(__file__).resolve().parent / "fixtures"
+
+        parser = SchemaParser(schema_dir, yaml_data_dir=fixtures_dir)
+        renderer = TemplateRenderer(parser, sample_frameworks_data)
+
+        # Inject a synthetic mapping with both yaml_source and exclude_ids
+        import copy
+
+        custom_mappings = copy.deepcopy(TemplateRenderer.PLACEHOLDER_MAPPINGS)
+        custom_mappings["PERSONAS_COMPOSE_TEST"] = {
+            "schema_paths": [("personas.schema.json", "definitions.persona.properties.id")],
+            "field_type": "checkbox",
+            "yaml_source": ("personas_abc_synthetic.yaml", "personas"),
+            "exclude_ids": ("personaB",),
+        }
+        renderer.PLACEHOLDER_MAPPINGS = custom_mappings
+
+        template = """options:
+        {{PERSONAS_COMPOSE_TEST}}"""
+
+        # When
+        result = renderer.expand_placeholders(template, "controls")
+
+        # Then: only personaC survives both filters
+        assert "personaC" in result
+        assert "personaA" not in result
+        assert "personaB" not in result
+
+    def test_personas_for_risks_placeholder_excludes_governance(
+        self,
+        risk_map_schemas_dir: Path,
+        repo_root: Path,
+    ) -> None:
+        """
+        Integration test: {{PERSONAS_FOR_RISKS}} excludes personaGovernance and deprecated.
+
+        MUST FAIL until PERSONAS_FOR_RISKS is added to PLACEHOLDER_MAPPINGS and
+        exclude_ids filtering is implemented in expand_placeholders().
+
+        Given: The real risk-map/schemas/personas.schema.json and
+               risk-map/yaml/personas.yaml (personaModelCreator and
+               personaModelConsumer marked deprecated: true), with
+               SchemaParser constructed with yaml_data_dir, and a renderer
+               that has PERSONAS_FOR_RISKS with exclude_ids=("personaGovernance",)
+        When:  expand_placeholders() is called on a template stub containing
+               only {{PERSONAS_FOR_RISKS}}
+        Then:
+            - "personaGovernance" is absent (removed by exclude_ids)
+            - "personaModelCreator" is absent (removed by deprecated-filter)
+            - "personaModelConsumer" is absent (removed by deprecated-filter)
+            - The seven remaining active non-governance personas are ALL present
+            - They appear in this exact order (schema enum order preserved):
+                1. personaModelProvider
+                2. personaDataProvider
+                3. personaPlatformProvider
+                4. personaModelServing
+                5. personaAgenticProvider
+                6. personaApplicationDeveloper
+                7. personaEndUser
+        """
+        import yaml as _yaml
+
+        real_yaml_dir = repo_root / "risk-map" / "yaml"
+        real_frameworks_yaml = real_yaml_dir / "frameworks.yaml"
+
+        with open(real_frameworks_yaml, "r", encoding="utf-8") as f:
+            frameworks_data = _yaml.safe_load(f)
+
+        parser = SchemaParser(risk_map_schemas_dir, yaml_data_dir=real_yaml_dir)
+        renderer = TemplateRenderer(parser, frameworks_data)
+
+        template = """options:
+        {{PERSONAS_FOR_RISKS}}"""
+
+        # When
+        result = renderer.expand_placeholders(template, "risks")
+
+        # Then — excluded and deprecated IDs must be absent
+        assert "personaGovernance" not in result
+        assert "personaModelCreator" not in result
+        assert "personaModelConsumer" not in result
+
+        # All seven active non-governance personas must be present
+        expected_active = [
+            "personaModelProvider",
+            "personaDataProvider",
+            "personaPlatformProvider",
+            "personaModelServing",
+            "personaAgenticProvider",
+            "personaApplicationDeveloper",
+            "personaEndUser",
+        ]
+        for persona_id in expected_active:
+            assert persona_id in result, f"Expected active persona missing: {persona_id}"
+
+        # Order must match schema enum order (stable, not set-shuffled)
+        positions = [result.index(p) for p in expected_active]
+        assert positions == sorted(positions), (
+            "Active personas must appear in original schema enum order: "
+            f"got order {[expected_active[i] for i in sorted(range(len(positions)), key=lambda x: positions[x])]}"
+        )
+
+    def test_personas_placeholder_still_includes_governance(
+        self,
+        risk_map_schemas_dir: Path,
+        repo_root: Path,
+    ) -> None:
+        """
+        Regression guard: {{PERSONAS}} still includes personaGovernance (controls path).
+
+        SHOULD PASS with the current code (personaGovernance is not deprecated in
+        personas.yaml) and MUST CONTINUE TO PASS after the exclude_ids implementation.
+        This guards against accidentally applying PERSONAS_FOR_RISKS exclusions to
+        the PERSONAS mapping.
+
+        Given: The real risk-map/schemas/personas.schema.json and
+               risk-map/yaml/personas.yaml, with SchemaParser pointing at both
+        When:  expand_placeholders() is called with a template containing {{PERSONAS}}
+        Then:
+            - "personaGovernance" IS present in rendered output
+            - "personaModelCreator" is absent (deprecated-filter still active)
+            - "personaModelConsumer" is absent (deprecated-filter still active)
+        """
+        import yaml as _yaml
+
+        real_yaml_dir = repo_root / "risk-map" / "yaml"
+        real_frameworks_yaml = real_yaml_dir / "frameworks.yaml"
+
+        with open(real_frameworks_yaml, "r", encoding="utf-8") as f:
+            frameworks_data = _yaml.safe_load(f)
+
+        parser = SchemaParser(risk_map_schemas_dir, yaml_data_dir=real_yaml_dir)
+        renderer = TemplateRenderer(parser, frameworks_data)
+
+        template = """options:
+        {{PERSONAS}}"""
+
+        # When
+        result = renderer.expand_placeholders(template, "controls")
+
+        # Then — governance must be present (controls path unchanged)
+        assert "personaGovernance" in result
+
+        # Deprecated legacy personas must still be absent
+        assert "personaModelCreator" not in result
+        assert "personaModelConsumer" not in result

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -405,7 +405,7 @@ echo  # Add blank line for readability
 echo "🔗 Running component edge validation..."
 
 # Path to the component edge validation script
-EDGE_VALIDATOR=".git/hooks/validate_riskmap.py"
+EDGE_VALIDATOR="${HOOKS_DIR}/validate_riskmap.py"
 
 # Run the component edge validation with appropriate args based on passed flags
 run_validator "$EDGE_VALIDATOR" "component edge validation" "$EDGE_ARGS"
@@ -444,7 +444,7 @@ echo  # Add blank line for readability
 echo "🔗 Running control-to-risk reference validation..."
 
 # Path to the control-risk reference validation script
-REF_VALIDATOR=".git/hooks/validate_control_risk_references.py"
+REF_VALIDATOR="${HOOKS_DIR}/validate_control_risk_references.py"
 
 # Run the control-risk reference validation
 # Uses same EDGE_ARGS since both validators support --force flag
@@ -461,7 +461,7 @@ echo  # Add blank line for readability
 echo "🔗 Running framework reference validation..."
 
 # Path to the framework reference validation script
-FRAMEWORK_VALIDATOR=".git/hooks/validate_framework_references.py"
+FRAMEWORK_VALIDATOR="${HOOKS_DIR}/validate_framework_references.py"
 
 # Run the framework reference validation
 # Uses same EDGE_ARGS since both validators support --force flag
@@ -566,7 +566,7 @@ if [[ $FORCE_VALIDATE -eq 0 ]]; then
     if echo "$STAGED_FILES" | grep -q "risk-map/yaml/\(components\|controls\|risks\|personas\)\.yaml$"; then
         echo "📋 YAML files changed - generating markdown tables..."
 
-        TABLE_GENERATOR=".git/hooks/yaml_to_markdown.py"
+        TABLE_GENERATOR="${HOOKS_DIR}/yaml_to_markdown.py"
 
         if [[ ! -f "$TABLE_GENERATOR" ]]; then
             echo "   ⚠️  Warning: Table generator not found - skipping table generation"


### PR DESCRIPTION
# Contributor guidance: title style guides, submission readiness, and template-generator hardening

## Summary

Establishes a coherent contributor-guidance layer for proposing new and updated CoSAI Risk Map content, and strengthens the issue-template generator so deprecated entities and context-specific persona rules flow automatically into the GitHub forms contributors see.

Three things change in concert:

1. **Contributor-facing docs** — new title style guides (per entity type), a submission-readiness guide, a common-review-findings catalog, and a per-issue review agent (`scripts/agents/issue-response-reviewer.md`). Existing docs and the `content-reviewer` agent are aligned around title-derived IDs and the persona model.
2. **Template-generation infrastructure** — adds two filtering mechanisms (`yaml_source` for deprecated entries, `exclude_ids` for per-context exclusions like `personaGovernance` on risk templates), a maintainer doc covering the source/generated split, and worktree-safe pre-commit hook paths. Source templates in `scripts/TEMPLATES/` are backported so regeneration produces the live `.github/ISSUE_TEMPLATE/` files byte-identically.
3. **Deprecated-persona cleanup** — removes `personaModelCreator` / `personaModelConsumer` from prose in maintainer guides and template inline text, replacing with active personas per the migration table in `guide-personas.md`.


## What contributors see

- Issue forms no longer ask for `*-id` (IDs derive mechanically from titles per the new style guides).
- Persona checkbox lists no longer include `personaModelCreator` / `personaModelConsumer`; risk templates no longer include `personaGovernance`.
- Each `new_*` template links to the submission-readiness guide and the entity's title style guide; the framework-mappings field calls out the technique-vs-mitigation rule inline.
- "Required Fields" relabeled "Required for review" with a note that GitHub Issue Forms cannot enforce required selection on checkbox groups.

## What maintainers / agents see

- New maintainer doc `scripts/docs/template-generation.md` covers the two-tier model (sources vs. generated), placeholder system, both filter mechanisms, and how to add a new placeholder or template.
- `scripts/agents/issue-response-reviewer.md` composes per-issue feedback and instructs reviewers to propose specific replacement titles when the derived ID would collide or be malformed.
- `scripts/agents/content-reviewer.md` updated with real risk-category enums and "derived ID" sample output.

## Test plan

- [x] `pytest scripts/hooks/issue_template_generator/tests/` — 225 tests pass.
- [x] `python3 scripts/generate_issue_templates.py` — runs cleanly; `git diff .github/ISSUE_TEMPLATE/` empty.
- [x] Pre-commit hook executes the four validators in a worktree (no "validator not found" warnings).
- [x] Open one of each `new_*.yml` template in GitHub's preview and confirm: ID field absent; persona checkboxes match expectations (governance present on controls, absent on risks; deprecated personas absent everywhere); style-guide and readiness-guide links resolve.
- [x] Spot-check `submission-readiness-guide.md` anchors (`#section-1-creating-a-valid-id`, `#section-3-the-persona-model`, `#section-4-universal-controls`, `#pre-submission-checklist`) and `common-review-findings.md` TOC anchors.

## Notes for the reviewer

- The two `feat(templates)` commits (`d3df827`, `cb10dea`) intentionally land in this order: filter mechanism first, then sources reference the new `{{PERSONAS_FOR_RISKS}}` placeholder.
- Hand-authored issue templates (`new_persona.yml`, `update_persona.yml`, `update_component.yml`, `infrastructure.yml`) have no source in `scripts/TEMPLATES/` and are not regenerated — see the inventory table in `scripts/docs/template-generation.md`.
- The `content-reviewer` and `issue-response-reviewer` agents are vendor-neutral (under `scripts/agents/`), per the project's agent-architecture pattern.
- No schema changes; no CI configuration changes.

## Out of scope (follow-ups)

- A `{{PERSONAS_FOR_RISKS}}`-equivalent variant for any future enum that needs context-specific exclusion will follow the same pattern (one mapping entry + one source-template reference).
- The "Recent Template Changes" section in `issue-templates-guide.md` is a drift-prone history aid; consider auto-generating from `git log` or removing in a follow-up.
- The `update_persona`, `update_component` templates remain hand-authored; promoting them to generated sources is a future option if their content starts depending on schema enums.
