### PR TITLE
Conformance sweep A1: Implementation of external-references schema + framework patterns

### DIFF
--- a/risk-map/schemas/external-references.schema.json
+++ b/risk-map/schemas/external-references.schema.json
@@ -1,0 +1,69 @@
+{
+  "$id": "external-references.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "External References Schema",
+  "description": "Shared shape for the externalReferences array on risks, controls, components, and personas. Single source of truth per ADR-016 D3; consumer schemas $ref the array definition rather than duplicating it.",
+  "definitions": {
+    "externalReferences": {
+      "type": "array",
+      "description": "Structured outbound citations and editorial pointers. Empty arrays are rejected per ADR-016 D3 — authors omit the field when there are no references.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "description": "One outbound reference. id is the sentinel target used by {{ref:identifier}} prose mentions; title is the display string; url is the underlying https resource.",
+        "required": ["type", "id", "title", "url"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Reference type. Citation-grade types underpin substance; the editorial type is the relief valve for color links.",
+            "enum": [
+              "cwe",
+              "cve",
+              "atlas",
+              "attack",
+              "advisory",
+              "paper",
+              "news",
+              "spec",
+              "editorial",
+              "other"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Author-chosen lowercase-kebab identifier; per-type regex pinned via allOf for canonical-form types.",
+            "minLength": 1
+          },
+          "title": {
+            "type": "string",
+            "description": "Display string used by table generators and the site renderer.",
+            "minLength": 1
+          },
+          "url": {
+            "type": "string",
+            "description": "Outbound URL. https only — http and other schemes are rejected.",
+            "pattern": "^https://"
+          }
+        },
+        "allOf": [
+          {
+            "if": { "properties": { "type": { "const": "cwe" } }, "required": ["type"] },
+            "then": { "properties": { "id": { "type": "string", "pattern": "^cwe-\\d+$" } } }
+          },
+          {
+            "if": { "properties": { "type": { "const": "cve" } }, "required": ["type"] },
+            "then": { "properties": { "id": { "type": "string", "pattern": "^cve-\\d{4}-\\d+$" } } }
+          },
+          {
+            "if": { "properties": { "type": { "const": "atlas" } }, "required": ["type"] },
+            "then": { "properties": { "id": { "type": "string", "pattern": "^aml-t\\d{4}(\\.\\d{3})?$" } } }
+          },
+          {
+            "if": { "properties": { "type": { "const": "attack" } }, "required": ["type"] },
+            "then": { "properties": { "id": { "type": "string", "pattern": "^attack-t\\d{4}(\\.\\d{3})?$" } } }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/risk-map/schemas/frameworks.schema.json
+++ b/risk-map/schemas/frameworks.schema.json
@@ -75,6 +75,36 @@
         }
       },
       "required": ["id", "name", "fullName", "description", "baseUri", "applicableTo"]
+    },
+    "framework-mapping-patterns": {
+      "type": "object",
+      "description": "Per-framework mapping-ID regex patterns per ADR-022 D5b. Keys mirror the framework.id enum to prevent drift; values constrain the canonical ID shape consumed by risks/controls/personas mappings. ISO 22989 is the deliberate exception (bare string, no regex) because persona ISO 22989 mappings are role descriptors rather than canonical IDs.",
+      "additionalProperties": false,
+      "properties": {
+        "mitre-atlas": {
+          "type": "string",
+          "pattern": "^AML\\.(T|M)\\d{4}(\\.\\d{3})?$"
+        },
+        "nist-ai-rmf": {
+          "type": "string",
+          "pattern": "^(GOVERN|MAP|MEASURE|MANAGE)-\\d+(\\.\\d+)*$"
+        },
+        "stride": {
+          "type": "string",
+          "pattern": "^(Spoofing|Tampering|Repudiation|InformationDisclosure|DenialOfService|ElevationOfPrivilege)$"
+        },
+        "owasp-top10-llm": {
+          "type": "string",
+          "pattern": "^LLM\\d{2}:\\d{4}$"
+        },
+        "iso-22989": {
+          "type": "string"
+        },
+        "eu-ai-act": {
+          "type": "string",
+          "pattern": "^Article\\s\\d+(\\(\\d+\\))?$"
+        }
+      }
     }
   }
 }

--- a/scripts/hooks/tests/test_external_references_schema.py
+++ b/scripts/hooks/tests/test_external_references_schema.py
@@ -1,0 +1,665 @@
+#!/usr/bin/env python3
+"""
+Tests for risk-map/schemas/external-references.schema.json.
+
+Covers the shared external-references schema per ADR-016 D3 — the canonical
+shape for outbound citations, $ref'd from risks/controls/components/personas
+schemas as their externalReferences field.
+
+Coverage:
+- File presence and JSON Schema Draft-07 self-validity.
+- `definitions/externalReferences` array shape (rejects empty array; accepts >= 1).
+- Per-item required fields (`type`, `id`, `title`, `url`).
+- `type` enum covers all 10 values from ADR-016 D3 (incl. `editorial`).
+- `url` rejects non-`https://` schemes via anchored regex.
+- Per-type `id` regex patterns for canonical-form types (`cwe`, `cve`, `atlas`,
+  `attack`) — at least 3 valid + 3 invalid examples each.
+- Non-canonical types (`paper`, `news`, `editorial`, `other`, `advisory`, `spec`)
+  accept author-chosen kebab-case identifiers.
+
+Authoritative source for the `id` patterns is ADR-016 D3, which fixes the
+lowercase-kebab convention for the `external-references.id` field. Note that
+ADR-022 D5b's regex patterns target a different surface
+(`frameworks.schema.json#/definitions/framework-mapping-patterns`) and use the
+canonical-uppercase form (e.g., `AML.T0020`); see
+`test_framework_mapping_patterns.py` for that surface.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+from jsonschema.exceptions import SchemaError
+from jsonschema.validators import validator_for
+
+# Allow imports of repo helpers if needed by future fixtures
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+# ============================================================================
+# Module-level constants
+# ============================================================================
+
+SCHEMA_FILENAME = "external-references.schema.json"
+
+# All 10 type values from ADR-016 D3.
+EXPECTED_TYPE_ENUM = {
+    "cwe",
+    "cve",
+    "atlas",
+    "attack",
+    "advisory",
+    "paper",
+    "news",
+    "spec",
+    "editorial",
+    "other",
+}
+
+# Per-type valid/invalid id examples for canonical-form types.
+# Patterns are the lowercase-kebab forms committed by ADR-016 D3.
+CANONICAL_ID_EXAMPLES: dict[str, dict[str, list[str]]] = {
+    "cwe": {
+        "valid": ["cwe-89", "cwe-1", "cwe-12345"],
+        # Wrong case, missing prefix, wrong delimiter, embedded spaces.
+        "invalid": ["CWE-89", "cwe89", "cwe_89", "cwe-", "cwe-89a"],
+    },
+    "cve": {
+        "valid": ["cve-2024-0001", "cve-2025-12345", "cve-1999-0001"],
+        # Wrong case, missing year, wrong separator, missing prefix.
+        "invalid": ["CVE-2024-0001", "cve-24-0001", "cve_2024_0001", "2024-0001", "cve-2024"],
+    },
+    "atlas": {
+        # ATLAS lowercase-kebab technique form per ADR-016 D3 / issue #240 body.
+        "valid": ["aml-t0020", "aml-t0020.001", "aml-t1234"],
+        # Uppercase canonical (belongs in framework-mapping-patterns surface),
+        # missing prefix, wrong delimiter, malformed sub-technique.
+        "invalid": ["AML.T0020", "aml-t20", "aml_t0020", "aml-T0020", "aml-t0020.1"],
+    },
+    "attack": {
+        # ATT&CK lowercase-kebab technique form, analogous to atlas.
+        # ADR-016 D3 commits to "lowercase-kebab" convention; issue body says
+        # "analogous to ATLAS"; this pattern follows that convention.
+        "valid": ["attack-t1190", "attack-t1190.001", "attack-t1059"],
+        "invalid": ["T1190", "attack-T1190", "attack_t1190", "attack-1190", "attack-t190"],
+    },
+}
+
+# Non-canonical types — bare kebab-case strings expected to be permitted.
+NON_CANONICAL_TYPE_EXAMPLES: dict[str, list[str]] = {
+    "paper": ["zhou-2023-poisoning", "smith-et-al-2024-rag"],
+    "news": ["wired-2024-ai-leak", "vendor-announcement-2025-q1"],
+    "editorial": ["vendor-blog-rag-eval", "maintainer-note-on-llm-eval"],
+    "other": ["misc-reference-1", "internal-doc-archive-42"],
+    "advisory": ["vendor-advisory-2024-01", "ghsa-xxxx-yyyy-zzzz"],
+    "spec": ["rfc-2119", "iso-iec-27001-2022"],
+}
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="module")
+def external_references_schema_path(risk_map_schemas_dir: Path) -> Path:
+    """Absolute path to external-references.schema.json (may not exist yet)."""
+    return risk_map_schemas_dir / SCHEMA_FILENAME
+
+
+@pytest.fixture(scope="module")
+def external_references_schema(external_references_schema_path: Path) -> dict:
+    """
+    Parsed external-references.schema.json contents.
+
+    Skips with a clear message if the file is absent, distinguishing
+    schema-absent failure from a fixture error.
+    """
+    if not external_references_schema_path.is_file():
+        pytest.fail(
+            f"Expected schema not found at {external_references_schema_path}. "
+            "Tests assume the schema is authored per ADR-016 D3."
+        )
+    with open(external_references_schema_path) as fh:
+        return json.load(fh)
+
+
+@pytest.fixture(scope="module")
+def external_references_item_validator(external_references_schema: dict) -> Draft7Validator:
+    """
+    Draft-07 validator over the per-item object schema.
+
+    Resolves to `definitions/externalReferences` then drills into the array's
+    `items` so individual reference objects can be validated in isolation.
+    The fixture asserts the path exists rather than guessing structure.
+    """
+    defs = external_references_schema.get("definitions", {})
+    assert "externalReferences" in defs, "Schema must define 'externalReferences' under definitions per ADR-016 D3"
+    array_schema = defs["externalReferences"]
+    assert array_schema.get("type") == "array", "externalReferences must be an array shape per ADR-016 D3"
+    item_schema = array_schema.get("items")
+    assert isinstance(item_schema, dict), "externalReferences.items must be an object schema (per-item shape)"
+    # Validator over the item schema in isolation; if the SWE agent uses
+    # internal $refs the validator will need a registry — extend here when
+    # the schema is authored if needed.
+    return Draft7Validator(item_schema)
+
+
+def _make_item(type_value: str, id_value: str) -> dict:
+    """Construct a minimal valid-shape externalReferences entry for testing."""
+    return {
+        "type": type_value,
+        "id": id_value,
+        "title": "Test Reference",
+        "url": "https://example.com/ref",
+    }
+
+
+# ============================================================================
+# Schema file presence and JSON Schema meta-validity
+# ============================================================================
+
+
+class TestSchemaFilePresence:
+    """The schema file must exist at the canonical path."""
+
+    def test_schema_file_exists(self, external_references_schema_path: Path):
+        """
+        Test that external-references.schema.json exists.
+
+        Given: ADR-016 D3 mandates a shared external-references schema
+        When: The schemas/ directory is inspected
+        Then: external-references.schema.json is present
+        """
+        assert external_references_schema_path.is_file(), (
+            f"{SCHEMA_FILENAME} must exist at {external_references_schema_path}"
+        )
+
+    def test_schema_is_valid_json(self, external_references_schema_path: Path):
+        """
+        Test that the file parses as valid JSON.
+
+        Given: The schema file exists
+        When: It is read and parsed as JSON
+        Then: No JSONDecodeError is raised
+        """
+        if not external_references_schema_path.is_file():
+            pytest.fail(f"{SCHEMA_FILENAME} not found")
+        with open(external_references_schema_path) as fh:
+            json.load(fh)  # Raises if invalid
+
+
+class TestSchemaMetaValidity:
+    """The schema must itself be a valid JSON Schema Draft-07 document."""
+
+    def test_schema_declares_draft07(self, external_references_schema: dict):
+        """
+        Test that the schema declares the Draft-07 meta-schema.
+
+        Given: A loaded schema document
+        When: The $schema field is examined
+        Then: It points at the Draft-07 meta-schema URL
+        """
+        assert external_references_schema.get("$schema") == ("http://json-schema.org/draft-07/schema#"), (
+            "Schema must declare Draft-07 ($schema field)"
+        )
+
+    def test_schema_passes_draft07_metaschema(self, external_references_schema: dict):
+        """
+        Test that the schema validates against the Draft-07 meta-schema.
+
+        Given: A loaded schema document
+        When: It is checked against the Draft-07 meta-schema
+        Then: No SchemaError is raised
+        """
+        # check_schema raises SchemaError if the schema is itself invalid.
+        try:
+            Draft7Validator.check_schema(external_references_schema)
+        except SchemaError as exc:
+            pytest.fail(f"Schema is not valid Draft-07: {exc.message}")
+
+    def test_validator_for_schema_resolves_to_draft07(self, external_references_schema: dict):
+        """
+        Test that the appropriate validator class is Draft-07.
+
+        Given: A loaded schema document
+        When: jsonschema selects a validator class via validator_for()
+        Then: The resolved class is Draft7Validator
+        """
+        cls = validator_for(external_references_schema)
+        assert cls is Draft7Validator, f"Expected Draft7Validator, got {cls.__name__}"
+
+
+# ============================================================================
+# definitions/externalReferences shape
+# ============================================================================
+
+
+class TestExternalReferencesDefinition:
+    """The schema must define the externalReferences array shape per ADR-016 D3."""
+
+    def test_definition_exists(self, external_references_schema: dict):
+        """
+        Test that definitions/externalReferences exists.
+
+        Given: A loaded schema
+        When: The definitions block is inspected
+        Then: An `externalReferences` definition is present
+        """
+        assert "definitions" in external_references_schema, "Schema must declare a 'definitions' block"
+        assert "externalReferences" in external_references_schema["definitions"], (
+            "definitions/externalReferences must exist (ADR-016 D3 single-source-of-truth)"
+        )
+
+    def test_definition_is_array_shape(self, external_references_schema: dict):
+        """
+        Test that externalReferences is an array.
+
+        Given: definitions/externalReferences is present
+        When: Its `type` is examined
+        Then: It is `array`
+        """
+        defn = external_references_schema["definitions"]["externalReferences"]
+        assert defn.get("type") == "array", "externalReferences must be an array shape (ADR-016 D3)"
+
+    def test_array_has_min_items_one(self, external_references_schema: dict):
+        """
+        Test that empty arrays are rejected.
+
+        Given: The externalReferences array shape
+        When: Its `minItems` is examined
+        Then: It is set to 1 (per ADR-016 D3: empty arrays are rejected;
+              authors should omit the field instead)
+        """
+        defn = external_references_schema["definitions"]["externalReferences"]
+        assert defn.get("minItems") == 1, (
+            "externalReferences array must reject empty arrays (minItems: 1) per ADR-016 D3 'use omission instead'"
+        )
+
+    def test_empty_array_fails_validation(self, external_references_schema: dict):
+        """
+        Test that an empty array fails validation in practice.
+
+        Given: A Draft-07 validator over the array schema
+        When: An empty list is validated
+        Then: ValidationError is raised
+        """
+        defn = external_references_schema["definitions"]["externalReferences"]
+        validator = Draft7Validator(defn)
+        errors = list(validator.iter_errors([]))
+        assert errors, "Empty array must be rejected by the schema"
+
+    def test_single_valid_item_array_passes(self, external_references_schema: dict):
+        """
+        Test that a one-element array with a valid item passes.
+
+        Given: The externalReferences array schema
+        When: An array with one valid item is validated
+        Then: No errors are raised
+        """
+        defn = external_references_schema["definitions"]["externalReferences"]
+        validator = Draft7Validator(defn)
+        item = _make_item("paper", "zhou-2023-poisoning")
+        errors = list(validator.iter_errors([item]))
+        assert not errors, f"Single valid item array must pass; got errors: {[e.message for e in errors]}"
+
+
+# ============================================================================
+# Per-item required fields
+# ============================================================================
+
+
+class TestItemRequiredFields:
+    """Each entry must require type, id, title, url per ADR-016 D3."""
+
+    @pytest.mark.parametrize("required_field", ["type", "id", "title", "url"])
+    def test_required_field_declared(self, external_references_schema: dict, required_field: str):
+        """
+        Test that the per-item schema declares each required field.
+
+        Given: definitions/externalReferences items schema
+        When: Its `required` array is examined
+        Then: It includes the named field
+        """
+        defn = external_references_schema["definitions"]["externalReferences"]
+        item_schema = defn["items"]
+        required = item_schema.get("required", [])
+        assert required_field in required, (
+            f"Per-item schema must declare '{required_field}' as required (ADR-016 D3)"
+        )
+
+    @pytest.mark.parametrize("missing_field", ["type", "id", "title", "url"])
+    def test_missing_required_field_rejected(
+        self, external_references_item_validator: Draft7Validator, missing_field: str
+    ):
+        """
+        Test that an item missing a required field fails validation.
+
+        Given: A complete valid item shape
+        When: The named required field is removed
+        Then: ValidationError is raised by the item validator
+        """
+        item = _make_item("paper", "test-paper")
+        del item[missing_field]
+        errors = list(external_references_item_validator.iter_errors(item))
+        assert errors, f"Item missing '{missing_field}' must be rejected"
+
+
+# ============================================================================
+# type enum coverage
+# ============================================================================
+
+
+class TestTypeEnum:
+    """The `type` enum must cover all 10 values from ADR-016 D3."""
+
+    def test_type_field_has_enum(self, external_references_schema: dict):
+        """
+        Test that the type field is an enum.
+
+        Given: The per-item schema
+        When: The `type` property is examined
+        Then: It declares an enum constraint
+        """
+        item = external_references_schema["definitions"]["externalReferences"]["items"]
+        type_schema = item["properties"]["type"]
+        assert "enum" in type_schema, "type must be enum-constrained per ADR-016 D3"
+
+    def test_type_enum_covers_all_ten_values(self, external_references_schema: dict):
+        """
+        Test that all 10 ADR-016 D3 type values are present.
+
+        Given: The type enum
+        When: Its values are examined
+        Then: It covers cwe, cve, atlas, attack, advisory, paper, news,
+              spec, editorial, other (set equality, not just subset)
+        """
+        item = external_references_schema["definitions"]["externalReferences"]["items"]
+        actual = set(item["properties"]["type"]["enum"])
+        assert actual == EXPECTED_TYPE_ENUM, (
+            f"type enum must equal ADR-016 D3 set; "
+            f"missing={EXPECTED_TYPE_ENUM - actual}, extra={actual - EXPECTED_TYPE_ENUM}"
+        )
+
+    def test_unknown_type_rejected(self, external_references_item_validator: Draft7Validator):
+        """
+        Test that an unknown type value fails validation.
+
+        Given: An item with type='regulation' (not in the enum)
+        When: It is validated
+        Then: ValidationError is raised
+        """
+        item = _make_item("regulation", "regulation-1")
+        errors = list(external_references_item_validator.iter_errors(item))
+        assert errors, "Unknown type values (e.g., 'regulation') must be rejected"
+
+    @pytest.mark.parametrize("type_value", sorted(EXPECTED_TYPE_ENUM))
+    def test_each_known_type_accepted(
+        self,
+        external_references_item_validator: Draft7Validator,
+        type_value: str,
+    ):
+        """
+        Test that each known type value is accepted (with a permissive id).
+
+        Given: An item with one of the 10 ADR-016 D3 type values
+        When: It is validated using a type-appropriate id format
+        Then: Validation passes (no errors)
+
+        Note: For canonical-form types we use a known-valid example;
+        for non-canonical types any kebab-case string suffices.
+        """
+        if type_value in CANONICAL_ID_EXAMPLES:
+            id_value = CANONICAL_ID_EXAMPLES[type_value]["valid"][0]
+        else:
+            # Non-canonical types accept any kebab-case string.
+            id_value = "test-reference-id"
+        item = _make_item(type_value, id_value)
+        errors = list(external_references_item_validator.iter_errors(item))
+        assert not errors, (
+            f"Known type '{type_value}' with valid id '{id_value}' must pass; got: {[e.message for e in errors]}"
+        )
+
+
+# ============================================================================
+# url scheme constraint
+# ============================================================================
+
+
+class TestUrlSchemeConstraint:
+    """The `url` field must require https:// per ADR-016 D3."""
+
+    def test_url_pattern_declared(self, external_references_schema: dict):
+        """
+        Test that the url field declares a pattern.
+
+        Given: The per-item schema
+        When: The `url` property is examined
+        Then: It declares a pattern constraint anchored to https://
+        """
+        item = external_references_schema["definitions"]["externalReferences"]["items"]
+        url_schema = item["properties"]["url"]
+        assert "pattern" in url_schema, "url must declare a pattern constraint (https:// only per ADR-016 D3)"
+        # The pattern must anchor to ^https:// — not merely contain https.
+        assert url_schema["pattern"].startswith("^https://"), (
+            f"url pattern must anchor at start with ^https://, got {url_schema['pattern']!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "valid_url",
+        [
+            "https://example.com",
+            "https://cwe.mitre.org/data/definitions/89.html",
+            "https://arxiv.org/abs/2305.00944",
+        ],
+    )
+    def test_https_urls_accepted(self, external_references_item_validator: Draft7Validator, valid_url: str):
+        """
+        Test that https:// URLs are accepted.
+
+        Given: An item with an https:// url
+        When: It is validated
+        Then: No errors are raised
+        """
+        item = _make_item("paper", "test-paper")
+        item["url"] = valid_url
+        errors = list(external_references_item_validator.iter_errors(item))
+        assert not errors, f"https URL must be accepted; got: {[e.message for e in errors]}"
+
+    @pytest.mark.parametrize(
+        "invalid_url",
+        [
+            "http://example.com",  # plain http
+            "ftp://example.com/ref",  # wrong scheme
+            "//example.com/ref",  # protocol-relative
+            "example.com/ref",  # bare host
+            "javascript:alert(1)",  # XSS surface
+            "  https://example.com",  # leading whitespace
+        ],
+    )
+    def test_non_https_urls_rejected(self, external_references_item_validator: Draft7Validator, invalid_url: str):
+        """
+        Test that non-https URLs are rejected.
+
+        Given: An item with a non-https url
+        When: It is validated
+        Then: ValidationError is raised (the url pattern blocks it)
+        """
+        item = _make_item("paper", "test-paper")
+        item["url"] = invalid_url
+        errors = list(external_references_item_validator.iter_errors(item))
+        assert errors, f"Non-https URL {invalid_url!r} must be rejected"
+
+
+# ============================================================================
+# Per-type id regex patterns (canonical-form types)
+# ============================================================================
+
+
+class TestCanonicalIdPatterns:
+    """
+    Per-type id regex patterns enforce the lowercase-kebab canonical form
+    (ADR-016 D3) for cwe, cve, atlas, attack.
+
+    Each canonical type is checked with >=3 valid + >=3 invalid examples
+    per the issue #240 acceptance criteria.
+    """
+
+    @pytest.mark.parametrize(
+        ("type_value", "valid_id"),
+        [(t, vid) for t, examples in CANONICAL_ID_EXAMPLES.items() for vid in examples["valid"]],
+    )
+    def test_canonical_valid_id_accepted(
+        self,
+        external_references_item_validator: Draft7Validator,
+        type_value: str,
+        valid_id: str,
+    ):
+        """
+        Test that canonical valid id forms are accepted.
+
+        Given: An item with type=<canonical> and a valid lowercase-kebab id
+        When: It is validated
+        Then: No errors are raised
+
+        Note on conditional validation: The schema must apply the per-type
+        id regex only when `type == <type_value>`. Implementations may use
+        `oneOf` / `anyOf` / `if-then` / per-type subschemas. This test
+        treats the wiring as opaque and just asserts the resulting behavior.
+        """
+        item = _make_item(type_value, valid_id)
+        errors = list(external_references_item_validator.iter_errors(item))
+        assert not errors, (
+            f"type={type_value!r} id={valid_id!r} must be accepted; got: {[e.message for e in errors]}"
+        )
+
+    @pytest.mark.parametrize(
+        ("type_value", "invalid_id"),
+        [(t, iid) for t, examples in CANONICAL_ID_EXAMPLES.items() for iid in examples["invalid"]],
+    )
+    def test_canonical_invalid_id_rejected(
+        self,
+        external_references_item_validator: Draft7Validator,
+        type_value: str,
+        invalid_id: str,
+    ):
+        """
+        Test that malformed canonical ids are rejected.
+
+        Given: An item with type=<canonical> and a malformed id (wrong case,
+               wrong delimiter, missing prefix, etc.)
+        When: It is validated
+        Then: ValidationError is raised
+        """
+        item = _make_item(type_value, invalid_id)
+        errors = list(external_references_item_validator.iter_errors(item))
+        assert errors, f"type={type_value!r} with malformed id={invalid_id!r} must be rejected"
+
+    @pytest.mark.parametrize("type_value", sorted(CANONICAL_ID_EXAMPLES.keys()))
+    def test_canonical_type_has_at_least_three_valid_examples(self, type_value: str):
+        """
+        Test that each canonical type has >=3 valid examples (test-data sanity).
+
+        Given: The CANONICAL_ID_EXAMPLES table
+        When: A canonical type's valid list is examined
+        Then: It has at least 3 entries (issue #240 acceptance criterion)
+        """
+        assert len(CANONICAL_ID_EXAMPLES[type_value]["valid"]) >= 3
+
+    @pytest.mark.parametrize("type_value", sorted(CANONICAL_ID_EXAMPLES.keys()))
+    def test_canonical_type_has_at_least_three_invalid_examples(self, type_value: str):
+        """
+        Test that each canonical type has >=3 invalid examples (test-data sanity).
+
+        Given: The CANONICAL_ID_EXAMPLES table
+        When: A canonical type's invalid list is examined
+        Then: It has at least 3 entries (issue #240 acceptance criterion)
+        """
+        assert len(CANONICAL_ID_EXAMPLES[type_value]["invalid"]) >= 3
+
+
+# ============================================================================
+# Non-canonical types accept author-chosen kebab-case ids
+# ============================================================================
+
+
+class TestNonCanonicalIdShapes:
+    """
+    Non-canonical types (`paper`, `news`, `editorial`, `other`, `advisory`,
+    `spec`) permit author-chosen kebab-case shorthand ids per ADR-016 D3.
+    """
+
+    @pytest.mark.parametrize(
+        ("type_value", "id_value"),
+        [(t, iid) for t, examples in NON_CANONICAL_TYPE_EXAMPLES.items() for iid in examples],
+    )
+    def test_non_canonical_id_accepted(
+        self,
+        external_references_item_validator: Draft7Validator,
+        type_value: str,
+        id_value: str,
+    ):
+        """
+        Test that non-canonical types accept author-chosen kebab-case ids.
+
+        Given: An item with a non-canonical type and a kebab-case id
+        When: It is validated
+        Then: No errors are raised
+
+        Examples like `zhou-2023-poisoning` and `vendor-blog-rag-eval` are
+        the literal examples ADR-016 D3 names.
+        """
+        item = _make_item(type_value, id_value)
+        errors = list(external_references_item_validator.iter_errors(item))
+        assert not errors, (
+            f"Non-canonical type={type_value!r} id={id_value!r} must be accepted; "
+            f"got: {[e.message for e in errors]}"
+        )
+
+    def test_empty_id_rejected_for_non_canonical(self, external_references_item_validator: Draft7Validator):
+        """
+        Test that an empty id is rejected even for non-canonical types.
+
+        Given: An item with type=paper and id=""
+        When: It is validated
+        Then: ValidationError is raised (the id is required and non-empty)
+        """
+        item = _make_item("paper", "")
+        errors = list(external_references_item_validator.iter_errors(item))
+        assert errors, "Empty id must be rejected (id is required and non-empty)"
+
+
+# ============================================================================
+# Test summary
+# ============================================================================
+"""
+Test Summary
+============
+Test classes: 8
+
+- TestSchemaFilePresence (2)        — file exists, parses as JSON
+- TestSchemaMetaValidity (3)        — Draft-07 declared, meta-valid, validator class
+- TestExternalReferencesDefinition (5) — definition exists, array shape, minItems,
+                                          empty rejected, single-item accepted
+- TestItemRequiredFields            — parametrized: 4 declared + 4 reject-on-missing
+- TestTypeEnum                      — has enum, set equality, unknown rejected,
+                                       parametrized: each of 10 types accepted
+- TestUrlSchemeConstraint           — pattern declared, parametrized: 3 https
+                                       accepted + 6 non-https rejected
+- TestCanonicalIdPatterns           — parametrized: valid and invalid examples
+                                       per (cwe, cve, atlas, attack), plus
+                                       test-data sanity assertions
+- TestNonCanonicalIdShapes          — parametrized: kebab-case ids accepted for
+                                       6 non-canonical types, empty id rejected
+
+Coverage areas:
+- File presence and JSON parse-ability
+- JSON Schema Draft-07 self-validity
+- Required-field enforcement
+- Enum coverage (10 type values)
+- URL scheme constraint (https-only, anchored)
+- Per-type id regex patterns (4 canonical types: cwe, cve, atlas, attack)
+- Non-canonical type id permissiveness (6 types)
+"""

--- a/scripts/hooks/tests/test_framework_mapping_patterns.py
+++ b/scripts/hooks/tests/test_framework_mapping_patterns.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""
+Tests for risk-map/schemas/frameworks.schema.json definitions/framework-mapping-patterns.
+
+Covers the per-framework mapping-ID regex patterns per ADR-022 D5b. These
+patterns are referenced from risks.schema.json and controls.schema.json to
+validate canonical-form mapping IDs (e.g., AML.T0020 for MITRE ATLAS,
+GOVERN-1.1 for NIST AI RMF) at the schema layer.
+
+Coverage:
+- The block exists at definitions/framework-mapping-patterns.
+- It declares all 6 framework keys (mitre-atlas, nist-ai-rmf, stride,
+  owasp-top10-llm, iso-22989, eu-ai-act).
+- Each canonical-form framework's regex matches >=3 representative valid
+  examples and rejects >=3 malformed inputs (per ADR-022 D5b commitments).
+- ISO 22989 entry is bare `string` (no canonical form) per ADR-022 D5b.
+- The block uses `additionalProperties: false` (closed schema).
+- The framework keys align with the `framework.id` enum in
+  frameworks.schema.json (drift-detection between the two surfaces).
+
+Authoritative source for the patterns is ADR-022 D5b. This is a different
+surface from `external-references.schema.json` (tested separately in
+test_external_references_schema.py) — the framework-mapping-patterns block
+uses the canonical-uppercase form (e.g., `AML.T0020`), where
+external-references uses lowercase-kebab (`aml-t0020`).
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+from jsonschema.exceptions import SchemaError
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+# ============================================================================
+# Module-level constants — patterns and examples per ADR-022 D5b
+# ============================================================================
+
+# Six framework keys per ADR-022 D5b. Must match the existing
+# framework.id enum in frameworks.schema.json.
+EXPECTED_FRAMEWORK_KEYS = {
+    "mitre-atlas",
+    "nist-ai-rmf",
+    "stride",
+    "owasp-top10-llm",
+    "iso-22989",
+    "eu-ai-act",
+}
+
+# Frameworks with canonical-form regexes per ADR-022 D5b.
+# ISO 22989 is the deliberate exception (bare string, see TestIso22989Entry).
+CANONICAL_FRAMEWORKS = EXPECTED_FRAMEWORK_KEYS - {"iso-22989"}
+
+# Pattern + valid/invalid examples per ADR-022 D5b.
+# These are the source-of-truth patterns for the framework-mapping-patterns
+# block; the SWE agent's schema must commit to these exact strings.
+FRAMEWORK_PATTERN_TABLE: dict[str, dict] = {
+    "mitre-atlas": {
+        # Technique + mitigation union per ADR-022 D5b.
+        "pattern": r"^AML\.(T|M)\d{4}(\.\d{3})?$",
+        "valid": ["AML.T0020", "AML.T0020.001", "AML.M0011", "AML.M0001"],
+        # lowercase (belongs in external-references surface); missing dot;
+        # short technique ID; non-T/M letter; whitespace separator.
+        "invalid": ["aml-t0020", "AML.T20", "AML.X0020", "AML T0020", "AML.T20020"],
+    },
+    "nist-ai-rmf": {
+        # Function-prefix subcategories per ADR-022 D5b.
+        "pattern": r"^(GOVERN|MAP|MEASURE|MANAGE)-\d+(\.\d+)*$",
+        "valid": ["GOVERN-1", "MAP-1.1", "MEASURE-2.1.1", "MANAGE-4"],
+        # lowercase function; underscore delimiter; wrong function name;
+        # missing dash; trailing dot.
+        "invalid": ["govern-1", "GOVERN_1", "GOVERNANCE-1", "GOVERN1", "GOVERN-1."],
+    },
+    "stride": {
+        # PascalCase enum-as-pattern per ADR-022 D5b.
+        # NOTE: The issue #240 body suggests lowercase-kebab values; ADR-022
+        # D5b is the source of truth for this surface and uses PascalCase
+        # without separators. Tests track ADR-022 D5b.
+        "pattern": (
+            r"^(Spoofing|Tampering|Repudiation|InformationDisclosure|"
+            r"DenialOfService|ElevationOfPrivilege)$"
+        ),
+        "valid": [
+            "Spoofing",
+            "Tampering",
+            "Repudiation",
+            "InformationDisclosure",
+            "DenialOfService",
+            "ElevationOfPrivilege",
+        ],
+        # lowercase, abbreviated, hyphenated forms, unknown category.
+        "invalid": [
+            "spoofing",
+            "dos",
+            "info-disclosure",
+            "ElevationPrivilege",
+            "InfoDisclosure",
+        ],
+    },
+    "owasp-top10-llm": {
+        # Versioned per ADR-022 D5b.
+        "pattern": r"^LLM\d{2}:\d{4}$",
+        "valid": ["LLM01:2025", "LLM10:2025", "LLM05:2024"],
+        # lowercase prefix; one digit only; dash instead of colon; missing
+        # version year.
+        "invalid": ["llm01:2025", "LLM1:2025", "LLM01-2025", "LLM01:25", "LLM01"],
+    },
+    "eu-ai-act": {
+        # Article-style references per ADR-022 D5b.
+        "pattern": r"^Article\s\d+(\(\d+\))?$",
+        "valid": ["Article 5", "Article 5(1)", "Article 50", "Article 6(2)"],
+        # lowercase; abbreviated; period subsection notation; missing space.
+        "invalid": ["article 5", "Art 5", "Article 5.1", "Article5", "Article 5("],
+    },
+}
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="module")
+def frameworks_schema(frameworks_schema_path: Path) -> dict:
+    """Parsed frameworks.schema.json contents."""
+    if not frameworks_schema_path.is_file():
+        pytest.fail(
+            f"frameworks.schema.json not found at {frameworks_schema_path}; "
+            "this is a baseline file that should already exist"
+        )
+    with open(frameworks_schema_path) as fh:
+        return json.load(fh)
+
+
+@pytest.fixture(scope="module")
+def framework_mapping_patterns(frameworks_schema: dict) -> dict:
+    """
+    The definitions/framework-mapping-patterns block.
+
+    Fails with a clear message if the block is absent — ADR-022 D5b mandates
+    this block as the canonical home for per-framework mapping-ID regex
+    patterns referenced from risks/controls schemas.
+    """
+    defs = frameworks_schema.get("definitions", {})
+    if "framework-mapping-patterns" not in defs:
+        pytest.fail(
+            "definitions/framework-mapping-patterns missing from frameworks.schema.json (required by ADR-022 D5b)."
+        )
+    return defs["framework-mapping-patterns"]
+
+
+# ============================================================================
+# Block presence and structural shape
+# ============================================================================
+
+
+class TestBlockPresence:
+    """The `definitions/framework-mapping-patterns` block must exist."""
+
+    def test_definitions_block_exists(self, frameworks_schema: dict):
+        """
+        Test that frameworks.schema.json has a definitions block.
+
+        Given: frameworks.schema.json
+        When: It is parsed
+        Then: It declares a 'definitions' object
+        """
+        assert "definitions" in frameworks_schema, "frameworks.schema.json must declare a 'definitions' block"
+
+    def test_framework_mapping_patterns_definition_present(self, frameworks_schema: dict):
+        """
+        Test that the framework-mapping-patterns definition is present.
+
+        Given: The definitions block of frameworks.schema.json
+        When: 'framework-mapping-patterns' key is checked
+        Then: It exists (per ADR-022 D5b)
+        """
+        defs = frameworks_schema["definitions"]
+        assert "framework-mapping-patterns" in defs, (
+            "definitions/framework-mapping-patterns must be added per ADR-022 D5b"
+        )
+
+
+class TestBlockStructure:
+    """The block must be a closed object with one entry per framework."""
+
+    def test_block_is_object_type(self, framework_mapping_patterns: dict):
+        """
+        Test that the block declares type: object.
+
+        Given: The framework-mapping-patterns block
+        When: Its 'type' is examined
+        Then: It is 'object'
+        """
+        assert framework_mapping_patterns.get("type") == "object", (
+            "framework-mapping-patterns must be a JSON Schema object"
+        )
+
+    def test_block_uses_additional_properties_false(self, framework_mapping_patterns: dict):
+        """
+        Test that the block is a closed schema.
+
+        Given: The framework-mapping-patterns block
+        When: 'additionalProperties' is examined
+        Then: It is False (per ADR-022 D5b code sample)
+        """
+        assert framework_mapping_patterns.get("additionalProperties") is False, (
+            "framework-mapping-patterns must set additionalProperties: false (closed schema per ADR-022 D5b)"
+        )
+
+    def test_block_has_six_framework_keys(self, framework_mapping_patterns: dict):
+        """
+        Test that all 6 framework keys are present.
+
+        Given: The framework-mapping-patterns block
+        When: Its 'properties' keys are examined
+        Then: They equal the 6-framework set from ADR-022 D5b exactly
+        """
+        properties = framework_mapping_patterns.get("properties", {})
+        actual_keys = set(properties.keys())
+        assert actual_keys == EXPECTED_FRAMEWORK_KEYS, (
+            f"framework-mapping-patterns properties must equal {EXPECTED_FRAMEWORK_KEYS}; "
+            f"missing={EXPECTED_FRAMEWORK_KEYS - actual_keys}, "
+            f"extra={actual_keys - EXPECTED_FRAMEWORK_KEYS}"
+        )
+
+    def test_keys_align_with_framework_id_enum(self, frameworks_schema: dict):
+        """
+        Test that the block's keys align with framework.id's enum.
+
+        Given: The framework-mapping-patterns block keys
+        When: They are compared against frameworks.schema.json
+              definitions/framework/properties/id/enum
+        Then: They are the same set (drift detection between surfaces)
+        """
+        framework_id_enum = set(frameworks_schema["definitions"]["framework"]["properties"]["id"]["enum"])
+        defs = frameworks_schema["definitions"]
+        if "framework-mapping-patterns" not in defs:
+            pytest.fail("framework-mapping-patterns block not yet added")
+        pattern_keys = set(defs["framework-mapping-patterns"]["properties"].keys())
+        assert pattern_keys == framework_id_enum, (
+            "Pattern keys must equal framework.id enum to prevent drift; "
+            f"diff: pattern_keys-id_enum={pattern_keys - framework_id_enum}, "
+            f"id_enum-pattern_keys={framework_id_enum - pattern_keys}"
+        )
+
+
+# ============================================================================
+# Per-framework regex commitments (ADR-022 D5b)
+# ============================================================================
+
+
+class TestPerFrameworkPatternCommitments:
+    """
+    Each canonical-form framework declares the exact ADR-022 D5b pattern.
+
+    Test-data sanity is also checked: each framework has >=3 valid + >=3
+    invalid examples per the issue #240 acceptance criterion.
+    """
+
+    @pytest.mark.parametrize("framework_key", sorted(CANONICAL_FRAMEWORKS))
+    def test_framework_entry_is_string_with_pattern(self, framework_mapping_patterns: dict, framework_key: str):
+        """
+        Test that each canonical framework entry is a string-with-pattern shape.
+
+        Given: A canonical framework key
+        When: Its sub-schema is examined
+        Then: It declares type:string and a 'pattern' field
+        """
+        entry = framework_mapping_patterns["properties"].get(framework_key)
+        assert entry is not None, f"{framework_key!r} entry missing"
+        assert entry.get("type") == "string", f"{framework_key!r} entry must be type:string per ADR-022 D5b"
+        assert "pattern" in entry, f"{framework_key!r} entry must declare a regex pattern per ADR-022 D5b"
+
+    @pytest.mark.parametrize("framework_key", sorted(CANONICAL_FRAMEWORKS))
+    def test_framework_pattern_matches_adr022_d5b_exactly(
+        self, framework_mapping_patterns: dict, framework_key: str
+    ):
+        """
+        Test that each pattern equals the ADR-022 D5b commitment exactly.
+
+        Given: A canonical framework key
+        When: Its 'pattern' is read
+        Then: It equals the string committed in ADR-022 D5b
+
+        The pattern strings are load-bearing — drifting from D5b silently
+        relaxes or tightens validation. The schema must commit to the
+        exact strings.
+        """
+        entry = framework_mapping_patterns["properties"][framework_key]
+        expected = FRAMEWORK_PATTERN_TABLE[framework_key]["pattern"]
+        actual = entry["pattern"]
+        assert actual == expected, (
+            f"{framework_key!r} pattern drift from ADR-022 D5b:\n  expected: {expected!r}\n  actual:   {actual!r}"
+        )
+
+    @pytest.mark.parametrize(
+        ("framework_key", "valid_id"),
+        [(fw, vid) for fw, info in FRAMEWORK_PATTERN_TABLE.items() for vid in info["valid"]],
+    )
+    def test_pattern_accepts_valid_example(
+        self,
+        framework_mapping_patterns: dict,
+        framework_key: str,
+        valid_id: str,
+    ):
+        """
+        Test that each canonical pattern accepts representative valid examples.
+
+        Given: A canonical framework's pattern
+        When: A representative valid id is tested against it
+        Then: re.fullmatch / Draft-07 validation succeeds
+
+        Behavior is checked by validating against a one-off Draft-07 schema
+        wrapping the per-framework string pattern; this exercises the actual
+        schema, not just the regex string in isolation.
+        """
+        entry = framework_mapping_patterns["properties"][framework_key]
+        validator = Draft7Validator(entry)
+        errors = list(validator.iter_errors(valid_id))
+        assert not errors, (
+            f"{framework_key!r} pattern must accept {valid_id!r}; got: {[e.message for e in errors]}"
+        )
+
+    @pytest.mark.parametrize(
+        ("framework_key", "invalid_id"),
+        [(fw, iid) for fw, info in FRAMEWORK_PATTERN_TABLE.items() for iid in info["invalid"]],
+    )
+    def test_pattern_rejects_invalid_example(
+        self,
+        framework_mapping_patterns: dict,
+        framework_key: str,
+        invalid_id: str,
+    ):
+        """
+        Test that each canonical pattern rejects malformed examples.
+
+        Given: A canonical framework's pattern
+        When: A malformed id is tested against it
+        Then: ValidationError is raised
+        """
+        entry = framework_mapping_patterns["properties"][framework_key]
+        validator = Draft7Validator(entry)
+        errors = list(validator.iter_errors(invalid_id))
+        assert errors, f"{framework_key!r} pattern must reject {invalid_id!r}; the malformed id slipped through"
+
+    @pytest.mark.parametrize("framework_key", sorted(FRAMEWORK_PATTERN_TABLE.keys()))
+    def test_test_data_has_three_or_more_valid_examples(self, framework_key: str):
+        """
+        Test that the test-data table has >=3 valid examples per framework
+        (issue #240 acceptance criterion).
+        """
+        assert len(FRAMEWORK_PATTERN_TABLE[framework_key]["valid"]) >= 3
+
+    @pytest.mark.parametrize("framework_key", sorted(FRAMEWORK_PATTERN_TABLE.keys()))
+    def test_test_data_has_three_or_more_invalid_examples(self, framework_key: str):
+        """
+        Test that the test-data table has >=3 invalid examples per framework
+        (issue #240 acceptance criterion).
+        """
+        assert len(FRAMEWORK_PATTERN_TABLE[framework_key]["invalid"]) >= 3
+
+
+# ============================================================================
+# ISO 22989 — explicit bare-string exception
+# ============================================================================
+
+
+class TestIso22989Entry:
+    """
+    ISO 22989 is the deliberate exception per ADR-022 D5b: bare `string`
+    with no canonical-form regex, because persona ISO 22989 mappings are
+    role descriptors (e.g., `"AI Partner (data supplier)"`), not canonical
+    IDs. This is documented behavior, not an oversight.
+    """
+
+    def test_iso22989_entry_present(self, framework_mapping_patterns: dict):
+        """
+        Test that the iso-22989 entry exists.
+
+        Given: The framework-mapping-patterns block
+        When: 'iso-22989' is looked up
+        Then: It is present
+        """
+        assert "iso-22989" in framework_mapping_patterns.get("properties", {}), (
+            "iso-22989 entry must be present (deliberate bare-string exception)"
+        )
+
+    def test_iso22989_is_bare_string(self, framework_mapping_patterns: dict):
+        """
+        Test that iso-22989 is a bare string with no pattern.
+
+        Given: The iso-22989 entry
+        When: Its keys are examined
+        Then: It declares type:string and does NOT declare a 'pattern'
+              (per ADR-022 D5b: explicit no-canonical-form exception)
+        """
+        entry = framework_mapping_patterns["properties"]["iso-22989"]
+        assert entry.get("type") == "string", "iso-22989 must be type:string"
+        assert "pattern" not in entry, (
+            "iso-22989 must NOT declare a pattern (ADR-022 D5b: explicit "
+            "exception; persona role descriptors are not canonical IDs)"
+        )
+
+    @pytest.mark.parametrize(
+        "valid_value",
+        [
+            "AI Partner (data supplier)",
+            "AI Producer",
+            "AI Subject",
+            "Some arbitrary descriptor",
+        ],
+    )
+    def test_iso22989_accepts_arbitrary_strings(self, framework_mapping_patterns: dict, valid_value: str):
+        """
+        Test that iso-22989 accepts arbitrary string values.
+
+        Given: The iso-22989 entry (bare string)
+        When: An arbitrary descriptor string is validated
+        Then: Validation passes (no pattern constraint applies)
+        """
+        entry = framework_mapping_patterns["properties"]["iso-22989"]
+        validator = Draft7Validator(entry)
+        errors = list(validator.iter_errors(valid_value))
+        assert not errors, (
+            f"iso-22989 must accept {valid_value!r} (no pattern constraint); got: {[e.message for e in errors]}"
+        )
+
+
+# ============================================================================
+# Schema meta-validity — the patterns must compile under Draft-07
+# ============================================================================
+
+
+class TestSchemaMetaValidity:
+    """The block must itself be a valid JSON Schema Draft-07 fragment."""
+
+    def test_block_passes_draft07_metaschema(self, framework_mapping_patterns: dict):
+        """
+        Test that the block is a valid Draft-07 schema fragment.
+
+        Given: The framework-mapping-patterns block
+        When: It is checked against the Draft-07 meta-schema
+        Then: No SchemaError is raised
+        """
+        try:
+            Draft7Validator.check_schema(framework_mapping_patterns)
+        except SchemaError as exc:
+            pytest.fail(f"framework-mapping-patterns is not valid Draft-07: {exc.message}")
+
+    @pytest.mark.parametrize("framework_key", sorted(CANONICAL_FRAMEWORKS))
+    def test_pattern_compiles_as_python_regex(self, framework_mapping_patterns: dict, framework_key: str):
+        """
+        Test that each pattern compiles as a Python regex.
+
+        Given: A canonical framework's pattern string
+        When: re.compile() is called on it
+        Then: No re.error is raised
+
+        Catches stray escapes / invalid groups before they hit the validator.
+        """
+        pattern = framework_mapping_patterns["properties"][framework_key]["pattern"]
+        try:
+            re.compile(pattern)
+        except re.error as exc:
+            pytest.fail(f"{framework_key!r} pattern does not compile: {exc} ({pattern!r})")
+
+
+# ============================================================================
+# Test summary
+# ============================================================================
+"""
+Test Summary
+============
+Test classes: 6
+
+- TestBlockPresence (2)              — definitions block exists,
+                                        framework-mapping-patterns present
+- TestBlockStructure (4)             — type=object, additionalProperties=false,
+                                        6 keys, drift-vs-id-enum
+- TestPerFrameworkPatternCommitments — parametrized: shape, exact-string match,
+                                        valid/invalid examples, test-data sanity
+                                        (per 5 canonical frameworks)
+- TestIso22989Entry                  — present, bare string, accepts arbitrary
+                                        values
+- TestSchemaMetaValidity             — block passes Draft-07; each pattern
+                                        compiles as Python regex
+
+Coverage areas:
+- Block existence and structural integrity
+- 6-framework key set match against framework.id enum (drift detection)
+- Per-framework pattern commitment to ADR-022 D5b strings
+- Per-framework regex behavior (>=3 valid + >=3 invalid examples each)
+- ISO 22989 bare-string exception per ADR-022 D5b
+- JSON Schema Draft-07 meta-validity and Python regex compile
+
+"""


### PR DESCRIPTION

# Conformance sweep A1: Implementation of external-references schema + framework patterns

Closes #240

## Summary

- Authors `risk-map/schemas/external-references.schema.json` per ADR-016 D3 — defines the shared `externalReferences[]` shape with a 10-value `type` enum (`cwe`, `cve`, `atlas`, `attack`, `advisory`, `paper`, `news`, `spec`, `editorial`, `other`), `https://`-only URLs, and per-type `id` regex patterns for canonical-form types.
- Adds `definitions/framework-mapping-patterns` to `risk-map/schemas/frameworks.schema.json` per ADR-022 D5b — concrete regex commitments for MITRE ATLAS, NIST AI RMF, STRIDE, OWASP LLM Top 10, EU AI Act, and ISO 22989 (the last as documented bare-string exception).
- Tests added across two test modules covering schema meta-validity, regex acceptance/rejection, and per-framework canonical-form fixtures.
- **Foundation only** — no consumer schemas (`risks` / `controls` / `components` / `personas`) `$ref` the new shared schema yet. That wiring lands in the next sub-PR (A2).

## Scope boundaries

In scope (this PR):
- New file: `risk-map/schemas/external-references.schema.json`
- Edit: `risk-map/schemas/frameworks.schema.json` — adds `definitions/framework-mapping-patterns` block (no other changes)
- New tests: `scripts/hooks/tests/test_external_references_schema.py`, `scripts/hooks/tests/test_framework_mapping_patterns.py`

Out of scope (deferred to subsequent sub-PRs):
- Adding `externalReferences` `$ref` to consumer schemas → A2
- Wiring per-framework patterns into `risks.schema.json` / `controls.schema.json` consumer rules → A2
- Any YAML content migration → Phase B

## Test plan

- [ ] `pytest scripts/hooks/tests/test_external_references_schema.py scripts/hooks/tests/test_framework_mapping_patterns.py` — all 178 tests pass
- [ ] `pre-commit run --all-files` clean (Python lint, schema meta-validation via `check-jsonschema`, ruff)
- [ ] Full repo regression: `pytest` reports no new failures (1549 pass / 6 skip baseline)
- [ ] Schema meta-validation: `external-references.schema.json` and the updated `frameworks.schema.json` both load cleanly under `check-jsonschema`
- [ ] Spot-check: each of the 5 canonical-form regex patterns matches ≥3 valid examples and rejects ≥3 invalid examples per `test_framework_mapping_patterns.py`
- [ ] Confirm no consumer schema `$ref`s the new shared schema yet (foundation-only invariant per ADR-016 D3 staging)


