### PR TITLE
[infra]: Bump persona-pages workflow actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/persona-pages.yml
+++ b/.github/workflows/persona-pages.yml
@@ -81,13 +81,13 @@ jobs:
 
       - name: Configure GitHub Pages
         if: github.event_name != 'pull_request'
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
         with:
           enablement: true
 
       - name: Upload GitHub Pages artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
@@ -107,7 +107,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   pages-summary:
     needs: [build, deploy]


### PR DESCRIPTION
## Summary
- Bumps `actions/configure-pages` from `v5` to `v6`.
- Bumps `actions/upload-pages-artifact` from `v4` to `v5`.
- Bumps `actions/deploy-pages` from `v4` to `v5`.

## Rationale
These releases move the persona-pages workflow's Pages-specific actions to Node.js 24-compatible versions ahead of GitHub Actions' Node 20 runner deprecation timeline. The workflow conditions, permissions, artifact path, and summary behavior are unchanged.

Closes #234

## Verification
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/persona-pages.yml'); puts '.github/workflows/persona-pages.yml: valid YAML'"`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest scripts/hooks/tests/test_build_persona_site_data.py`
- `node --test site/tests/*.test.mjs`
- `node_modules/.bin/prettier --check .github/workflows/persona-pages.yml`
- `git diff --check`
