### PR TITLE
Conformance sweep A6: site sanitizer.mjs with bounded HTML emission

### DIFF
--- a/site/assets/sanitizer.mjs
+++ b/site/assets/sanitizer.mjs
@@ -1,0 +1,419 @@
+/**
+ * sanitizer.mjs — render-time prose sanitizer for the CoSAI Risk Map site.
+ *
+ * Exports renderProse(input) which accepts either a plain string or a
+ * structured link object ({type: "link", title, url}) and returns an
+ * HTML-safe string suitable for assignment to innerHTML.
+ *
+ * Design: ADR-015 D3 (hand-rolled, bounded emission), D3a (ALLOWED_TAGS
+ * literal const), D3b (per-tag fixtures + meta-test enforce the boundary).
+ *
+ * Allowed output tags: <strong>, <em>, <a> with restricted attributes only.
+ * Everything else is escaped with &lt;/&gt; and triggers one console.warn
+ * per renderProse call.
+ *
+ * This file must remain browser-compatible (no node: imports).
+ */
+
+// Bounded-emission literal constant — ADR-015 D3a.
+// Must be a literal const at module scope. Never derive from input or config.
+// The meta-test in sanitizer.test.mjs reads this file's source and asserts
+// this pattern exists. Adding a tag here requires a matching fixture update.
+const ALLOWED_TAGS = ["strong", "em", "a"];
+
+// ---------------------------------------------------------------------------
+// HTML character escaping
+// ---------------------------------------------------------------------------
+
+/**
+ * Escape a string for safe inclusion in HTML text content or attribute values.
+ * Replaces &, <, >, ", ' with their named HTML entities.
+ *
+ * @param {string} text - Raw text to escape
+ * @returns {string} HTML-escaped text
+ */
+function escapeHtml(text) {
+  return String(text).replace(/[&<>"']/g, (ch) => {
+    switch (ch) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      case "'":
+        return "&#39;";
+    }
+  });
+}
+
+/**
+ * Escape a string for use as anchor text content.
+ * Extends escapeHtml by also encoding `=` as `&#61;` so that attribute-
+ * injection patterns like `onclick=` cannot appear as a raw substring in the
+ * rendered HTML output, even inside text content where they are already
+ * structurally harmless.
+ *
+ * This defence-in-depth prevents the raw string `onclick=` from surfacing in
+ * the serialised output, which is the requirement the attack-corpus fixture
+ * for attribute-injection-quote-in-text asserts.
+ *
+ * @param {string} text - Raw title text from a structured link item
+ * @returns {string} HTML-escaped text safe for anchor inner content
+ */
+function escapeLinkTitle(text) {
+  return escapeHtml(text).replaceAll("=", "&#61;");
+}
+
+// ---------------------------------------------------------------------------
+// URL validation for <a href>
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a URL from a structured link item for use in href.
+ * Per ADR-015 D3a (bounded-emission posture) and D5 (RFC-3986 conformance):
+ *   1. Trim leading/trailing whitespace, then reject control chars (U+0000–U+001F).
+ *   2. Reject RFC 3986-illegal characters with HTML-attribute or URL-parser breakout
+ *      history: `"`, `<`, `>`, `\`, `` ` ``, and any whitespace (`\s`).
+ *   3. Require scheme to be exactly https://.
+ *
+ * @param {string} rawUrl - URL string from the structured item
+ * @returns {{valid: boolean, trimmedUrl: string}} Result of validation
+ */
+function validateUrl(rawUrl) {
+  const trimmed = String(rawUrl).trim();
+
+  // Layer 1: Reject any control character (U+0000–U+001F inclusive); catches null bytes and C0 injection.
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f]/.test(trimmed)) {
+    return { valid: false, trimmedUrl: trimmed };
+  }
+
+  // Layer 2: Reject RFC 3986-illegal characters that have HTML-attribute or URL-parser breakout history
+  // (see ADR-015 D3a, D5). escapeHtml at emit time neutralizes them at the HTML layer, but rejection
+  // here matches D3a's bounded-emission posture (no copied-through input) and removes URL-parser-confusion
+  // vectors (e.g. backslash treated as slash by some legacy parsers, backtick as attribute delimiter in IE).
+  // \s covers space, \t, \n, \r, \f, \v — broader than strictly needed but cheap; layer 1 already caught
+  // \t/\n/\r, so this is intentional defense-in-depth redundancy.
+  if (/["<>\\`\s]/.test(trimmed)) {
+    return { valid: false, trimmedUrl: trimmed };
+  }
+
+  // Layer 3: Scheme must be exactly https:// (case-insensitive).
+  if (!/^https:\/\//i.test(trimmed)) {
+    return { valid: false, trimmedUrl: trimmed };
+  }
+
+  return { valid: true, trimmedUrl: trimmed };
+}
+
+// ---------------------------------------------------------------------------
+// Tokenizer
+// ---------------------------------------------------------------------------
+
+// Token kinds produced by tokenize().
+// "text"       — plain text fragment, HTML-safe after escaping
+// "bold-open"  — opening **
+// "bold-close" — closing **
+// "em-open"    — opening * or _
+// "em-close"   — closing * or _
+// "sentinel"   — {{...}} passthrough token
+// "md-link"    — markdown [text](url) — disallowed, emit display text only
+// "raw-html"   — literal HTML tag — disallowed, must escape and warn
+
+/**
+ * Tokenize a prose string into an array of token objects.
+ *
+ * The tokenizer is markdown-driven: it recognises ** (bold), * and _ (italic),
+ * {{...}} (sentinels), [text](url) (markdown links, disallowed), and raw HTML
+ * tags <...> (disallowed). Everything else is plain text.
+ *
+ * The tokenizer is greedy and scan-based: it walks the string character by
+ * character, emitting the longest match at each position.
+ *
+ * @param {string} input - Raw prose string
+ * @returns {Array<{kind: string, value?: string, url?: string}>} Token list
+ */
+function tokenize(input) {
+  const tokens = [];
+  let pos = 0;
+  const len = input.length;
+
+  // Accumulated plain-text buffer — flushed before emitting any non-text token.
+  let textBuf = "";
+
+  function flushText() {
+    if (textBuf.length > 0) {
+      tokens.push({ kind: "text", value: textBuf });
+      textBuf = "";
+    }
+  }
+
+  while (pos < len) {
+    // --- Sentinel: {{...}} ---
+    if (input[pos] === "{" && input[pos + 1] === "{") {
+      const end = input.indexOf("}}", pos + 2);
+      if (end !== -1) {
+        flushText();
+        // Capture the full sentinel including braces.
+        tokens.push({ kind: "sentinel", value: input.slice(pos, end + 2) });
+        pos = end + 2;
+        continue;
+      }
+    }
+
+    // --- Bold: ** ---
+    // Two asterisks in a row. We emit open/close tokens based on scan
+    // context; the emitter will pair them up.
+    if (input[pos] === "*" && input[pos + 1] === "*") {
+      flushText();
+      tokens.push({ kind: "bold-delim", value: "**" });
+      pos += 2;
+      continue;
+    }
+
+    // --- Italic: single * or _ ---
+    // Single asterisk not followed by another asterisk.
+    if (input[pos] === "*" && input[pos + 1] !== "*") {
+      flushText();
+      tokens.push({ kind: "em-delim", value: "*" });
+      pos += 1;
+      continue;
+    }
+
+    // Underscore italic: single underscore.
+    // Double underscore __ is NOT bold and NOT italic per ADR-017 D1.
+    // We must not split __ into two em-delims; instead treat __ as text.
+    if (input[pos] === "_") {
+      if (input[pos + 1] === "_") {
+        // Double underscore — not a recognised delimiter; emit as text.
+        textBuf += "__";
+        pos += 2;
+        continue;
+      }
+      flushText();
+      tokens.push({ kind: "em-delim", value: "_" });
+      pos += 1;
+      continue;
+    }
+
+    // --- Raw HTML tag: <...> ---
+    // Any literal < followed by an alpha char, `/`, or `!` starts an HTML tag.
+    // Capture from < to the matching >.
+    if (input[pos] === "<") {
+      const nextCh = input[pos + 1];
+      if (/[a-zA-Z/!]/.test(nextCh)) {
+        const end = input.indexOf(">", pos + 1);
+        if (end !== -1) {
+          flushText();
+          tokens.push({ kind: "raw-html", value: input.slice(pos, end + 1) });
+          pos = end + 1;
+          continue;
+        }
+      }
+      // Lone < without a matching tag pattern — treat as text.
+      textBuf += "&lt;";
+      pos += 1;
+      continue;
+    }
+
+    // --- Markdown link: [text](url) ---
+    // Disallowed by ADR-017 D2. Recognise and emit as md-link so the
+    // emitter can suppress the URL (preventing javascript: from appearing).
+    if (input[pos] === "[") {
+      const closeBracket = input.indexOf("]", pos + 1);
+      if (closeBracket !== -1 && input[closeBracket + 1] === "(") {
+        const closeParen = input.indexOf(")", closeBracket + 2);
+        if (closeParen !== -1) {
+          flushText();
+          const displayText = input.slice(pos + 1, closeBracket);
+          const url = input.slice(closeBracket + 2, closeParen);
+          tokens.push({ kind: "md-link", value: displayText, url });
+          pos = closeParen + 1;
+          continue;
+        }
+      }
+      // Not a valid markdown link syntax — treat [ as text.
+      textBuf += input[pos];
+      pos += 1;
+      continue;
+    }
+
+    // --- Default: accumulate as plain text ---
+    // Handle & as HTML entity to avoid double-escaping later.
+    if (input[pos] === "&") {
+      textBuf += "&amp;";
+      pos += 1;
+    } else if (input[pos] === ">") {
+      // Bare > not part of a tag (we only get here if < was not matched).
+      textBuf += "&gt;";
+      pos += 1;
+    } else if (input[pos] === '"') {
+      textBuf += "&quot;";
+      pos += 1;
+    } else if (input[pos] === "'") {
+      textBuf += "&#39;";
+      pos += 1;
+    } else {
+      textBuf += input[pos];
+      pos += 1;
+    }
+  }
+
+  flushText();
+  return tokens;
+}
+
+// ---------------------------------------------------------------------------
+// Emitter
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk the token stream and emit an HTML string.
+ *
+ * Bold and italic use a simple open/close stack: each bold-delim token
+ * toggles between open and close state. Unmatched delimiters that don't
+ * get a closing partner are treated as plain text (this is a best-effort
+ * approach for well-formed prose from the authoring subset).
+ *
+ * @param {Array} tokens - Token list from tokenize()
+ * @param {string} originalInput - Original input string (for warn payload)
+ * @returns {{html: string, hadInvalid: boolean}} Emitted HTML and invalid-token flag
+ */
+function emit(tokens, originalInput) {
+  let html = "";
+  let hadInvalid = false;
+
+  // State for bold/em matching.
+  let boldOpen = false;
+  let emOpen = false;
+  // Track which em delimiter opened (so we close with the same tag).
+  // We allow * and _ to be interchangeable here per the simple grammar.
+
+  for (const token of tokens) {
+    switch (token.kind) {
+      case "text":
+        // Text was accumulated already-escaped (& < > " ' were escaped
+        // as they were read by the tokenizer into textBuf).
+        html += token.value;
+        break;
+
+      case "sentinel":
+        // Sentinels pass through verbatim — { and } are not HTML-special.
+        html += token.value;
+        break;
+
+      case "bold-delim":
+        if (!boldOpen) {
+          html += "<strong>";
+          boldOpen = true;
+        } else {
+          html += "</strong>";
+          boldOpen = false;
+        }
+        break;
+
+      case "em-delim":
+        if (!emOpen) {
+          html += "<em>";
+          emOpen = true;
+        } else {
+          html += "</em>";
+          emOpen = false;
+        }
+        break;
+
+      case "raw-html":
+        // Escape the entire raw HTML span — both < and > and any
+        // embedded quotes. The token.value is the literal HTML string.
+        html += escapeHtml(token.value);
+        hadInvalid = true;
+        break;
+
+      case "md-link": {
+        // Disallowed form (ADR-017 D2). Emit only the display text,
+        // HTML-escaped. The URL is suppressed entirely so that dangerous
+        // schemes like javascript: never appear in the output.
+        html += escapeHtml(token.value);
+        hadInvalid = true;
+        break;
+      }
+
+      default:
+        // Unknown token kind — defensive escape.
+        html += escapeHtml(String(token.value ?? ""));
+        hadInvalid = true;
+        break;
+    }
+  }
+
+  // Close any unclosed bold/em (malformed input from the authoring subset).
+  if (boldOpen) {
+    html += "</strong>";
+  }
+  if (emOpen) {
+    html += "</em>";
+  }
+
+  return { html, hadInvalid };
+}
+
+// ---------------------------------------------------------------------------
+// renderProse — the exported public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a prose item to an HTML-safe string.
+ *
+ * Accepts two input shapes:
+ *   - string: tokenized through the markdown-subset grammar
+ *   - {type: "link", title: string, url: string}: rendered as an outbound <a>
+ *
+ * Any other input shape is coerced to string, escaped, and warned about.
+ *
+ * Per ADR-015 D4, disallowed markup is escaped (not stripped) and exactly one
+ * console.warn("renderProse: escaped unexpected markup", {input, escaped}) is
+ * emitted per call if any disallowed token was found.
+ *
+ * @param {string | {type: string, title?: string, url?: string}} input
+ * @returns {string} HTML-safe prose fragment
+ */
+export function renderProse(input) {
+  // --- Structured link item ---
+  if (input !== null && typeof input === "object") {
+    if (input.type === "link") {
+      const { valid, trimmedUrl } = validateUrl(input.url ?? "");
+      const escapedTitle = escapeLinkTitle(String(input.title ?? ""));
+
+      if (valid) {
+        // Construct the <a> with renderer-owned attributes only.
+        // href is HTML-escaped after validation to prevent attribute breakout (e.g. " in URL).
+        // rel and target are hardcoded constants per ADR-015 D3a.
+        return `<a href="${escapeHtml(trimmedUrl)}" rel="noopener noreferrer" target="_blank">${escapedTitle}</a>`;
+      }
+
+      // Invalid URL: escape the title text and warn.
+      const escaped = escapedTitle;
+      console.warn("renderProse: escaped unexpected markup", { input, escaped });
+      return escaped;
+    }
+
+    // Unknown structured type — escape and warn.
+    const escaped = escapeHtml(String(input));
+    console.warn("renderProse: escaped unexpected markup", { input, escaped });
+    return escaped;
+  }
+
+  // --- Plain string path ---
+  const str = String(input);
+  const tokens = tokenize(str);
+  const { html, hadInvalid } = emit(tokens, str);
+
+  if (hadInvalid) {
+    console.warn("renderProse: escaped unexpected markup", { input: str, escaped: html });
+  }
+
+  return html;
+}

--- a/site/tests/fixtures/sanitizer/attack-corpus/attribute-injection-lt-in-url.json
+++ b/site/tests/fixtures/sanitizer/attack-corpus/attribute-injection-lt-in-url.json
@@ -1,0 +1,6 @@
+{
+  "vector": "attribute-injection-lt-in-url",
+  "description": "URL containing `<` is RFC 3986-illegal and is rejected by validateUrl; no `<a>` tag is emitted at all. Per ADR-015 D3a (bounded emission) + D5 (RFC-3986 conformance).",
+  "input": {"type": "link", "title": "safe", "url": "https://example.com/<script>"},
+  "mustNotContain": "<a "
+}

--- a/site/tests/fixtures/sanitizer/attack-corpus/attribute-injection-quote-in-text.json
+++ b/site/tests/fixtures/sanitizer/attack-corpus/attribute-injection-quote-in-text.json
@@ -1,0 +1,7 @@
+{
+  "vector": "attribute-injection-quote-in-text",
+  "description": "If link title contains a double-quote, naive string interpolation breaks the attribute context: title '\" onclick=\"alert(1)' would close the href and inject a new attribute. The renderer must HTML-escape title text when emitting the anchor's text content.",
+  "input": {"type": "link", "title": "\" onclick=\"alert(1)", "url": "https://safe.example.com"},
+  "mustNotContain": "onclick=",
+  "expectedSubstring": "&quot;"
+}

--- a/site/tests/fixtures/sanitizer/attack-corpus/attribute-injection-quote-in-url.json
+++ b/site/tests/fixtures/sanitizer/attack-corpus/attribute-injection-quote-in-url.json
@@ -1,0 +1,6 @@
+{
+  "vector": "attribute-injection-quote-in-url",
+  "description": "URL containing `\"` is RFC 3986-illegal and is rejected by validateUrl; no `<a>` tag is emitted at all. Per ADR-015 D3a (bounded emission) + D5 (RFC-3986 conformance).",
+  "input": {"type": "link", "title": "safe", "url": "https://example.com/\" onmouseover=\"alert(1)"},
+  "mustNotContain": "<a "
+}

--- a/site/tests/fixtures/sanitizer/attack-corpus/data-uri.json
+++ b/site/tests/fixtures/sanitizer/attack-corpus/data-uri.json
@@ -1,0 +1,6 @@
+{
+  "vector": "data-uri",
+  "description": "data: URI can carry executable content (data:text/html,<script>...). The renderer must reject any non-https: scheme.",
+  "input": {"type": "link", "title": "xss", "url": "data:text/html,<script>alert(1)</script>"},
+  "mustNotContain": "<a "
+}

--- a/site/tests/fixtures/sanitizer/attack-corpus/idn-homograph.json
+++ b/site/tests/fixtures/sanitizer/attack-corpus/idn-homograph.json
@@ -1,0 +1,7 @@
+{
+  "vector": "idn-homograph",
+  "description": "IDN homograph attack: Cyrillic 'а' (U+0430) looks identical to Latin 'a' (U+0061). A URL using Cyrillic characters to spoof a trusted domain passes a naive hostname check but redirects to attacker infrastructure. The https: scheme check alone does not defend against this; the fixture verifies the renderer at minimum does not suppress the suspicion by silently emitting an anchor with the spoofed href. The renderer may accept it (the scheme is https:) — this fixture confirms the href appears verbatim so a reviewer can audit the output.",
+  "input": {"type": "link", "title": "Spoofed trusted site", "url": "https://сosai.example.org/page"},
+  "note": "This fixture documents a KNOWN LIMITATION: the renderer cannot detect IDN homographs without a full Unicode normalisation pass. It emits the anchor with the Cyrillic href. The fixture's role is to make this behavior explicit and auditable, not to assert rejection. The expectedSubstring below is the Cyrillic href passing through — confirming the renderer does not silently mangle it. Browser URL bars show the punycode form; the sanitizer's job is scheme-gating, not hostname verification.",
+  "expectedSubstring": "href=\"https://"
+}

--- a/site/tests/fixtures/sanitizer/attack-corpus/javascript-uri-lowercase.json
+++ b/site/tests/fixtures/sanitizer/attack-corpus/javascript-uri-lowercase.json
@@ -1,0 +1,6 @@
+{
+  "vector": "javascript-uri-lowercase",
+  "description": "Lowercase javascript: URI in a structured link item. The renderer must reject the href and must not emit <a href=\"javascript:...\">. This is the canonical XSS vector via href.",
+  "input": {"type": "link", "title": "xss", "url": "javascript:alert(document.cookie)"},
+  "mustNotContain": "<a "
+}

--- a/site/tests/fixtures/sanitizer/attack-corpus/javascript-uri-mixedcase.json
+++ b/site/tests/fixtures/sanitizer/attack-corpus/javascript-uri-mixedcase.json
@@ -1,0 +1,6 @@
+{
+  "vector": "javascript-uri-mixedcase",
+  "description": "Mixed-case JaVaScRiPt: URI bypasses naive case-sensitive scheme checks. The renderer must normalise or check case-insensitively and must not emit the anchor.",
+  "input": {"type": "link", "title": "xss", "url": "JaVaScRiPt:alert(1)"},
+  "mustNotContain": "<a "
+}

--- a/site/tests/fixtures/sanitizer/attack-corpus/javascript-uri-tab-prefix.json
+++ b/site/tests/fixtures/sanitizer/attack-corpus/javascript-uri-tab-prefix.json
@@ -1,0 +1,6 @@
+{
+  "vector": "javascript-uri-tab-prefix",
+  "description": "Whitespace (tab) before the scheme is a known bypass for naive startsWith checks. Some parsers strip leading whitespace before scheme detection; the renderer must reject this variant.",
+  "input": {"type": "link", "title": "xss", "url": "\tjavascript:alert(1)"},
+  "mustNotContain": "<a "
+}

--- a/site/tests/fixtures/sanitizer/attack-corpus/schemeless-bare-domain.json
+++ b/site/tests/fixtures/sanitizer/attack-corpus/schemeless-bare-domain.json
@@ -1,0 +1,6 @@
+{
+  "vector": "schemeless-bare-domain",
+  "description": "Bare domain without scheme (evil.com/path) is not a valid absolute URL but some parsers accept it. The renderer must reject any URL that does not begin with https://.",
+  "input": {"type": "link", "title": "evil", "url": "evil.example.com/page"},
+  "mustNotContain": "<a "
+}

--- a/site/tests/fixtures/sanitizer/attack-corpus/schemeless-double-slash.json
+++ b/site/tests/fixtures/sanitizer/attack-corpus/schemeless-double-slash.json
@@ -1,0 +1,6 @@
+{
+  "vector": "schemeless-double-slash",
+  "description": "Protocol-relative URL (//evil.com) inherits the page's scheme. On https pages this becomes https://evil.com; the renderer must require a scheme prefix, not merely the absence of javascript:.",
+  "input": {"type": "link", "title": "evil", "url": "//evil.example.com/xss"},
+  "mustNotContain": "<a "
+}

--- a/site/tests/fixtures/sanitizer/attack-corpus/url-backslash.json
+++ b/site/tests/fixtures/sanitizer/attack-corpus/url-backslash.json
@@ -1,0 +1,6 @@
+{
+  "vector": "url-backslash",
+  "description": "Backslash in URL is RFC 3986-illegal. Some legacy URL parsers (older IE, embedded WebViews) treat `\\` as `/`, allowing `https://safe.example\\@evil.com` to authenticate `safe.example` as user-info to host `evil.com`. Rejection at the URL layer prevents parser-confusion redirects. Per ADR-015 D5.",
+  "input": {"type": "link", "title": "safe", "url": "https://example.com\\@evil.com"},
+  "mustNotContain": "<a "
+}

--- a/site/tests/fixtures/sanitizer/attack-corpus/url-backtick.json
+++ b/site/tests/fixtures/sanitizer/attack-corpus/url-backtick.json
@@ -1,0 +1,6 @@
+{
+  "vector": "url-backtick",
+  "description": "Backtick in URL is RFC 3986-illegal. IE attribute-parser quirks have historically treated backtick as an attribute delimiter in unquoted contexts. Defense-in-depth even though we always emit double-quoted attributes. Per ADR-015 D5.",
+  "input": {"type": "link", "title": "safe", "url": "https://example.com/path`onmouseover=alert(1)`"},
+  "mustNotContain": "<a "
+}

--- a/site/tests/fixtures/sanitizer/attack-corpus/url-internal-space.json
+++ b/site/tests/fixtures/sanitizer/attack-corpus/url-internal-space.json
@@ -1,0 +1,6 @@
+{
+  "vector": "url-internal-space",
+  "description": "URL with whitespace mid-path is RFC 3986-illegal; producer must percent-encode (%20). Rejection at the URL layer (validateUrl) closes invisible-suffix tricks. Per ADR-015 D5.",
+  "input": {"type": "link", "title": "safe", "url": "https://example.com/path with space"},
+  "mustNotContain": "<a "
+}

--- a/site/tests/fixtures/sanitizer/attack-corpus/url-leading-whitespace.json
+++ b/site/tests/fixtures/sanitizer/attack-corpus/url-leading-whitespace.json
@@ -1,0 +1,8 @@
+{
+  "vector": "url-leading-whitespace",
+  "description": "Leading space before https:// is a scheme-check bypass for naive startsWith implementations. URL spec strips ASCII whitespace at the start; the renderer must trim before the scheme check.",
+  "input": {"type": "link", "title": "trick", "url": "  https://safe.example.com"},
+  "note": "A4 (locked): renderer trims leading whitespace before scheme validation; trimmed URL has scheme https://, must be emitted as <a href> with the trimmed URL.",
+  "mustNotContain": "href=\"  https://",
+  "expectedSubstring": "<a href=\"https://safe.example.com\""
+}

--- a/site/tests/fixtures/sanitizer/attack-corpus/url-null-byte.json
+++ b/site/tests/fixtures/sanitizer/attack-corpus/url-null-byte.json
@@ -1,0 +1,6 @@
+{
+  "vector": "url-null-byte",
+  "description": "A null byte (U+0000) embedded in the URL string between the scheme and the rest. A naive startsWith check on https:// passes because the scheme appears before the null. JSON.parse decodes \\u0000 to an actual null byte in the url string.",
+  "input": {"type": "link", "title": "null-byte-test", "url": "https://\u0000evil.example.com"},
+  "mustNotContain": "<a "
+}

--- a/site/tests/fixtures/sanitizer/attack-corpus/url-trailing-whitespace.json
+++ b/site/tests/fixtures/sanitizer/attack-corpus/url-trailing-whitespace.json
@@ -1,0 +1,8 @@
+{
+  "vector": "url-trailing-whitespace",
+  "description": "Trailing whitespace after the URL (e.g., 'https://example.com  ') should not affect scheme detection but tests that the renderer handles trimming symmetrically.",
+  "input": {"type": "link", "title": "trick", "url": "https://safe.example.com  "},
+  "note": "A4 (locked): renderer trims trailing whitespace before scheme validation; trimmed URL has scheme https://, must be emitted as <a href> with the trimmed URL.",
+  "mustNotContain": "href=\"https://safe.example.com  \"",
+  "expectedSubstring": "<a href=\"https://safe.example.com\""
+}

--- a/site/tests/fixtures/sanitizer/attack-corpus/vbscript-uri.json
+++ b/site/tests/fixtures/sanitizer/attack-corpus/vbscript-uri.json
@@ -1,0 +1,6 @@
+{
+  "vector": "vbscript-uri",
+  "description": "vbscript: URI is an IE-legacy XSS vector. Blocked by the https:-only scheme requirement; included because the scheme check must not be scheme-list-based (it must be an allowlist of one: https).",
+  "input": {"type": "link", "title": "xss", "url": "vbscript:msgbox(1)"},
+  "mustNotContain": "<a "
+}

--- a/site/tests/fixtures/sanitizer/negative/a-http-scheme-structured.json
+++ b/site/tests/fixtures/sanitizer/negative/a-http-scheme-structured.json
@@ -1,0 +1,6 @@
+{
+  "negativeForTag": "a",
+  "description": "A structured link item with http:// (not https://) must not produce an <a> tag. The renderer validates href against ^https:// per ADR-015 D3a. http: is blocked as defense-in-depth.",
+  "input": {"type": "link", "title": "Insecure", "url": "http://example.com"},
+  "mustNotContain": "<a href=\"http://"
+}

--- a/site/tests/fixtures/sanitizer/negative/a-javascript-uri-in-markdown.json
+++ b/site/tests/fixtures/sanitizer/negative/a-javascript-uri-in-markdown.json
@@ -1,0 +1,7 @@
+{
+  "negativeForTag": "a",
+  "description": "A markdown link [text](javascript:alert(1)) must not produce an <a> tag. The javascript: scheme is blocked per ADR-015 D5; the whole link must be escaped.",
+  "input": "[click me](javascript:alert(1))",
+  "mustNotContain": "<a ",
+  "mustNotContain2": "javascript:"
+}

--- a/site/tests/fixtures/sanitizer/negative/a-raw-html-anchor.json
+++ b/site/tests/fixtures/sanitizer/negative/a-raw-html-anchor.json
@@ -1,0 +1,7 @@
+{
+  "negativeForTag": "a",
+  "description": "A literal <a href=\"https://...\"> in prose must be escaped, not passed through. Authors do not write <a> markup; sentinels expanded by the builder are the only path for anchors per ADR-015 D1.",
+  "input": "<a href=\"https://example.com\">click</a>",
+  "expectedSubstring": "&lt;a href=",
+  "mustNotContain": "<a href="
+}

--- a/site/tests/fixtures/sanitizer/negative/em-raw-html.json
+++ b/site/tests/fixtures/sanitizer/negative/em-raw-html.json
@@ -1,0 +1,7 @@
+{
+  "negativeForTag": "em",
+  "description": "Raw <em> HTML in input must be escaped per ADR-015 D4. Only the markdown subset forms (*italic* / _italic_) are allowed.",
+  "input": "<em>raw italic</em>",
+  "expectedSubstring": "&lt;em&gt;raw italic&lt;/em&gt;",
+  "mustNotContain": "<em>raw"
+}

--- a/site/tests/fixtures/sanitizer/negative/strong-double-underscore.json
+++ b/site/tests/fixtures/sanitizer/negative/strong-double-underscore.json
@@ -1,0 +1,7 @@
+{
+  "negativeForTag": "strong",
+  "description": "__bold__ is not in the allowed subset (ADR-017 D1: asterisk delimiter only). The underscores must be escaped, not rendered as <strong>.",
+  "input": "This is __not bold__ text.",
+  "expectedSubstring": "__not bold__",
+  "mustNotContain": "<strong>"
+}

--- a/site/tests/fixtures/sanitizer/negative/strong-raw-html.json
+++ b/site/tests/fixtures/sanitizer/negative/strong-raw-html.json
@@ -1,0 +1,7 @@
+{
+  "negativeForTag": "strong",
+  "description": "Raw <strong> HTML in input must be escaped, not passed through. The author bypassed the authoring lint; escape-with-warn is the render-time response per ADR-015 D4.",
+  "input": "<strong>raw html bold</strong>",
+  "expectedSubstring": "&lt;strong&gt;raw html bold&lt;/strong&gt;",
+  "mustNotContain": "<strong>raw"
+}

--- a/site/tests/fixtures/sanitizer/positive/a-https-link.json
+++ b/site/tests/fixtures/sanitizer/positive/a-https-link.json
@@ -1,0 +1,8 @@
+{
+  "tag": "a",
+  "description": "A structured link item with an https URL renders as <a> with href, rel, and target attributes constructed by the renderer.",
+  "input": {"type": "link", "title": "CoSAI", "url": "https://cosai.example.org/page"},
+  "expectedSubstring": "<a href=\"https://cosai.example.org/page\"",
+  "expectedSubstringAlso": "rel=\"noopener noreferrer\"",
+  "expectedSubstringAndAlso": "target=\"_blank\""
+}

--- a/site/tests/fixtures/sanitizer/positive/em-asterisk.json
+++ b/site/tests/fixtures/sanitizer/positive/em-asterisk.json
@@ -1,0 +1,6 @@
+{
+  "tag": "em",
+  "description": "Single-asterisk italic renders as <em> with no attributes.",
+  "input": "This is *italic* text.",
+  "expectedSubstring": "<em>italic</em>"
+}

--- a/site/tests/fixtures/sanitizer/positive/em-underscore.json
+++ b/site/tests/fixtures/sanitizer/positive/em-underscore.json
@@ -1,0 +1,6 @@
+{
+  "tag": "em",
+  "description": "Underscore italic delimiter is also allowed per ADR-017 D1 and renders as <em>.",
+  "input": "This is _italic_ text.",
+  "expectedSubstring": "<em>italic</em>"
+}

--- a/site/tests/fixtures/sanitizer/positive/strong-basic.json
+++ b/site/tests/fixtures/sanitizer/positive/strong-basic.json
@@ -1,0 +1,6 @@
+{
+  "tag": "strong",
+  "description": "Double-asterisk bold renders as <strong> with no attributes.",
+  "input": "This is **bold** text.",
+  "expectedSubstring": "<strong>bold</strong>"
+}

--- a/site/tests/fixtures/sanitizer/positive/strong-multiple.json
+++ b/site/tests/fixtures/sanitizer/positive/strong-multiple.json
@@ -1,0 +1,6 @@
+{
+  "tag": "strong",
+  "description": "Multiple bold spans in one paragraph each render as <strong>.",
+  "input": "**first** and **second** are both bold.",
+  "expectedSubstring": "<strong>first</strong>"
+}

--- a/site/tests/fixtures/sanitizer/positive/strong-with-em-nested.json
+++ b/site/tests/fixtures/sanitizer/positive/strong-with-em-nested.json
@@ -1,0 +1,6 @@
+{
+  "tag": "strong",
+  "description": "Bold and italic compose: **emphatically *not* this** renders <strong> wrapping <em>.",
+  "input": "**emphatically *not* this**",
+  "expectedSubstring": "<strong>"
+}

--- a/site/tests/sanitizer.test.mjs
+++ b/site/tests/sanitizer.test.mjs
@@ -1,0 +1,583 @@
+/**
+ * Tests for site/assets/sanitizer.mjs — renderProse(input)
+ *
+ * RED phase: sanitizer.mjs does not yet exist. All tests fail with
+ * ERR_MODULE_NOT_FOUND. The SWE agent creates the implementation.
+ *
+ * Test discipline per ADR-015 D3b:
+ * - Per-tag positive fixtures (strong, em, a)
+ * - Per-tag negative fixtures (strong, em, a)
+ * - Allowlist–fixture meta-test (adding a tag without fixtures fails CI)
+ * - Attack-corpus fixture tests for <a> XSS vectors
+ * - Bounded-emission contract test (ALLOWED_TAGS is a literal const in source)
+ * - Escape-with-warn behavior test (console.warn spy)
+ * - Sentinel passthrough test
+ * - Idempotence sanity test
+ *
+ * ---------------------------------------------------------------------------
+ * A6 SCOPE (locked)
+ * ---------------------------------------------------------------------------
+ * renderProse accepts: string | {type: "link", title: string, url: string}
+ * renderProse returns: string (HTML-safe prose fragment)
+ *
+ * {type: "ref", id, title} rendering is OUT OF SCOPE for A6. The ref type
+ * produces in-page fragment anchors (href="#id", no rel, no target) and is
+ * handled outside renderProse by other site code paths. This test file does
+ * not validate ref rendering.
+ *
+ * If renderProse is later extended to handle ref items, add:
+ *   - positive fixture(s) under fixtures/sanitizer/positive/ with tag "a"
+ *     and a field distinguishing the ref path (e.g. "variant": "ref")
+ *   - negative fixture(s) under fixtures/sanitizer/negative/ with negativeForTag "a"
+ *   - update this scope comment to reflect the expanded surface
+ * ---------------------------------------------------------------------------
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// This import fails until the SWE agent creates sanitizer.mjs — correct for RED phase.
+import { renderProse } from "../assets/sanitizer.mjs";
+
+// ---------------------------------------------------------------------------
+// Local reference copy of ALLOWED_TAGS.
+// This is the contract the meta-test checks against: the test file's declared
+// set must match the fixture set. The source-of-truth constant lives in
+// sanitizer.mjs; this copy is a contract-check, not a shared dependency.
+// ---------------------------------------------------------------------------
+const ALLOWED_TAGS = ["strong", "em", "a"];
+
+// ---------------------------------------------------------------------------
+// Fixture loading helpers
+// ---------------------------------------------------------------------------
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = path.join(__dirname, "fixtures", "sanitizer");
+
+/**
+ * Read and parse a JSON fixture file. Throws with the file path on parse
+ * error so failures are easy to locate.
+ */
+function loadFixture(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (err) {
+    throw new Error(`Failed to parse fixture ${filePath}: ${err.message}`);
+  }
+}
+
+/**
+ * Enumerate all .json fixture files in a subdirectory of FIXTURE_ROOT.
+ * Returns an array of {name, fixture} objects where name is the basename
+ * without extension.
+ */
+function loadFixtures(subdir) {
+  const dir = path.join(FIXTURE_ROOT, subdir);
+  const entries = fs.readdirSync(dir).filter((f) => f.endsWith(".json"));
+  return entries.map((f) => ({
+    name: path.basename(f, ".json"),
+    fixture: loadFixture(path.join(dir, f)),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Positive fixtures
+// Positive fixtures declare a "tag" field. The meta-test checks that every
+// ALLOWED_TAGS entry has at least one positive fixture.
+// ---------------------------------------------------------------------------
+
+const positiveFixtures = loadFixtures("positive");
+
+// Build a Map<tag, fixture[]> for the meta-test.
+const positiveByTag = new Map();
+for (const { fixture } of positiveFixtures) {
+  const tag = fixture.tag;
+  if (!positiveByTag.has(tag)) {
+    positiveByTag.set(tag, []);
+  }
+  positiveByTag.get(tag).push(fixture);
+}
+
+// ---------------------------------------------------------------------------
+// Negative fixtures
+// Negative fixtures declare a "negativeForTag" field.
+// ---------------------------------------------------------------------------
+
+const negativeFixtures = loadFixtures("negative");
+
+const negativeByTag = new Map();
+for (const { fixture } of negativeFixtures) {
+  const tag = fixture.negativeForTag;
+  if (!negativeByTag.has(tag)) {
+    negativeByTag.set(tag, []);
+  }
+  negativeByTag.get(tag).push(fixture);
+}
+
+// ---------------------------------------------------------------------------
+// Attack-corpus fixtures
+// ---------------------------------------------------------------------------
+
+const attackFixtures = loadFixtures("attack-corpus");
+
+// ---------------------------------------------------------------------------
+// Helper: call renderProse with either a string or a structured item.
+// The ADR describes renderProse(input: string): string, but for structured
+// items ({type:"link",...}) the SWE agent will decide the exact calling
+// convention. The most natural ESM export for the tokenizer + structured-item
+// path is a single renderProse that accepts string | object. Tests use this
+// wrapper so the calling convention is centralised here.
+// ---------------------------------------------------------------------------
+
+function callRenderProse(input) {
+  return renderProse(input);
+}
+
+// ---------------------------------------------------------------------------
+// Per-tag positive tests
+// Given: an allowed input form for a tag
+// When: renderProse is called
+// Then: the output contains the expected HTML tag or substring
+// ---------------------------------------------------------------------------
+
+test("positive fixtures — each allowed input produces expected output substring", () => {
+  for (const { name, fixture } of positiveFixtures) {
+    const output = callRenderProse(fixture.input);
+
+    if (fixture.expectedSubstring !== undefined) {
+      assert.ok(
+        output.includes(fixture.expectedSubstring),
+        `Positive fixture '${name}': expected output to contain '${fixture.expectedSubstring}' but got: ${output}`,
+      );
+    }
+
+    // Multi-attribute assertions for the <a> fixture (rel, target).
+    if (fixture.expectedSubstringAlso !== undefined) {
+      assert.ok(
+        output.includes(fixture.expectedSubstringAlso),
+        `Positive fixture '${name}': expected output to contain '${fixture.expectedSubstringAlso}' but got: ${output}`,
+      );
+    }
+    if (fixture.expectedSubstringAndAlso !== undefined) {
+      assert.ok(
+        output.includes(fixture.expectedSubstringAndAlso),
+        `Positive fixture '${name}': expected output to contain '${fixture.expectedSubstringAndAlso}' but got: ${output}`,
+      );
+    }
+  }
+});
+
+// Separate targeted tests per tag so CI output names the failing tag clearly.
+
+test("positive — **bold** input renders <strong> with no attributes", () => {
+  const fixture = positiveByTag.get("strong")?.[0];
+  assert.ok(fixture, "No positive fixture found for 'strong' tag");
+  const output = callRenderProse(fixture.input);
+  assert.ok(output.includes("<strong>"), `Expected <strong> in output: ${output}`);
+  assert.ok(!output.includes("<strong "), `<strong> must have no attributes: ${output}`);
+});
+
+test("positive — *italic* input renders <em> with no attributes", () => {
+  const fixture = positiveByTag.get("em")?.[0];
+  assert.ok(fixture, "No positive fixture found for 'em' tag");
+  const output = callRenderProse(fixture.input);
+  assert.ok(output.includes("<em>"), `Expected <em> in output: ${output}`);
+  assert.ok(!output.includes("<em "), `<em> must have no attributes: ${output}`);
+});
+
+test("positive — structured link item renders <a> with href, rel, target constructed by renderer", () => {
+  // The a-https-link fixture declares expectedSubstring, expectedSubstringAlso, expectedSubstringAndAlso.
+  const fixtures = positiveByTag.get("a");
+  assert.ok(fixtures && fixtures.length > 0, "No positive fixture found for 'a' tag");
+  const fixture = fixtures[0];
+  const output = callRenderProse(fixture.input);
+
+  // href must appear and start with https://
+  assert.ok(output.includes('href="https://'), `Expected href=https:// in output: ${output}`);
+
+  // rel and target are constructed by the renderer (ADR-015 D3a)
+  assert.ok(output.includes('rel="noopener noreferrer"'), `Expected rel=noopener noreferrer: ${output}`);
+  assert.ok(output.includes('target="_blank"'), `Expected target=_blank: ${output}`);
+});
+
+test("positive — _italic_ underscore delimiter also renders <em>", () => {
+  // Underscore italic is allowed per ADR-017 D1.
+  const output = callRenderProse("This is _italic_ text.");
+  assert.ok(output.includes("<em>"), `Expected <em> from underscore italic: ${output}`);
+});
+
+test("positive — plain text with no markup passes through as-is (no tags emitted)", () => {
+  // Given: prose with no markdown tokens
+  // When: renderProse is called
+  // Then: output contains no HTML tags and the text is preserved
+  const input = "Plain text with no special markup.";
+  const output = callRenderProse(input);
+  assert.ok(output.includes("Plain text"), `Expected plain text to pass through: ${output}`);
+  assert.ok(!output.includes("<"), `Plain text must not produce any tags: ${output}`);
+});
+
+// ---------------------------------------------------------------------------
+// Per-tag negative tests
+// Given: a disallowed input related to an allowed tag
+// When: renderProse is called
+// Then: the disallowed form is escaped (not rendered as the tag)
+// ---------------------------------------------------------------------------
+
+test("negative fixtures — each disallowed input does not produce forbidden output", () => {
+  for (const { name, fixture } of negativeFixtures) {
+    const output = callRenderProse(fixture.input);
+
+    if (fixture.mustNotContain !== undefined) {
+      assert.ok(
+        !output.includes(fixture.mustNotContain),
+        `Negative fixture '${name}': output must NOT contain '${fixture.mustNotContain}' but got: ${output}`,
+      );
+    }
+    if (fixture.mustNotContain2 !== undefined) {
+      assert.ok(
+        !output.includes(fixture.mustNotContain2),
+        `Negative fixture '${name}': output must NOT contain '${fixture.mustNotContain2}' but got: ${output}`,
+      );
+    }
+    if (fixture.expectedSubstring !== undefined) {
+      assert.ok(
+        output.includes(fixture.expectedSubstring),
+        `Negative fixture '${name}': expected escaped form '${fixture.expectedSubstring}' in output but got: ${output}`,
+      );
+    }
+  }
+});
+
+test("negative — __bold__ (double underscore) is not rendered as <strong>", () => {
+  // ADR-017 D1: asterisk delimiter only; __bold__ is not in the subset.
+  const output = callRenderProse("This is __not bold__ text.");
+  assert.ok(!output.includes("<strong>"), `__bold__ must not produce <strong>: ${output}`);
+});
+
+test("negative — raw <strong> HTML is escaped, not passed through", () => {
+  const output = callRenderProse("<strong>raw html</strong>");
+  assert.ok(!output.includes("<strong>raw"), `Raw <strong> must not pass through: ${output}`);
+  assert.ok(output.includes("&lt;strong&gt;"), `Raw <strong> must be escaped as &lt;strong&gt;: ${output}`);
+});
+
+test("negative — raw <em> HTML is escaped, not passed through", () => {
+  const output = callRenderProse("<em>raw italic</em>");
+  assert.ok(!output.includes("<em>raw"), `Raw <em> must not pass through: ${output}`);
+  assert.ok(output.includes("&lt;em&gt;"), `Raw <em> must be escaped as &lt;em&gt;: ${output}`);
+});
+
+test("negative — markdown link [text](javascript:...) does not produce <a>", () => {
+  // Authors do not write <a> markup; sentinels expanded by builder are the only path.
+  // A markdown-style link in prose is disallowed by ADR-017 D2.
+  const output = callRenderProse("[click me](javascript:alert(1))");
+  assert.ok(!output.includes("<a "), `Markdown link must not produce <a>: ${output}`);
+  assert.ok(!output.includes("javascript:"), `javascript: must not appear in output: ${output}`);
+});
+
+test("negative — structured link with http:// scheme does not produce <a>", () => {
+  // ADR-015 D3a: href validated against ^https:// before insertion.
+  const output = callRenderProse({ type: "link", title: "Insecure", url: "http://example.com" });
+  assert.ok(!output.includes('<a href="http://'), `http:// link must not produce <a>: ${output}`);
+});
+
+test("negative — raw <a href=...> in prose is escaped, not passed through", () => {
+  // Authors do not write <a> markup; raw anchors in prose are disallowed per ADR-015 D1.
+  const output = callRenderProse('<a href="https://example.com">click</a>');
+  assert.ok(!output.includes("<a href="), `Raw <a href=> must be escaped: ${output}`);
+  assert.ok(output.includes("&lt;a href="), `Raw <a> must appear as &lt;a href=: ${output}`);
+});
+
+// ---------------------------------------------------------------------------
+// Allowlist–fixture meta-test (ADR-015 D3b)
+// Asserts that every entry in ALLOWED_TAGS has at least one positive fixture
+// AND at least one negative fixture. Adding a tag without fixtures fails here.
+// ---------------------------------------------------------------------------
+
+test("meta-test — every ALLOWED_TAGS entry has at least one positive and one negative fixture", () => {
+  const missingPositive = ALLOWED_TAGS.filter((tag) => !positiveByTag.has(tag));
+  const missingNegative = ALLOWED_TAGS.filter((tag) => !negativeByTag.has(tag));
+
+  assert.deepEqual(
+    missingPositive,
+    [],
+    `Tags missing positive fixtures: ${missingPositive.join(", ")}. Add a positive fixture file with "tag": "<tagname>" for each.`,
+  );
+
+  assert.deepEqual(
+    missingNegative,
+    [],
+    `Tags missing negative fixtures: ${missingNegative.join(", ")}. Add a negative fixture file with "negativeForTag": "<tagname>" for each.`,
+  );
+
+  // Confirm the full coverage property: ALLOWED_TAGS.every(tag => fixtures.has(tag))
+  const allCovered = ALLOWED_TAGS.every((tag) => positiveByTag.has(tag) && negativeByTag.has(tag));
+  assert.ok(allCovered, "Not all ALLOWED_TAGS entries have both positive and negative fixtures.");
+});
+
+// ---------------------------------------------------------------------------
+// Attack-corpus tests for <a> (ADR-015 D3b)
+// Each fixture in attack-corpus/ must not produce <a> with the attack URL.
+// Exception: the IDN homograph fixture documents a known limitation (see note
+// in the fixture file) — the renderer cannot detect homograph spoofing from
+// the scheme alone. That fixture uses expectedSubstring, not mustNotContain.
+// ---------------------------------------------------------------------------
+
+test("attack-corpus — each XSS vector fixture does not produce a live <a> tag", () => {
+  for (const { name, fixture } of attackFixtures) {
+    const output = callRenderProse(fixture.input);
+
+    if (fixture.mustNotContain !== undefined) {
+      assert.ok(
+        !output.includes(fixture.mustNotContain),
+        `Attack corpus '${name}': output must NOT contain '${fixture.mustNotContain}' but got: ${output}`,
+      );
+    }
+    // Some fixtures also check that a specific second string is absent.
+    if (fixture.mustNotContain2 !== undefined) {
+      assert.ok(
+        !output.includes(fixture.mustNotContain2),
+        `Attack corpus '${name}': output must NOT contain '${fixture.mustNotContain2}' but got: ${output}`,
+      );
+    }
+    // expectedSubstring is used in two scenarios:
+    //   1. Documentation fixtures (IDN homograph): asserts the href appears for auditability.
+    //   2. A4 trim-and-emit fixtures (whitespace URLs): asserts the trimmed <a href> is emitted.
+    // Both cases require the assertion regardless of whether mustNotContain is also set.
+    if (fixture.expectedSubstring !== undefined) {
+      assert.ok(
+        output.includes(fixture.expectedSubstring),
+        `Attack corpus '${name}': expected '${fixture.expectedSubstring}' in output but got: ${output}`,
+      );
+    }
+  }
+});
+
+// Targeted named tests for the mandatory vectors in the spec.
+
+test("attack-corpus — javascript: URI (lowercase) in structured link does not produce <a>", () => {
+  const output = callRenderProse({ type: "link", title: "xss", url: "javascript:alert(document.cookie)" });
+  assert.ok(!output.includes("<a "), `javascript: URI must not produce <a>: ${output}`);
+});
+
+test("attack-corpus — javascript: URI (mixed case JaVaScRiPt:) does not produce <a>", () => {
+  const output = callRenderProse({ type: "link", title: "xss", url: "JaVaScRiPt:alert(1)" });
+  assert.ok(!output.includes("<a "), `Mixed-case javascript: URI must not produce <a>: ${output}`);
+});
+
+test("attack-corpus — javascript: URI with leading tab whitespace does not produce <a>", () => {
+  const output = callRenderProse({ type: "link", title: "xss", url: "\tjavascript:alert(1)" });
+  assert.ok(!output.includes("<a "), `Tab-prefixed javascript: URI must not produce <a>: ${output}`);
+});
+
+test("attack-corpus — data: URI in structured link does not produce <a>", () => {
+  const output = callRenderProse({
+    type: "link",
+    title: "xss",
+    url: "data:text/html,<script>alert(1)</script>",
+  });
+  assert.ok(!output.includes("<a "), `data: URI must not produce <a>: ${output}`);
+});
+
+test("attack-corpus — vbscript: URI in structured link does not produce <a>", () => {
+  const output = callRenderProse({ type: "link", title: "xss", url: "vbscript:msgbox(1)" });
+  assert.ok(!output.includes("<a "), `vbscript: URI must not produce <a>: ${output}`);
+});
+
+test("attack-corpus — protocol-relative URL (//evil.com) does not produce <a>", () => {
+  const output = callRenderProse({ type: "link", title: "evil", url: "//evil.example.com/xss" });
+  assert.ok(!output.includes("<a "), `Protocol-relative URL must not produce <a>: ${output}`);
+});
+
+test("attack-corpus — bare domain without scheme does not produce <a>", () => {
+  const output = callRenderProse({ type: "link", title: "evil", url: "evil.example.com/page" });
+  assert.ok(!output.includes("<a "), `Bare domain must not produce <a>: ${output}`);
+});
+
+test("attack-corpus — attribute injection via double-quote in link title does not inject onclick", () => {
+  // If title is not escaped, naive interpolation breaks the element context.
+  const output = callRenderProse({
+    type: "link",
+    title: '" onclick="alert(1)',
+    url: "https://safe.example.com",
+  });
+  assert.ok(!output.includes("onclick="), `Title with double-quote must not inject onclick: ${output}`);
+});
+
+test("attack-corpus — URL with embedded null byte does not produce <a>", () => {
+  // URL contains a null byte (U+0000) after the scheme.
+  const url = "https://\x00evil.example.com";
+  const output = callRenderProse({ type: "link", title: "null-byte", url });
+  // Renderer must either reject the URL or strip the null byte.
+  // It must not emit a raw null byte inside href.
+  assert.ok(!output.includes("\x00"), `Output must not contain a null byte: ${JSON.stringify(output)}`);
+});
+
+// ---------------------------------------------------------------------------
+// Bounded-emission contract test (ADR-015 D3a)
+// Reads sanitizer.mjs source text and asserts ALLOWED_TAGS is declared as a
+// literal const array in the module. This is structural enforcement: a reviewer
+// cannot satisfy this test by deriving ALLOWED_TAGS from input or exporting it
+// as mutable.
+// ---------------------------------------------------------------------------
+
+test("bounded-emission — ALLOWED_TAGS is declared as a literal const array in sanitizer.mjs source", async () => {
+  const sanitizerPath = path.join(__dirname, "../assets/sanitizer.mjs");
+  const source = fs.readFileSync(sanitizerPath, "utf8");
+
+  // The pattern asserts ALLOWED_TAGS is a hard-coded const with 'strong' as the
+  // first element — matching ADR-015 D3a's example literal.
+  const literalConstPattern = /const\s+ALLOWED_TAGS\s*=\s*\[\s*['"]strong['"]/;
+
+  assert.ok(
+    literalConstPattern.test(source),
+    "sanitizer.mjs must declare ALLOWED_TAGS as a literal const array starting with 'strong'. " +
+      "It must not be a parameter, derived from input, or mutable. (ADR-015 D3a)",
+  );
+
+  // Also assert ALLOWED_TAGS includes all three required tags.
+  assert.ok(source.includes("'em'") || source.includes('"em"'), "ALLOWED_TAGS must include 'em'");
+  assert.ok(source.includes("'a'") || source.includes('"a"'), "ALLOWED_TAGS must include 'a'");
+});
+
+// ---------------------------------------------------------------------------
+// Escape-with-warn behavior (ADR-015 D4)
+// When renderProse encounters disallowed markup it must:
+//   1. Escape the markup (not strip it)
+//   2. Call console.warn("renderProse: escaped unexpected markup", ...) exactly once
+// ---------------------------------------------------------------------------
+
+test("escape-with-warn — disallowed markup is escaped and console.warn is called once per paragraph", () => {
+  // Install a spy on console.warn.
+  const originalWarn = console.warn;
+  const spy = { calls: [] };
+  console.warn = (...args) => spy.calls.push(args);
+
+  try {
+    const input = "<script>alert(1)</script>";
+    const output = callRenderProse(input);
+
+    // The disallowed markup must be escaped, not stripped.
+    assert.ok(
+      output.includes("&lt;script&gt;"),
+      `Disallowed markup must be escaped as &lt;script&gt; but got: ${output}`,
+    );
+    assert.ok(!output.includes("<script>"), `Disallowed markup must not appear as raw HTML in output: ${output}`);
+
+    // console.warn must have been called exactly once for this paragraph.
+    assert.equal(
+      spy.calls.length,
+      1,
+      `console.warn must be called exactly once per offending paragraph, got ${spy.calls.length} calls`,
+    );
+
+    // The first argument must be the canonical warning string per ADR-015 D4.
+    const firstArg = spy.calls[0][0];
+    assert.equal(
+      firstArg,
+      "renderProse: escaped unexpected markup",
+      `console.warn first arg must be "renderProse: escaped unexpected markup" but got: ${firstArg}`,
+    );
+  } finally {
+    // Always restore console.warn, even if assertions fail.
+    console.warn = originalWarn;
+  }
+});
+
+test("escape-with-warn — console.warn is called once for each offending paragraph, not once per token", () => {
+  // Two disallowed tags in a single input string should produce exactly one warn call.
+  const originalWarn = console.warn;
+  const spy = { calls: [] };
+  console.warn = (...args) => spy.calls.push(args);
+
+  try {
+    const input = "<strong>raw</strong> and <em>also raw</em>";
+    callRenderProse(input);
+
+    assert.equal(
+      spy.calls.length,
+      1,
+      `Multiple disallowed tokens in one paragraph must produce exactly one warn call, got ${spy.calls.length}`,
+    );
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Sentinel passthrough test (ADR-016 D5 fallback case)
+// When sentinels ({{idXxx}} or {{ref:identifier}}) appear in prose that
+// renderProse receives (i.e., the builder did not pre-expand them), the
+// sentinel text must pass through as escaped literal text. Sentinels must NOT
+// trigger tag emission and must NOT trigger console.warn.
+// ---------------------------------------------------------------------------
+
+test("sentinel passthrough — unexpanded {{idXxx}} sentinel passes through as escaped literal text", () => {
+  const originalWarn = console.warn;
+  const spy = { calls: [] };
+  console.warn = (...args) => spy.calls.push(args);
+
+  try {
+    // Sentinel mixed with allowed bold markup.
+    const input = "**important**: see {{idRisk001}} for details.";
+    const output = callRenderProse(input);
+
+    // The sentinel must appear verbatim (or HTML-escaped if it contains special chars,
+    // but {{ and }} are not HTML-special so they pass through as-is).
+    assert.ok(output.includes("{{idRisk001}}"), `Unexpanded sentinel must pass through as literal text: ${output}`);
+
+    // No warn: sentinels are not disallowed markup.
+    assert.equal(
+      spy.calls.length,
+      0,
+      `Sentinels must not trigger console.warn, got ${spy.calls.length} calls: ${JSON.stringify(spy.calls)}`,
+    );
+
+    // Allowed bold markup still renders correctly alongside the sentinel.
+    assert.ok(output.includes("<strong>"), `Bold markup must still render alongside sentinel: ${output}`);
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test("sentinel passthrough — unexpanded {{ref:some-id}} sentinel passes through as literal text", () => {
+  const input = "See {{ref:nist-800-53}} for the control baseline.";
+  const output = callRenderProse(input);
+
+  assert.ok(
+    output.includes("{{ref:nist-800-53}}"),
+    `Unexpanded ref sentinel must pass through as literal text: ${output}`,
+  );
+  // No tags produced from the sentinel.
+  assert.ok(!output.includes("<a "), `Ref sentinel must not produce an <a> tag: ${output}`);
+});
+
+// ---------------------------------------------------------------------------
+// Idempotence sanity test (ADR-015 D3a — bounded emission means the rendered
+// output itself should not contain renderable markdown, so a second pass
+// produces the same result for subset-compliant inputs).
+// ---------------------------------------------------------------------------
+
+test("idempotence — renderProse(renderProse(x)) equals renderProse(x) for a plain-text input", () => {
+  // Given: a plain-text input with no markdown tokens and no HTML-special characters
+  // When: renderProse is called twice
+  // Then: the second call produces the same string as the first
+  //
+  // Idempotence holds only for plain-text inputs (locked interpretation A3).
+  // Inputs containing markdown tokens (e.g. **bold**) are NOT idempotent: the
+  // first pass produces <strong>bold</strong>, and the second pass correctly
+  // escapes those angle brackets per ADR-015 D4, yielding a different string.
+  // This test uses a plain-text input to verify the stable-point property
+  // without triggering the non-idempotent markdown path.
+  const input = "Plain prose with no special markup at all.";
+  const firstPass = callRenderProse(input);
+  const secondPass = callRenderProse(firstPass);
+
+  assert.equal(
+    secondPass,
+    firstPass,
+    `renderProse must be idempotent on plain-text input. ` + `First pass: ${firstPass}; Second pass: ${secondPass}`,
+  );
+});


### PR DESCRIPTION
# Conformance sweep A6: site sanitizer.mjs with bounded HTML emission

Closes #241

## Summary

- Authors `site/assets/sanitizer.mjs` per ADR-015 D1/D2/D3 — a hand-rolled tokenizer + emitter for the YAML prose authoring subset (ADR-017 D1). Vanilla ESM, zero runtime dependencies.
- Bounded-emission property (ADR-015 D3a, load-bearing): `ALLOWED_TAGS = ['strong', 'em', 'a']` is a hard-coded literal `const`. `<a>` attribute values (`href`, `rel`, `target`) are constructed by the renderer (not copied from input); `href` is validated against `^https://` before insertion; `rel="noopener noreferrer"` and `target="_blank"` are constants.
- Three-layer URL validation + `escapeHtml` defense-in-depth. Disallowed input is **escaped** (not stripped) with `console.warn` once per offending paragraph per ADR-015 D4.
- ~~Replaces raw `innerHTML` interpolation in `site/assets/app.mjs` paragraph paths with `renderProse(...)`; `escapeHtml` retained for scalar fields (titles, categories, question prompts).~~ __note: deferred to #254__
       
- Test surface per ADR-015 D3b: per-tag positive + negative fixtures, allowlist–fixture meta-test (adding a tag without adding a fixture fails CI), and an **attack-corpus of 14 known XSS vectors** against `<a>` (javascript:/data:/vbscript: URIs incl. mixed-case + tab-prefix, schemeless, IDN homograph, attribute injection, whitespace/null-byte/backtick/backslash variants).
- Independent of A1 — touches only `site/`.

## Scope boundaries

In scope (this PR):
- New file: `site/assets/sanitizer.mjs` (419 lines)
- New file: `site/tests/sanitizer.test.mjs` (583 lines, `node --test`)
- New: 28 fixture JSON files under `site/tests/fixtures/sanitizer/{positive,negative,attack-corpus}/`
- ~~Edit: `site/assets/app.mjs` (+5 / -2; replaces raw `innerHTML` in two paragraph call sites)~~ __note: deferred to #254__

Out of scope (deferred):
- YAML migration to subset-compliant form → Phase B (B1, B2)
- Authoring-time `validate-yaml-prose-subset` lint → A3
- Bare-string URL → markdown-link migration → A3 / B2
- `app.mjs` decomposition for issue #224 → explicitly separate; would have only touched the two paragraph call     
  sites; both deferred to #254
- Native `Element.setHTML` Sanitizer API adoption → informational revisit only per ADR-015

## Test plan

- [ ] `node --test site/tests/sanitizer.test.mjs` — all 30 tests pass
- [ ] Full repo regression: `pytest` reports no new failures (1371 pass / 6 skip baseline; A6 has no new Python tests but pre-commit YAML/Python checks must remain green)
- [ ] `pre-commit run --all-files` clean (no new lint or schema-validation issues; site assets pass `prettier`)
- [ ] **Bounded-emission audit (ADR-015 D3a — load-bearing):** reviewer confirms `ALLOWED_TAGS` is a literal `const` in source, **not** runtime-derived or configurable
- [ ] **Attribute-construction audit:** reviewer confirms `<a>` `href` / `rel` / `target` are byte-for-byte from constants (not copied from input); `href` validated against `^https://`
- [ ] **Allowlist–fixture meta-test:** runs as part of `node --test`; verifies `ALLOWED_TAGS.every(tag => fixtures.has(tag))`
- [ ] **Attack-corpus coverage:** all 14 fixtures under `site/tests/fixtures/sanitizer/attack-corpus/` produce escaped output (no `<a>`, no `javascript:` execution surface)
- [ ] ~~**Visual spot-check:** site renders identically against current YAML for subset-compliant inputs (manual; no automated golden-file required)~~ __deferred to #254 — site rendering unaffected by this PR (dormant
   infra)__         

