### PR TITLE
Conformance sweep A2: additive schema edits (consumer + prose-strict)

### DIFF
--- a/risk-map/schemas/components.schema.json
+++ b/risk-map/schemas/components.schema.json
@@ -93,7 +93,35 @@
         "subcategory": {
           "$ref": "#/definitions/subcategory/properties/id"
         },
-        "edges": { "$ref": "#/definitions/edges" }
+        "edges": { "$ref": "#/definitions/edges" },
+        "mappings": {
+          "type": "object",
+          "description": "Cross-references to external security frameworks. Per ADR-018 D6 + ADR-022 D5b+D5c: mitre-atlas, iso-22989, and eu-ai-act receive per-framework strict patterns from frameworks.schema.json; stride, nist-ai-rmf, and owasp-top10-llm fall through to the loose catch-all because their current entries use non-canonical forms. Keys must match valid framework IDs in frameworks.schema.json.",
+          "propertyNames": {
+            "$ref": "frameworks.schema.json#/definitions/framework/properties/id"
+          },
+          "properties": {
+            "mitre-atlas": {
+              "type": "array",
+              "items": { "$ref": "frameworks.schema.json#/definitions/framework-mapping-patterns/properties/mitre-atlas" }
+            },
+            "iso-22989": {
+              "type": "array",
+              "items": { "$ref": "frameworks.schema.json#/definitions/framework-mapping-patterns/properties/iso-22989" }
+            },
+            "eu-ai-act": {
+              "type": "array",
+              "items": { "$ref": "frameworks.schema.json#/definitions/framework-mapping-patterns/properties/eu-ai-act" }
+            }
+          },
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "externalReferences": {
+          "$ref": "external-references.schema.json#/definitions/externalReferences"
+        }
       },
       "required": ["id", "title", "category", "edges"]
     },

--- a/risk-map/schemas/controls.schema.json
+++ b/risk-map/schemas/controls.schema.json
@@ -106,23 +106,28 @@
         },
         "mappings": {
           "type": "object",
-          "description": "Cross-references to external security frameworks. Keys must match valid framework IDs defined in frameworks.schema.json and frameworks.yaml.",
+          "description": "Cross-references to external security frameworks. Per ADR-020 D5 + ADR-022 D5b: mitre-atlas, iso-22989, and eu-ai-act receive per-framework strict patterns from frameworks.schema.json; stride, nist-ai-rmf, and owasp-top10-llm fall through to the loose catch-all because their current entries use non-canonical forms. Keys must match valid framework IDs in frameworks.schema.json.",
           "propertyNames": {
             "$ref": "frameworks.schema.json#/definitions/framework/properties/id"
           },
-          "additionalProperties": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "description": "Framework-specific category, technique, or tactic identifier"
+          "properties": {
+            "mitre-atlas": {
+              "type": "array",
+              "items": { "$ref": "frameworks.schema.json#/definitions/framework-mapping-patterns/properties/mitre-atlas" }
+            },
+            "iso-22989": {
+              "type": "array",
+              "items": { "$ref": "frameworks.schema.json#/definitions/framework-mapping-patterns/properties/iso-22989" }
+            },
+            "eu-ai-act": {
+              "type": "array",
+              "items": { "$ref": "frameworks.schema.json#/definitions/framework-mapping-patterns/properties/eu-ai-act" }
             }
           },
-          "examples": [
-            {
-              "mitre-atlas": ["ml-model-access", "exfiltration"],
-              "stride": ["information-disclosure"]
-            }
-          ]
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
         },
         "lifecycleStage": {
           "description": "AI system lifecycle phases where applicable",
@@ -168,6 +173,9 @@
               "enum": ["all", "none"]
             }
           ]
+        },
+        "externalReferences": {
+          "$ref": "external-references.schema.json#/definitions/externalReferences"
         }
       },
       "required": ["title", "description", "category", "personas", "components", "risks"]

--- a/risk-map/schemas/lifecycle-stage.schema.json
+++ b/risk-map/schemas/lifecycle-stage.schema.json
@@ -41,7 +41,9 @@
         },
         "order": {
           "type": "integer",
-          "description": "Sequential order in the lifecycle (1-8)"
+          "description": "Sequential order in the lifecycle (1-8)",
+          "minimum": 1,
+          "maximum": 8
         }
       },
       "required": ["id", "title", "description"]

--- a/risk-map/schemas/persona-site-data.schema.json
+++ b/risk-map/schemas/persona-site-data.schema.json
@@ -10,8 +10,54 @@
         "oneOf": [
           { "type": "string" },
           {
+            "type": "object",
+            "description": "Intra-document sentinel resolution: {{idXxx}} expands to a typed reference.",
+            "required": ["type", "id", "title"],
+            "additionalProperties": false,
+            "properties": {
+              "type": { "type": "string", "const": "ref" },
+              "id": { "type": "string", "minLength": 1 },
+              "title": { "type": "string", "minLength": 1 }
+            }
+          },
+          {
+            "type": "object",
+            "description": "External sentinel resolution: {{ref:identifier}} expands to a URL from matching externalReferences entry.",
+            "required": ["type", "title", "url"],
+            "additionalProperties": false,
+            "properties": {
+              "type": { "type": "string", "const": "link" },
+              "title": { "type": "string", "minLength": 1 },
+              "url": { "type": "string", "pattern": "^https://" }
+            }
+          },
+          {
             "type": "array",
-            "items": { "type": "string" },
+            "items": {
+              "oneOf": [
+                { "type": "string" },
+                {
+                  "type": "object",
+                  "required": ["type", "id", "title"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "type": { "type": "string", "const": "ref" },
+                    "id": { "type": "string", "minLength": 1 },
+                    "title": { "type": "string", "minLength": 1 }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": ["type", "title", "url"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "type": { "type": "string", "const": "link" },
+                    "title": { "type": "string", "minLength": 1 },
+                    "url": { "type": "string", "pattern": "^https://" }
+                  }
+                }
+              ]
+            },
             "minItems": 1
           }
         ]
@@ -83,6 +129,9 @@
           "controlCount": {
             "type": "integer",
             "minimum": 0
+          },
+          "externalReferences": {
+            "$ref": "external-references.schema.json#/definitions/externalReferences"
           }
         },
         "additionalProperties": false
@@ -158,6 +207,9 @@
           "personaIds": {
             "type": "array",
             "items": { "type": "string" }
+          },
+          "externalReferences": {
+            "$ref": "external-references.schema.json#/definitions/externalReferences"
           }
         },
         "additionalProperties": false
@@ -180,6 +232,9 @@
           "riskIds": {
             "type": "array",
             "items": { "type": "string" }
+          },
+          "externalReferences": {
+            "$ref": "external-references.schema.json#/definitions/externalReferences"
           }
         },
         "additionalProperties": false

--- a/risk-map/schemas/personas.schema.json
+++ b/risk-map/schemas/personas.schema.json
@@ -67,6 +67,9 @@
           "type": "array",
           "description": "Questions to help identify if this persona applies",
           "items": { "type": "string", "minLength": 1 }
+        },
+        "externalReferences": {
+          "$ref": "external-references.schema.json#/definitions/externalReferences"
         }
       },
       "required": ["id", "title", "description"]

--- a/risk-map/schemas/riskmap.schema.json
+++ b/risk-map/schemas/riskmap.schema.json
@@ -17,6 +17,20 @@
             }
           ]
         }
+      },
+      "prose-strict": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "oneOf": [
+            { "type": "string", "minLength": 1 },
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string", "minLength": 1 }
+            }
+          ]
+        }
       }
     }
   }

--- a/risk-map/schemas/risks.schema.json
+++ b/risk-map/schemas/risks.schema.json
@@ -86,23 +86,28 @@
         },
         "mappings": {
           "type": "object",
-          "description": "Cross-references to external security frameworks. Keys must match valid framework IDs defined in frameworks.schema.json and frameworks.yaml.",
+          "description": "Cross-references to external security frameworks. Per ADR-019 D5 + ADR-022 D5b: mitre-atlas, iso-22989, and eu-ai-act receive per-framework strict patterns from frameworks.schema.json; stride, nist-ai-rmf, and owasp-top10-llm fall through to the loose catch-all because their current entries use non-canonical forms. Keys must match valid framework IDs in frameworks.schema.json.",
           "propertyNames": {
             "$ref": "frameworks.schema.json#/definitions/framework/properties/id"
           },
-          "additionalProperties": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "description": "Framework-specific category, technique, or tactic identifier"
+          "properties": {
+            "mitre-atlas": {
+              "type": "array",
+              "items": { "$ref": "frameworks.schema.json#/definitions/framework-mapping-patterns/properties/mitre-atlas" }
+            },
+            "iso-22989": {
+              "type": "array",
+              "items": { "$ref": "frameworks.schema.json#/definitions/framework-mapping-patterns/properties/iso-22989" }
+            },
+            "eu-ai-act": {
+              "type": "array",
+              "items": { "$ref": "frameworks.schema.json#/definitions/framework-mapping-patterns/properties/eu-ai-act" }
             }
           },
-          "examples": [
-            {
-              "mitre-atlas": ["ml-model-access", "exfiltration"],
-              "stride": ["information-disclosure"]
-            }
-          ]
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
         },
         "lifecycleStage": {
           "description": "AI system lifecycle phases where applicable",
@@ -148,6 +153,9 @@
               "enum": ["all", "none"]
             }
           ]
+        },
+        "externalReferences": {
+          "$ref": "external-references.schema.json#/definitions/externalReferences"
         }
       },
       "required": ["id", "title", "shortDescription", "longDescription", "category", "personas", "controls"]

--- a/scripts/hooks/tests/test_components_mappings_field.py
+++ b/scripts/hooks/tests/test_components_mappings_field.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""
+Tests for the optional mappings field on components.schema.json.
+
+Per ADR-018 D6 + ADR-022 D5b/D5c, definitions/component/properties declares
+a mappings field with the same hybrid shape used by risks/controls/personas:
+- propertyNames $ref to frameworks.schema.json framework/id enum.
+- Per-property strict wiring for mitre-atlas, iso-22989, eu-ai-act (regex-
+  backed via $ref to framework-mapping-patterns).
+- Loose additionalProperties catch-all (array of strings) for remaining
+  frameworks (stride, nist-ai-rmf, owasp-top10-llm).
+- Optional — NOT in the required array.
+
+The hybrid wiring reflects the state of current YAML mappings content:
+mitre-atlas/iso-22989/eu-ai-act entries already conform to ADR-022 D5b
+canonical regexes; stride/nist-ai-rmf/owasp-top10-llm use non-canonical
+short forms that subsequent content normalisation will fix.
+
+Coverage:
+- mappings property is declared in definitions/component/properties.
+- propertyNames $ref to frameworks.schema.json is present.
+- Per-property entries for mitre-atlas, iso-22989, eu-ai-act are declared.
+- additionalProperties catch-all is present.
+- Field is NOT in required.
+- Known-good mitre-atlas value AML.T0020 validates.
+- Malformed mitre-atlas value aml-t0020 is rejected.
+- Unknown framework key is rejected via propertyNames.
+- Current components.yaml passes validation unchanged.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+from jsonschema.exceptions import SchemaError
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT7
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+# ============================================================================
+# Module-level constants
+# ============================================================================
+
+SCHEMA_FILE = "components.schema.json"
+ENTITY_KEY = "component"
+
+# Frameworks wired with per-property strict patterns.
+STRICTLY_WIRED_FRAMEWORKS = {"mitre-atlas", "iso-22989", "eu-ai-act"}
+
+# Frameworks that fall through to the loose additionalProperties catch-all.
+LOOSE_FRAMEWORKS = {"stride", "nist-ai-rmf", "owasp-top10-llm"}
+
+# Valid per-framework examples for the strictly-wired set.
+# mitre-atlas: canonical uppercase form from A1 pattern ^AML\.(T|M)\d{4}(\.\d{3})?$
+# iso-22989: bare string (no pattern)
+# eu-ai-act: pattern ^Article\s\d+(\(\d+\))?$
+VALID_STRICT_EXAMPLES: dict[str, list[str]] = {
+    "mitre-atlas": ["AML.T0020", "AML.M0011", "AML.T0010.002"],
+    "iso-22989": ["AI Producer", "AI Customer (application builder)"],
+    "eu-ai-act": ["Article 5", "Article 5(1)", "Article 50"],
+}
+
+# Invalid mitre-atlas examples (wrong form).
+INVALID_MITRE_ATLAS: list[str] = [
+    "aml-t0020",  # lowercase-kebab (external-references surface, not this one)
+    "AML.T20",  # short ID
+    "AML.X0020",  # non-T/M letter
+]
+
+# Loose framework examples — current content uses short forms that don't match
+# the A1 patterns, so they go through the catch-all.
+VALID_LOOSE_EXAMPLES: dict[str, list[str]] = {
+    "stride": ["tampering", "spoofing", "repudiation"],
+    "nist-ai-rmf": ["GV-6.2", "MS-2.11", "MS-2.3"],
+    "owasp-top10-llm": ["LLM01", "LLM09"],
+}
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="module")
+def components_schema(risk_map_schemas_dir: Path) -> dict:
+    """Parsed components.schema.json."""
+    path = risk_map_schemas_dir / SCHEMA_FILE
+    if not path.is_file():
+        pytest.fail(f"Schema not found: {path}")
+    with open(path) as fh:
+        return json.load(fh)
+
+
+@pytest.fixture(scope="module")
+def component_properties(components_schema: dict) -> dict:
+    """definitions/component/properties block."""
+    props = components_schema.get("definitions", {}).get(ENTITY_KEY, {}).get("properties", {})
+    assert props, f"definitions/{ENTITY_KEY}/properties must exist in {SCHEMA_FILE}"
+    return props
+
+
+@pytest.fixture(scope="module")
+def mappings_schema(component_properties: dict) -> dict:
+    """The mappings sub-schema from definitions/component/properties."""
+    if "mappings" not in component_properties:
+        pytest.fail(
+            f"definitions/{ENTITY_KEY}/properties/mappings not found in {SCHEMA_FILE}. "
+            "The mappings field has not been declared yet."
+        )
+    return component_properties["mappings"]
+
+
+@pytest.fixture(scope="module")
+def registry(risk_map_schemas_dir: Path) -> Registry:
+    """
+    referencing.Registry that resolves bare-filename $refs against the
+    schemas directory. Replaces the deprecated jsonschema.RefResolver.
+    """
+
+    def retrieve(uri: str):
+        # The validator hands us the URI portion of a $ref; for our refs the
+        # URI is a bare schema filename relative to risk_map_schemas_dir.
+        name = uri.rsplit("/", 1)[-1]
+        path = risk_map_schemas_dir / name
+        with open(path) as fh:
+            return Resource.from_contents(json.load(fh), default_specification=DRAFT7)
+
+    return Registry(retrieve=retrieve)
+
+
+# ============================================================================
+# Schema meta-validity
+# ============================================================================
+
+
+class TestSchemaMetaValidity:
+    """components.schema.json must be valid Draft-07."""
+
+    def test_schema_passes_draft07_metaschema(self, components_schema: dict):
+        """
+        Test that components.schema.json is a valid Draft-07 schema.
+
+        Given: components.schema.json loaded
+        When: Draft7Validator.check_schema() is called
+        Then: No SchemaError is raised
+        """
+        try:
+            Draft7Validator.check_schema(components_schema)
+        except SchemaError as exc:
+            pytest.fail(f"{SCHEMA_FILE} is not valid Draft-07: {exc.message}")
+
+
+# ============================================================================
+# mappings field presence and structure
+# ============================================================================
+
+
+class TestMappingsFieldPresence:
+    """The mappings field must be declared under definitions/component/properties."""
+
+    def test_mappings_property_exists(self, component_properties: dict):
+        """
+        Test that the mappings property is declared.
+
+        Given: definitions/component/properties in components.schema.json
+        When: The keys are inspected
+        Then: 'mappings' is present
+        """
+        assert "mappings" in component_properties, f"definitions/{ENTITY_KEY}/properties must declare 'mappings'"
+
+    def test_mappings_is_object_type(self, mappings_schema: dict):
+        """
+        Test that the mappings schema declares type: object.
+
+        Given: definitions/component/properties/mappings
+        When: Its 'type' is examined
+        Then: It is 'object'
+        """
+        assert mappings_schema.get("type") == "object", "mappings must be type: object"
+
+    def test_mappings_has_property_names_ref(self, mappings_schema: dict):
+        """
+        Test that propertyNames is wired to the framework id enum.
+
+        Given: The mappings sub-schema
+        When: Its propertyNames is examined
+        Then: It uses $ref to frameworks.schema.json#/definitions/framework/properties/id
+        """
+        property_names = mappings_schema.get("propertyNames", {})
+        expected_ref = "frameworks.schema.json#/definitions/framework/properties/id"
+        assert property_names.get("$ref") == expected_ref, (
+            f"mappings.propertyNames must $ref {expected_ref!r}; got: {property_names!r}"
+        )
+
+    def test_mappings_has_additional_properties_catch_all(self, mappings_schema: dict):
+        """
+        Test that the loose catch-all additionalProperties is declared.
+
+        Given: The mappings sub-schema
+        When: additionalProperties is examined
+        Then: It is present and is an array-of-strings shape
+
+        The catch-all covers stride/nist-ai-rmf/owasp-top10-llm whose current
+        content uses non-canonical forms that do not match the ADR-022 D5b
+        canonical regexes. Only mitre-atlas/iso-22989/eu-ai-act receive
+        per-property strict wiring.
+        """
+        additional = mappings_schema.get("additionalProperties")
+        assert additional is not None, "mappings must declare additionalProperties catch-all"
+        assert additional.get("type") == "array", "additionalProperties catch-all must be type: array"
+        items = additional.get("items", {})
+        assert items.get("type") == "string", "additionalProperties items must be type: string"
+
+    @pytest.mark.parametrize("framework_key", sorted(STRICTLY_WIRED_FRAMEWORKS))
+    def test_strictly_wired_frameworks_declared_in_properties(self, mappings_schema: dict, framework_key: str):
+        """
+        Test that per-property entries for strictly-wired frameworks are declared.
+
+        Given: The mappings sub-schema properties block
+        When: A strictly-wired framework key is looked up
+        Then: It is present (with its items $ref pointing at framework-mapping-patterns)
+        """
+        props = mappings_schema.get("properties", {})
+        assert framework_key in props, f"mappings.properties must declare '{framework_key}' (strictly-wired)"
+
+
+# ============================================================================
+# Optional — not in required
+# ============================================================================
+
+
+class TestMappingsIsOptional:
+    """mappings must be optional in the component object schema."""
+
+    def test_mappings_not_in_required(self, components_schema: dict):
+        """
+        Test that mappings is not in the required array.
+
+        Given: definitions/component in components.schema.json
+        When: Its required array is inspected
+        Then: 'mappings' is absent
+        """
+        entity_schema = components_schema["definitions"][ENTITY_KEY]
+        required = entity_schema.get("required", [])
+        assert "mappings" not in required, (
+            "mappings must NOT be in definitions/component/required (optional field)"
+        )
+
+
+# ============================================================================
+# Behavioral validation — mitre-atlas strict wiring
+# ============================================================================
+
+
+class TestMitreAtlasWiring:
+    """
+    mitre-atlas items must be validated against the ADR-022 D5b pattern
+    ^AML\\.(T|M)\\d{4}(\\.\\d{3})?$ via the framework-mapping-patterns $ref.
+    """
+
+    @pytest.mark.parametrize("valid_id", VALID_STRICT_EXAMPLES["mitre-atlas"])
+    def test_mitre_atlas_valid_value_accepted(self, mappings_schema: dict, registry: Registry, valid_id: str):
+        """
+        Test that canonical mitre-atlas values pass.
+
+        Given: A mappings object with mitre-atlas: [<valid_id>]
+        When: It is validated against the mappings schema
+        Then: No errors are raised
+        """
+        validator = Draft7Validator(mappings_schema, registry=registry)
+        instance = {"mitre-atlas": [valid_id]}
+        errors = list(validator.iter_errors(instance))
+        assert not errors, f"mitre-atlas value {valid_id!r} must be accepted; got: {[e.message for e in errors]}"
+
+    @pytest.mark.parametrize("invalid_id", INVALID_MITRE_ATLAS)
+    def test_mitre_atlas_invalid_value_rejected(self, mappings_schema: dict, registry: Registry, invalid_id: str):
+        """
+        Test that malformed mitre-atlas values are rejected.
+
+        Given: A mappings object with mitre-atlas: [<invalid_id>]
+        When: It is validated
+        Then: ValidationError is raised (strict pattern rejects malformed IDs)
+        """
+        validator = Draft7Validator(mappings_schema, registry=registry)
+        instance = {"mitre-atlas": [invalid_id]}
+        errors = list(validator.iter_errors(instance))
+        assert errors, f"mitre-atlas value {invalid_id!r} must be rejected by the strict pattern"
+
+
+# ============================================================================
+# Behavioral validation — iso-22989 and eu-ai-act strict wiring
+# ============================================================================
+
+
+class TestIsoAndEuAiActStrictWiring:
+    """
+    iso-22989 uses bare string items with no pattern constraint (deliberately
+    permissive per A1 design). eu-ai-act items must match
+    ^Article\\s\\d+(\\(\\d+\\))?$ per ADR-022 D5b.
+
+    Both frameworks receive per-property strict wiring in the components mappings
+    schema via $ref to framework-mapping-patterns in frameworks.schema.json.
+    """
+
+    @pytest.mark.parametrize("value", VALID_STRICT_EXAMPLES["iso-22989"])
+    def test_iso_22989_valid_value_accepted(self, mappings_schema: dict, registry: Registry, value: str):
+        """
+        Test that iso-22989 bare-string descriptors are accepted.
+
+        Given: A mappings object with iso-22989: [<value>]
+        When: It is validated against the mappings schema
+        Then: No errors are raised (iso-22989 is permissive — any non-empty string)
+        """
+        validator = Draft7Validator(mappings_schema, registry=registry)
+        instance = {"iso-22989": [value]}
+        errors = list(validator.iter_errors(instance))
+        assert not errors, f"iso-22989 value {value!r} must be accepted; got: {[e.message for e in errors]}"
+
+    @pytest.mark.parametrize("value", VALID_STRICT_EXAMPLES["eu-ai-act"])
+    def test_eu_ai_act_valid_value_accepted(self, mappings_schema: dict, registry: Registry, value: str):
+        """
+        Test that eu-ai-act Article-form values are accepted.
+
+        Given: A mappings object with eu-ai-act: [<value>] in ^Article\\s\\d+(\\(\\d+\\))?$ form
+        When: It is validated against the mappings schema
+        Then: No errors are raised
+        """
+        validator = Draft7Validator(mappings_schema, registry=registry)
+        instance = {"eu-ai-act": [value]}
+        errors = list(validator.iter_errors(instance))
+        assert not errors, f"eu-ai-act value {value!r} must be accepted; got: {[e.message for e in errors]}"
+
+    @pytest.mark.parametrize(
+        "invalid_value",
+        [
+            "Article",  # no article number
+            "article-5",  # lowercase-kebab form
+            "Art 5",  # abbreviated prefix
+            "Art. 5(1)",  # abbreviated with period
+        ],
+    )
+    def test_eu_ai_act_invalid_value_rejected(self, mappings_schema: dict, registry: Registry, invalid_value: str):
+        """
+        Test that malformed eu-ai-act values are rejected.
+
+        Given: A mappings object with eu-ai-act: [<invalid_value>]
+        When: It is validated against the mappings schema
+        Then: ValidationError is raised (strict pattern ^Article\\s\\d+(\\(\\d+\\))?$ rejects it)
+        """
+        validator = Draft7Validator(mappings_schema, registry=registry)
+        instance = {"eu-ai-act": [invalid_value]}
+        errors = list(validator.iter_errors(instance))
+        assert errors, f"eu-ai-act value {invalid_value!r} must be rejected by the strict pattern"
+
+
+# ============================================================================
+# Behavioral validation — loose frameworks pass through
+# ============================================================================
+
+
+class TestLooseFrameworksPassThrough:
+    """
+    stride, nist-ai-rmf, and owasp-top10-llm fall through to the loose
+    additionalProperties catch-all (array of strings). Current YAML uses
+    non-canonical forms that subsequent content normalisation will fix.
+    """
+
+    @pytest.mark.parametrize(
+        ("framework_key", "value"),
+        [(fw, v) for fw, vals in VALID_LOOSE_EXAMPLES.items() for v in vals],
+    )
+    def test_loose_framework_value_accepted(
+        self, mappings_schema: dict, registry: Registry, framework_key: str, value: str
+    ):
+        """
+        Test that non-canonical values for loose frameworks are accepted.
+
+        Given: A mappings object with <framework_key>: [<value>]
+        When: It is validated against the mappings schema
+        Then: No errors are raised (falls through to additionalProperties catch-all)
+        """
+        validator = Draft7Validator(mappings_schema, registry=registry)
+        instance = {framework_key: [value]}
+        errors = list(validator.iter_errors(instance))
+        assert not errors, (
+            f"Loose framework {framework_key!r} value {value!r} must be accepted "
+            f"via catch-all; got: {[e.message for e in errors]}"
+        )
+
+
+# ============================================================================
+# Behavioral validation — unknown framework key rejected
+# ============================================================================
+
+
+class TestUnknownFrameworkRejected:
+    """Unknown framework keys must be rejected via propertyNames."""
+
+    def test_unknown_framework_key_rejected(self, mappings_schema: dict, registry: Registry):
+        """
+        Test that an unregistered framework key is rejected.
+
+        Given: A mappings object with made-up-framework: ["some-value"]
+        When: It is validated
+        Then: ValidationError is raised (propertyNames constraint rejects it)
+        """
+        validator = Draft7Validator(mappings_schema, registry=registry)
+        instance = {"made-up-framework": ["some-value"]}
+        errors = list(validator.iter_errors(instance))
+        assert errors, "Unknown framework key 'made-up-framework' must be rejected via propertyNames"
+
+
+# ============================================================================
+# Regression — current components.yaml still validates
+# ============================================================================
+
+
+class TestCurrentYamlStillValid:
+    """
+    The current components.yaml must continue to pass check-jsonschema
+    (additive only, no existing content is invalidated).
+    """
+
+    def test_components_yaml_passes_check_jsonschema(self, risk_map_schemas_dir: Path, risk_map_yaml_dir: Path):
+        """
+        Test that current components.yaml validates against components.schema.json.
+
+        Given: The current components.yaml on disk (no mappings fields today)
+        When: check-jsonschema is run with --schemafile components.schema.json
+        Then: Exit code is 0 (schema addition is backward-compatible)
+        """
+        schema_path = risk_map_schemas_dir / SCHEMA_FILE
+        yaml_path = risk_map_yaml_dir / "components.yaml"
+        base_uri = f"file://{risk_map_schemas_dir}/"
+        result = subprocess.run(
+            [
+                "check-jsonschema",
+                "--base-uri",
+                base_uri,
+                "--schemafile",
+                str(schema_path),
+                str(yaml_path),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"components.yaml must remain valid:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+
+# ============================================================================
+# Test summary
+# ============================================================================
+"""
+Test Summary
+============
+Test classes: 8
+
+- TestSchemaMetaValidity (1)             — schema valid Draft-07
+- TestMappingsFieldPresence (5)          — property exists, type=object,
+                                           propertyNames $ref, catch-all,
+                                           strictly-wired keys present
+- TestMappingsIsOptional (1)             — not in required
+- TestMitreAtlasWiring (6)               — parametrized: 3 valid + 3 invalid
+- TestIsoAndEuAiActStrictWiring          — iso-22989: 2 valid accepted;
+                                           eu-ai-act: 3 valid accepted +
+                                           4 invalid rejected
+- TestLooseFrameworksPassThrough         — parametrized: stride/nist-ai-rmf/
+                                           owasp-top10-llm loose values accepted
+                                           (8 cases; nist-ai-rmf has 3 values)
+- TestUnknownFrameworkRejected (1)       — propertyNames rejects unknown key
+- TestCurrentYamlStillValid (1)          — regression: components.yaml still passes
+
+Coverage areas:
+- mappings field: presence, structure, optional status
+- Strict wiring: mitre-atlas, iso-22989, eu-ai-act valid/invalid examples
+- Loose catch-all: stride/nist-ai-rmf/owasp-top10-llm
+- propertyNames constraint enforcement
+- Backward compatibility: current components.yaml unchanged
+"""

--- a/scripts/hooks/tests/test_consumer_external_references_refs.py
+++ b/scripts/hooks/tests/test_consumer_external_references_refs.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+Tests for the optional externalReferences $ref on the four consumer schemas.
+
+Covers ADR-016 D3 (shared external-references schema) and its wiring into
+risks.schema.json, controls.schema.json, components.schema.json, and
+personas.schema.json.
+
+Coverage:
+- Each consumer schema declares externalReferences in definitions/<entity>/properties.
+- The property uses a $ref to external-references.schema.json#/definitions/externalReferences.
+- The field is NOT in the required array (optional).
+- A valid externalReferences value passes Draft-07 validation against each consumer.
+- Current YAML files remain valid (no regression on existing content).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+from jsonschema.exceptions import SchemaError
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT7
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+# ============================================================================
+# Module-level constants
+# ============================================================================
+
+# Each tuple: (schema filename, definition path to the entity properties dict).
+# The path mirrors definitions/<entity>/properties in each schema.
+CONSUMER_SCHEMAS: list[tuple[str, str]] = [
+    ("risks.schema.json", "risk"),
+    ("controls.schema.json", "control"),
+    ("components.schema.json", "component"),
+    ("personas.schema.json", "persona"),
+]
+
+# A minimal valid externalReferences value per external-references.schema.json.
+VALID_EXTERNAL_REFERENCES = [
+    {
+        "type": "paper",
+        "id": "smith-2024-example",
+        "title": "A Sample Paper",
+        "url": "https://example.com/paper",
+    }
+]
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="module")
+def schemas_dir(risk_map_schemas_dir: Path) -> Path:
+    """Alias to keep test signatures concise."""
+    return risk_map_schemas_dir
+
+
+def _load_schema(schemas_dir: Path, filename: str) -> dict:
+    """Load and return a schema file, failing with a clear message if absent."""
+    path = schemas_dir / filename
+    if not path.is_file():
+        pytest.fail(f"Schema not found: {path}")
+    with open(path) as fh:
+        return json.load(fh)
+
+
+def _make_registry(schemas_dir: Path) -> Registry:
+    """
+    Build a referencing.Registry that resolves bare-filename $refs against
+    schemas in the given directory. Replaces the deprecated jsonschema.RefResolver
+    pattern (deprecated since jsonschema 4.18; scheduled for removal).
+    """
+
+    def retrieve(uri: str):
+        # The validator hands us the URI portion of a $ref. For our refs
+        # (e.g., "external-references.schema.json"), the URI is a bare schema
+        # filename relative to schemas_dir. Path-prefixed refs (e.g.,
+        # "../foo.json") would silently drop the prefix here; that's acceptable
+        # because all consumer-schema $refs in this repo are bare filenames.
+        name = uri.rsplit("/", 1)[-1]
+        path = schemas_dir / name
+        with open(path) as fh:
+            return Resource.from_contents(json.load(fh), default_specification=DRAFT7)
+
+    return Registry(retrieve=retrieve)
+
+
+# ============================================================================
+# Schema meta-validity — each consumer schema must be valid Draft-07
+# ============================================================================
+
+
+class TestConsumerSchemaMetaValidity:
+    """Each consumer schema must be a valid JSON Schema Draft-07 document."""
+
+    @pytest.mark.parametrize("schema_file,entity_key", CONSUMER_SCHEMAS, ids=[s[0] for s in CONSUMER_SCHEMAS])
+    def test_consumer_schema_passes_draft07_metaschema(self, schemas_dir: Path, schema_file: str, entity_key: str):
+        """
+        Test that each consumer schema is itself a valid Draft-07 schema.
+
+        Given: A consumer schema file
+        When: Draft7Validator.check_schema() is called
+        Then: No SchemaError is raised
+        """
+        schema = _load_schema(schemas_dir, schema_file)
+        try:
+            Draft7Validator.check_schema(schema)
+        except SchemaError as exc:
+            pytest.fail(f"{schema_file} is not valid Draft-07: {exc.message}")
+
+
+# ============================================================================
+# externalReferences property declared in each consumer
+# ============================================================================
+
+
+class TestExternalReferencesPropertyDeclared:
+    """
+    Each consumer schema must declare externalReferences under
+    definitions/<entity>/properties.
+    """
+
+    @pytest.mark.parametrize("schema_file,entity_key", CONSUMER_SCHEMAS, ids=[s[0] for s in CONSUMER_SCHEMAS])
+    def test_external_references_property_exists(self, schemas_dir: Path, schema_file: str, entity_key: str):
+        """
+        Test that each consumer schema declares the externalReferences property.
+
+        Given: A consumer schema with its definitions/<entity>/properties block
+        When: The properties block is inspected
+        Then: An externalReferences entry is present (per ADR-016 D3)
+        """
+        schema = _load_schema(schemas_dir, schema_file)
+        props = schema.get("definitions", {}).get(entity_key, {}).get("properties", {})
+        assert "externalReferences" in props, (
+            f"{schema_file} definitions/{entity_key}/properties must declare 'externalReferences' (per ADR-016 D3)"
+        )
+
+    @pytest.mark.parametrize("schema_file,entity_key", CONSUMER_SCHEMAS, ids=[s[0] for s in CONSUMER_SCHEMAS])
+    def test_external_references_uses_ref(self, schemas_dir: Path, schema_file: str, entity_key: str):
+        """
+        Test that externalReferences is wired via $ref to the shared schema.
+
+        Given: The externalReferences property entry in a consumer schema
+        When: The entry is examined
+        Then: It uses $ref pointing at
+              external-references.schema.json#/definitions/externalReferences
+        """
+        schema = _load_schema(schemas_dir, schema_file)
+        props = schema["definitions"][entity_key]["properties"]
+        ext_ref_entry = props.get("externalReferences", {})
+        expected_ref = "external-references.schema.json#/definitions/externalReferences"
+        assert ext_ref_entry.get("$ref") == expected_ref, (
+            f"{schema_file} externalReferences must use $ref={expected_ref!r}; got: {ext_ref_entry!r}"
+        )
+
+
+# ============================================================================
+# externalReferences must NOT be in required
+# ============================================================================
+
+
+class TestExternalReferencesIsOptional:
+    """
+    The externalReferences property must be optional in each consumer schema
+    (not in the required array, per ADR-016 D3).
+    """
+
+    @pytest.mark.parametrize("schema_file,entity_key", CONSUMER_SCHEMAS, ids=[s[0] for s in CONSUMER_SCHEMAS])
+    def test_external_references_not_in_required(self, schemas_dir: Path, schema_file: str, entity_key: str):
+        """
+        Test that externalReferences is not listed in the required array.
+
+        Given: The definitions/<entity> object schema
+        When: Its required array is inspected
+        Then: externalReferences is absent from required
+        """
+        schema = _load_schema(schemas_dir, schema_file)
+        entity_schema = schema.get("definitions", {}).get(entity_key, {})
+        required = entity_schema.get("required", [])
+        assert "externalReferences" not in required, (
+            f"{schema_file} definitions/{entity_key} must not require externalReferences "
+            "(field is optional per ADR-016 D3)"
+        )
+
+
+# ============================================================================
+# Behavioral validation — valid externalReferences value accepted
+# ============================================================================
+
+
+class TestExternalReferencesValueAccepted:
+    """
+    A valid externalReferences array must pass validation against each
+    consumer schema when the field is present.
+    """
+
+    @pytest.mark.parametrize("schema_file,entity_key", CONSUMER_SCHEMAS, ids=[s[0] for s in CONSUMER_SCHEMAS])
+    def test_valid_external_references_passes(self, schemas_dir: Path, schema_file: str, entity_key: str):
+        """
+        Test that a valid externalReferences array is accepted.
+
+        Given: A Draft-07 validator over definitions/<entity>
+        When: An entity object containing a valid externalReferences array is validated
+        Then: No errors are raised
+
+        Note: The full entity object must satisfy required fields too; this
+        test uses a partial approach — it validates only the externalReferences
+        property sub-schema via a targeted validator.
+        """
+        schema = _load_schema(schemas_dir, schema_file)
+        props = schema.get("definitions", {}).get(entity_key, {}).get("properties", {})
+        ext_ref_entry = props.get("externalReferences")
+        assert ext_ref_entry is not None, f"externalReferences not in {schema_file} yet"
+
+        # Resolve the $ref against the schemas directory.
+        registry = _make_registry(schemas_dir)
+        resolved_schema = registry.resolver(base_uri="").lookup(ext_ref_entry["$ref"]).contents
+        validator = Draft7Validator(resolved_schema, registry=registry)
+        errors = list(validator.iter_errors(VALID_EXTERNAL_REFERENCES))
+        assert not errors, (
+            f"Valid externalReferences must pass for {schema_file}; got: {[e.message for e in errors]}"
+        )
+
+    @pytest.mark.parametrize("schema_file,entity_key", CONSUMER_SCHEMAS, ids=[s[0] for s in CONSUMER_SCHEMAS])
+    def test_empty_array_rejected(self, schemas_dir: Path, schema_file: str, entity_key: str):
+        """
+        Test that an empty externalReferences array is rejected (per ADR-016 D3
+        minItems: 1 on the shared schema — authors omit the field instead).
+
+        Given: A resolver over the $ref'd external-references schema
+        When: An empty array is validated
+        Then: Validation fails (minItems: 1 enforced by the shared schema)
+        """
+        schema = _load_schema(schemas_dir, schema_file)
+        props = schema.get("definitions", {}).get(entity_key, {}).get("properties", {})
+        ext_ref_entry = props.get("externalReferences")
+        assert ext_ref_entry is not None, f"externalReferences not in {schema_file} yet"
+
+        registry = _make_registry(schemas_dir)
+        resolved_schema = registry.resolver(base_uri="").lookup(ext_ref_entry["$ref"]).contents
+        validator = Draft7Validator(resolved_schema, registry=registry)
+        errors = list(validator.iter_errors([]))
+        assert errors, (
+            f"Empty externalReferences array must be rejected for {schema_file} "
+            "(minItems: 1 from shared schema per ADR-016 D3)"
+        )
+
+
+# ============================================================================
+# Test summary
+# ============================================================================
+"""
+Test Summary
+============
+Test classes: 5
+
+- TestConsumerSchemaMetaValidity (4)         — each of 4 consumer schemas is
+                                                valid Draft-07
+- TestExternalReferencesPropertyDeclared (8) — property exists + uses correct $ref
+                                                (parametrized × 4 schemas)
+- TestExternalReferencesIsOptional (4)       — field absent from required array
+                                                (parametrized × 4 schemas)
+- TestExternalReferencesValueAccepted (8)    — valid array accepted + empty rejected
+                                                (parametrized × 4 schemas)
+
+Coverage areas:
+- externalReferences wiring: property presence, $ref target, optional status
+- Behavioral: valid value accepted, empty array rejected
+- Schema meta-validity: all 4 consumer schemas valid Draft-07
+
+Total parametrized test cases: ~24 (4 schemas × multiple classes)
+"""

--- a/scripts/hooks/tests/test_consumer_mappings_per_framework_wiring.py
+++ b/scripts/hooks/tests/test_consumer_mappings_per_framework_wiring.py
@@ -1,0 +1,691 @@
+#!/usr/bin/env python3
+"""
+Tests for the selective per-framework wiring in risks + controls mappings.
+
+Per ADR-019 D5 and ADR-020 D5, risks.schema.json and controls.schema.json
+declare a mappings block with a hybrid shape:
+- Per-property strict wiring for mitre-atlas, iso-22989, eu-ai-act (regex via
+  $ref to frameworks.schema.json#/definitions/framework-mapping-patterns).
+- Loose additionalProperties catch-all for stride, nist-ai-rmf, owasp-top10-llm
+  whose current YAML content does not match the ADR-022 D5b canonical regexes.
+
+The decision is deliberate and selective: only frameworks whose current YAML
+content already matches the canonical regexes receive per-property strict
+wiring. Subsequent content normalisation will fix the remaining frameworks.
+
+Coverage:
+- risks and controls schemas each have per-property mitre-atlas/iso-22989/eu-ai-act.
+- additionalProperties catch-all is present.
+- mitre-atlas "AML.T0020" validates; "aml-t0020" is rejected.
+- stride "tampering" passes (loose path — not yet normalised to PascalCase).
+- Unknown framework key "made-up-framework" is rejected via propertyNames.
+- Current risks.yaml and controls.yaml still pass check-jsonschema.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+from jsonschema.exceptions import SchemaError
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT7
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+# ============================================================================
+# Module-level constants — current-YAML-content audit data
+# ============================================================================
+
+# Consumer schemas receiving the hybrid wiring.
+CONSUMER_SCHEMAS = [
+    ("risks.schema.json", "risk"),
+    ("controls.schema.json", "control"),
+]
+
+# These frameworks get strict per-property wiring because their current YAML
+# content already matches the ADR-022 D5b canonical regex patterns.
+STRICTLY_WIRED_FRAMEWORKS = {"mitre-atlas", "iso-22989", "eu-ai-act"}
+
+# These frameworks fall through to the loose additionalProperties catch-all
+# because current YAML uses non-canonical short forms:
+#   nist-ai-rmf:     GV-6.2, MS-2.11     — short prefix; pattern needs GOVERN/MAP/...
+#   owasp-top10-llm: LLM01, LLM09        — missing version year; pattern needs LLM\d{2}:\d{4}
+#   stride:          tampering, spoofing  — lowercase-kebab; pattern needs PascalCase
+LOOSE_FRAMEWORKS = {"stride", "nist-ai-rmf", "owasp-top10-llm"}
+
+# mitre-atlas valid examples drawn from current risks.yaml content.
+MITRE_ATLAS_VALID: list[str] = [
+    "AML.T0020",
+    "AML.M0011",
+    "AML.T0010.002",
+]
+
+# mitre-atlas malformed examples that must be rejected after strict wiring.
+MITRE_ATLAS_INVALID: list[str] = [
+    "aml-t0020",  # lowercase-kebab (external-references surface)
+    "AML.T20",  # short technique ID
+    "AML.X0020",  # non-T/M letter
+]
+
+# stride current-YAML values that must still pass via the loose catch-all.
+STRIDE_LOOSE_VALID: list[str] = [
+    "tampering",
+    "spoofing",
+    "repudiation",
+    "information-disclosure",
+    "denial-of-service",
+]
+
+# nist-ai-rmf current-YAML values (short prefix form).
+NIST_LOOSE_VALID: list[str] = ["GV-6.2", "MS-2.11", "MS-2.3"]
+
+# owasp-top10-llm current-YAML values (missing version year).
+OWASP_LOOSE_VALID: list[str] = ["LLM01", "LLM05", "LLM09"]
+
+# iso-22989 bare strings from current personas.yaml.
+ISO_VALID: list[str] = [
+    "AI Producer",
+    "AI Customer (application builder)",
+    "Arbitrary descriptor",
+]
+
+# eu-ai-act is currently empty in YAML; any Article-form value should pass.
+EU_AI_ACT_VALID: list[str] = ["Article 5", "Article 5(1)", "Article 50"]
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+def _load_schema(schemas_dir: Path, filename: str) -> dict:
+    path = schemas_dir / filename
+    if not path.is_file():
+        pytest.fail(f"Schema not found: {path}")
+    with open(path) as fh:
+        return json.load(fh)
+
+
+def _make_registry(schemas_dir: Path) -> Registry:
+    """
+    Build a referencing.Registry that resolves bare-filename $refs against
+    schemas in the given directory. Replaces the deprecated jsonschema.RefResolver.
+    """
+
+    def retrieve(uri: str):
+        # The validator hands us the URI portion of a $ref; for our refs the
+        # URI is a bare schema filename relative to schemas_dir.
+        name = uri.rsplit("/", 1)[-1]
+        path = schemas_dir / name
+        with open(path) as fh:
+            return Resource.from_contents(json.load(fh), default_specification=DRAFT7)
+
+    return Registry(retrieve=retrieve)
+
+
+@pytest.fixture(scope="module")
+def risks_schema(risk_map_schemas_dir: Path) -> dict:
+    return _load_schema(risk_map_schemas_dir, "risks.schema.json")
+
+
+@pytest.fixture(scope="module")
+def controls_schema(risk_map_schemas_dir: Path) -> dict:
+    return _load_schema(risk_map_schemas_dir, "controls.schema.json")
+
+
+@pytest.fixture(scope="module")
+def schemas_registry(risk_map_schemas_dir: Path) -> Registry:
+    """Shared registry for risks + controls cross-file $ref resolution."""
+    return _make_registry(risk_map_schemas_dir)
+
+
+def _get_mappings_schema(schema: dict, entity_key: str) -> dict:
+    """Extract definitions/<entity>/properties/mappings from a schema."""
+    mappings = schema.get("definitions", {}).get(entity_key, {}).get("properties", {}).get("mappings")
+    if mappings is None:
+        pytest.fail(f"definitions/{entity_key}/properties/mappings not found")
+    return mappings
+
+
+# ============================================================================
+# Schema meta-validity
+# ============================================================================
+
+
+class TestSchemaMetaValidity:
+    """risks.schema.json and controls.schema.json must each be valid Draft-07."""
+
+    @pytest.mark.parametrize("schema_file,entity_key", CONSUMER_SCHEMAS, ids=["risks", "controls"])
+    def test_schema_passes_draft07_metaschema(self, risk_map_schemas_dir: Path, schema_file: str, entity_key: str):
+        """
+        Test that each consumer schema is valid Draft-07.
+
+        Given: A consumer schema file
+        When: Draft7Validator.check_schema() is called
+        Then: No SchemaError is raised
+        """
+        schema = _load_schema(risk_map_schemas_dir, schema_file)
+        try:
+            Draft7Validator.check_schema(schema)
+        except SchemaError as exc:
+            pytest.fail(f"{schema_file} is not valid Draft-07: {exc.message}")
+
+
+# ============================================================================
+# Structural shape of mappings (hybrid wiring)
+# ============================================================================
+
+
+class TestMappingsStructure:
+    """
+    The mappings block in risks/controls must have the hybrid wiring shape:
+    per-property strict entries + loose catch-all.
+    """
+
+    @pytest.mark.parametrize("schema_file,entity_key", CONSUMER_SCHEMAS, ids=["risks", "controls"])
+    def test_mappings_has_additional_properties_catch_all(
+        self, risk_map_schemas_dir: Path, schema_file: str, entity_key: str
+    ):
+        """
+        Test that the loose catch-all additionalProperties is present.
+
+        Given: The mappings sub-schema in a consumer schema
+        When: Its additionalProperties is examined
+        Then: It is type:array with items type:string
+        """
+        schema = _load_schema(risk_map_schemas_dir, schema_file)
+        mappings = _get_mappings_schema(schema, entity_key)
+        additional = mappings.get("additionalProperties")
+        assert additional is not None, f"{schema_file} mappings must declare additionalProperties catch-all"
+        assert additional.get("type") == "array", "additionalProperties catch-all must be type: array"
+        assert additional.get("items", {}).get("type") == "string", "catch-all items must be type: string"
+
+    @pytest.mark.parametrize("schema_file,entity_key", CONSUMER_SCHEMAS, ids=["risks", "controls"])
+    @pytest.mark.parametrize("framework_key", sorted(STRICTLY_WIRED_FRAMEWORKS))
+    def test_strictly_wired_framework_declared_in_properties(
+        self, risk_map_schemas_dir: Path, schema_file: str, entity_key: str, framework_key: str
+    ):
+        """
+        Test that per-property entries for mitre-atlas/iso-22989/eu-ai-act exist.
+
+        Given: The mappings sub-schema properties block in a consumer schema
+        When: A strictly-wired framework key is looked up
+        Then: It is present
+        """
+        schema = _load_schema(risk_map_schemas_dir, schema_file)
+        mappings = _get_mappings_schema(schema, entity_key)
+        props = mappings.get("properties", {})
+        assert framework_key in props, (
+            f"{schema_file} mappings.properties must declare '{framework_key}' "
+            "(strictly-wired per ADR-019 D5 / ADR-020 D5)"
+        )
+
+
+# ============================================================================
+# mitre-atlas strict wiring — valid / invalid behavioral tests
+# ============================================================================
+
+
+class TestMitreAtlasStrictWiring:
+    """
+    mitre-atlas items must match ^AML\\.(T|M)\\d{4}(\\.\\d{3})?$ per ADR-022 D5b.
+    All 34 distinct values in the current corpus match this pattern, so strict
+    wiring is safe.
+    """
+
+    @pytest.mark.parametrize("valid_id", MITRE_ATLAS_VALID)
+    def test_mitre_atlas_valid_accepted_in_risks(
+        self, risks_schema: dict, schemas_registry: Registry, valid_id: str
+    ):
+        """
+        Test that canonical mitre-atlas IDs pass in risks mappings.
+
+        Given: risks mappings schema with mitre-atlas strict wiring
+        When: {"mitre-atlas": [<valid_id>]} is validated
+        Then: No errors are raised
+        """
+        mappings = _get_mappings_schema(risks_schema, "risk")
+        validator = Draft7Validator(mappings, registry=schemas_registry)
+        errors = list(validator.iter_errors({"mitre-atlas": [valid_id]}))
+        assert not errors, f"risks mitre-atlas {valid_id!r} must be accepted; got: {[e.message for e in errors]}"
+
+    @pytest.mark.parametrize("invalid_id", MITRE_ATLAS_INVALID)
+    def test_mitre_atlas_invalid_rejected_in_risks(
+        self, risks_schema: dict, schemas_registry: Registry, invalid_id: str
+    ):
+        """
+        Test that malformed mitre-atlas IDs are rejected in risks mappings.
+
+        Given: risks mappings schema with mitre-atlas strict wiring
+        When: {"mitre-atlas": [<invalid_id>]} is validated
+        Then: ValidationError is raised
+        """
+        mappings = _get_mappings_schema(risks_schema, "risk")
+        validator = Draft7Validator(mappings, registry=schemas_registry)
+        errors = list(validator.iter_errors({"mitre-atlas": [invalid_id]}))
+        assert errors, f"risks mitre-atlas malformed ID {invalid_id!r} must be rejected"
+
+    @pytest.mark.parametrize("valid_id", MITRE_ATLAS_VALID)
+    def test_mitre_atlas_valid_accepted_in_controls(
+        self, controls_schema: dict, schemas_registry: Registry, valid_id: str
+    ):
+        """
+        Test that canonical mitre-atlas IDs pass in controls mappings.
+
+        Given: controls mappings schema with mitre-atlas strict wiring
+        When: {"mitre-atlas": [<valid_id>]} is validated
+        Then: No errors are raised
+        """
+        mappings = _get_mappings_schema(controls_schema, "control")
+        validator = Draft7Validator(mappings, registry=schemas_registry)
+        errors = list(validator.iter_errors({"mitre-atlas": [valid_id]}))
+        assert not errors, (
+            f"controls mitre-atlas {valid_id!r} must be accepted; got: {[e.message for e in errors]}"
+        )
+
+    @pytest.mark.parametrize("invalid_id", MITRE_ATLAS_INVALID)
+    def test_mitre_atlas_invalid_rejected_in_controls(
+        self, controls_schema: dict, schemas_registry: Registry, invalid_id: str
+    ):
+        """
+        Test that malformed mitre-atlas IDs are rejected in controls mappings.
+
+        Given: controls mappings schema with mitre-atlas strict wiring
+        When: {"mitre-atlas": [<invalid_id>]} is validated
+        Then: ValidationError is raised
+        """
+        mappings = _get_mappings_schema(controls_schema, "control")
+        validator = Draft7Validator(mappings, registry=schemas_registry)
+        errors = list(validator.iter_errors({"mitre-atlas": [invalid_id]}))
+        assert errors, f"controls mitre-atlas malformed ID {invalid_id!r} must be rejected"
+
+
+# ============================================================================
+# iso-22989 and eu-ai-act strict wiring — valid / invalid behavioral tests
+# ============================================================================
+
+
+class TestIsoAndEuAiActStrictWiring:
+    """
+    iso-22989 uses bare string items with no pattern constraint (deliberately
+    permissive per A1 design — any non-empty string is valid). eu-ai-act items
+    must match ^Article\\s\\d+(\\(\\d+\\))?$ per ADR-022 D5b.
+
+    Both frameworks receive per-property strict wiring in the risks and controls
+    mappings schemas via $ref to framework-mapping-patterns in
+    frameworks.schema.json.
+    """
+
+    @pytest.mark.parametrize("valid_value", ISO_VALID)
+    def test_iso_22989_valid_accepted_in_risks(
+        self, risks_schema: dict, schemas_registry: Registry, valid_value: str
+    ):
+        """
+        Test that iso-22989 bare-string descriptors pass in risks mappings.
+
+        Given: risks mappings schema with iso-22989 strict wiring
+        When: {"iso-22989": [<valid_value>]} is validated
+        Then: No errors are raised (iso-22989 is permissive; any string is valid)
+        """
+        mappings = _get_mappings_schema(risks_schema, "risk")
+        validator = Draft7Validator(mappings, registry=schemas_registry)
+        errors = list(validator.iter_errors({"iso-22989": [valid_value]}))
+        assert not errors, f"risks iso-22989 {valid_value!r} must be accepted; got: {[e.message for e in errors]}"
+
+    @pytest.mark.parametrize("valid_value", ISO_VALID)
+    def test_iso_22989_valid_accepted_in_controls(
+        self, controls_schema: dict, schemas_registry: Registry, valid_value: str
+    ):
+        """
+        Test that iso-22989 bare-string descriptors pass in controls mappings.
+
+        Given: controls mappings schema with iso-22989 strict wiring
+        When: {"iso-22989": [<valid_value>]} is validated
+        Then: No errors are raised
+        """
+        mappings = _get_mappings_schema(controls_schema, "control")
+        validator = Draft7Validator(mappings, registry=schemas_registry)
+        errors = list(validator.iter_errors({"iso-22989": [valid_value]}))
+        assert not errors, (
+            f"controls iso-22989 {valid_value!r} must be accepted; got: {[e.message for e in errors]}"
+        )
+
+    @pytest.mark.parametrize("valid_value", EU_AI_ACT_VALID)
+    def test_eu_ai_act_valid_accepted_in_risks(
+        self, risks_schema: dict, schemas_registry: Registry, valid_value: str
+    ):
+        """
+        Test that eu-ai-act Article-form values pass in risks mappings.
+
+        Given: risks mappings schema with eu-ai-act strict wiring
+        When: {"eu-ai-act": [<valid_value>]} in ^Article\\s\\d+(\\(\\d+\\))?$ form is validated
+        Then: No errors are raised
+        """
+        mappings = _get_mappings_schema(risks_schema, "risk")
+        validator = Draft7Validator(mappings, registry=schemas_registry)
+        errors = list(validator.iter_errors({"eu-ai-act": [valid_value]}))
+        assert not errors, f"risks eu-ai-act {valid_value!r} must be accepted; got: {[e.message for e in errors]}"
+
+    @pytest.mark.parametrize("valid_value", EU_AI_ACT_VALID)
+    def test_eu_ai_act_valid_accepted_in_controls(
+        self, controls_schema: dict, schemas_registry: Registry, valid_value: str
+    ):
+        """
+        Test that eu-ai-act Article-form values pass in controls mappings.
+
+        Given: controls mappings schema with eu-ai-act strict wiring
+        When: {"eu-ai-act": [<valid_value>]} is validated
+        Then: No errors are raised
+        """
+        mappings = _get_mappings_schema(controls_schema, "control")
+        validator = Draft7Validator(mappings, registry=schemas_registry)
+        errors = list(validator.iter_errors({"eu-ai-act": [valid_value]}))
+        assert not errors, (
+            f"controls eu-ai-act {valid_value!r} must be accepted; got: {[e.message for e in errors]}"
+        )
+
+    @pytest.mark.parametrize(
+        "invalid_value",
+        [
+            "Article",  # no article number
+            "article-5",  # lowercase-kebab form (rejected by strict pattern)
+            "Art 5",  # abbreviated prefix
+        ],
+    )
+    def test_eu_ai_act_invalid_rejected_in_risks(
+        self, risks_schema: dict, schemas_registry: Registry, invalid_value: str
+    ):
+        """
+        Test that malformed eu-ai-act values are rejected in risks mappings.
+
+        Given: risks mappings schema with eu-ai-act strict wiring
+        When: {"eu-ai-act": [<invalid_value>]} with a non-Article-form value is validated
+        Then: ValidationError is raised (strict pattern ^Article\\s\\d+(\\(\\d+\\))?$ rejects it)
+        """
+        mappings = _get_mappings_schema(risks_schema, "risk")
+        validator = Draft7Validator(mappings, registry=schemas_registry)
+        errors = list(validator.iter_errors({"eu-ai-act": [invalid_value]}))
+        assert errors, f"risks eu-ai-act malformed value {invalid_value!r} must be rejected"
+
+    @pytest.mark.parametrize(
+        "invalid_value",
+        [
+            "Article",  # no article number
+            "article-5",  # lowercase-kebab form (rejected by strict pattern)
+            "Art 5",  # abbreviated prefix
+        ],
+    )
+    def test_eu_ai_act_invalid_rejected_in_controls(
+        self, controls_schema: dict, schemas_registry: Registry, invalid_value: str
+    ):
+        """
+        Test that malformed eu-ai-act values are rejected in controls mappings.
+
+        Given: controls mappings schema with eu-ai-act strict wiring
+        When: {"eu-ai-act": [<invalid_value>]} is validated
+        Then: ValidationError is raised
+        """
+        mappings = _get_mappings_schema(controls_schema, "control")
+        validator = Draft7Validator(mappings, registry=schemas_registry)
+        errors = list(validator.iter_errors({"eu-ai-act": [invalid_value]}))
+        assert errors, f"controls eu-ai-act malformed value {invalid_value!r} must be rejected"
+
+
+# ============================================================================
+# Loose frameworks — current content must still pass via catch-all
+# ============================================================================
+
+
+class TestLooseFrameworksPassThrough:
+    """
+    stride, nist-ai-rmf, and owasp-top10-llm fall through to the loose
+    additionalProperties catch-all. Their current YAML content does not match
+    the ADR-022 D5b canonical regexes and will be normalised by subsequent
+    content fixes.
+    """
+
+    @pytest.mark.parametrize("value", STRIDE_LOOSE_VALID)
+    def test_stride_current_content_accepted_in_risks(
+        self, risks_schema: dict, schemas_registry: Registry, value: str
+    ):
+        """
+        Test that current stride values (lowercase-kebab) pass via the catch-all.
+
+        Given: risks mappings with stride pointing to loose catch-all
+        When: {"stride": [<value>]} is validated
+        Then: No errors are raised (loose path; subsequent content fixes will normalise)
+        """
+        mappings = _get_mappings_schema(risks_schema, "risk")
+        validator = Draft7Validator(mappings, registry=schemas_registry)
+        errors = list(validator.iter_errors({"stride": [value]}))
+        assert not errors, (
+            f"stride value {value!r} must be accepted via loose catch-all; got: {[e.message for e in errors]}"
+        )
+
+    @pytest.mark.parametrize("value", NIST_LOOSE_VALID)
+    def test_nist_ai_rmf_current_content_accepted_in_risks(
+        self, risks_schema: dict, schemas_registry: Registry, value: str
+    ):
+        """
+        Test that current nist-ai-rmf values (short prefix form) pass via the catch-all.
+
+        Given: risks mappings with nist-ai-rmf pointing to loose catch-all
+        When: {"nist-ai-rmf": [<value>]} is validated
+        Then: No errors are raised
+        """
+        mappings = _get_mappings_schema(risks_schema, "risk")
+        validator = Draft7Validator(mappings, registry=schemas_registry)
+        errors = list(validator.iter_errors({"nist-ai-rmf": [value]}))
+        assert not errors, (
+            f"nist-ai-rmf value {value!r} must be accepted via loose catch-all; got: {[e.message for e in errors]}"
+        )
+
+    @pytest.mark.parametrize("value", OWASP_LOOSE_VALID)
+    def test_owasp_top10_llm_current_content_accepted_in_risks(
+        self, risks_schema: dict, schemas_registry: Registry, value: str
+    ):
+        """
+        Test that current owasp-top10-llm values (no version year) pass via catch-all.
+
+        Given: risks mappings with owasp-top10-llm pointing to loose catch-all
+        When: {"owasp-top10-llm": [<value>]} is validated
+        Then: No errors are raised
+        """
+        mappings = _get_mappings_schema(risks_schema, "risk")
+        validator = Draft7Validator(mappings, registry=schemas_registry)
+        errors = list(validator.iter_errors({"owasp-top10-llm": [value]}))
+        assert not errors, (
+            f"owasp-top10-llm value {value!r} must be accepted via loose catch-all; "
+            f"got: {[e.message for e in errors]}"
+        )
+
+    @pytest.mark.parametrize("value", STRIDE_LOOSE_VALID)
+    def test_stride_current_content_accepted_in_controls(
+        self, controls_schema: dict, schemas_registry: Registry, value: str
+    ):
+        """
+        Test that current stride values (lowercase-kebab) pass via the controls catch-all.
+
+        Given: controls mappings with stride pointing to loose catch-all
+        When: {"stride": [<value>]} is validated
+        Then: No errors are raised (controls hybrid wiring)
+        """
+        mappings = _get_mappings_schema(controls_schema, "control")
+        validator = Draft7Validator(mappings, registry=schemas_registry)
+        errors = list(validator.iter_errors({"stride": [value]}))
+        assert not errors, (
+            f"controls stride value {value!r} must be accepted via loose catch-all; "
+            f"got: {[e.message for e in errors]}"
+        )
+
+    @pytest.mark.parametrize("value", NIST_LOOSE_VALID)
+    def test_nist_ai_rmf_current_content_accepted_in_controls(
+        self, controls_schema: dict, schemas_registry: Registry, value: str
+    ):
+        """
+        Test that current nist-ai-rmf values (short prefix form) pass via the controls catch-all.
+
+        Given: controls mappings with nist-ai-rmf pointing to loose catch-all
+        When: {"nist-ai-rmf": [<value>]} is validated
+        Then: No errors are raised
+        """
+        mappings = _get_mappings_schema(controls_schema, "control")
+        validator = Draft7Validator(mappings, registry=schemas_registry)
+        errors = list(validator.iter_errors({"nist-ai-rmf": [value]}))
+        assert not errors, (
+            f"controls nist-ai-rmf value {value!r} must be accepted via loose catch-all; "
+            f"got: {[e.message for e in errors]}"
+        )
+
+    @pytest.mark.parametrize("value", OWASP_LOOSE_VALID)
+    def test_owasp_top10_llm_current_content_accepted_in_controls(
+        self, controls_schema: dict, schemas_registry: Registry, value: str
+    ):
+        """
+        Test that current owasp-top10-llm values (no version year) pass via controls catch-all.
+
+        Given: controls mappings with owasp-top10-llm pointing to loose catch-all
+        When: {"owasp-top10-llm": [<value>]} is validated
+        Then: No errors are raised
+        """
+        mappings = _get_mappings_schema(controls_schema, "control")
+        validator = Draft7Validator(mappings, registry=schemas_registry)
+        errors = list(validator.iter_errors({"owasp-top10-llm": [value]}))
+        assert not errors, (
+            f"controls owasp-top10-llm value {value!r} must be accepted via loose catch-all; "
+            f"got: {[e.message for e in errors]}"
+        )
+
+
+# ============================================================================
+# Unknown framework key rejected via propertyNames
+# ============================================================================
+
+
+class TestUnknownFrameworkRejected:
+    """Unknown framework keys must be rejected via propertyNames."""
+
+    @pytest.mark.parametrize("schema_file,entity_key", CONSUMER_SCHEMAS, ids=["risks", "controls"])
+    def test_unknown_framework_key_rejected(
+        self,
+        risk_map_schemas_dir: Path,
+        schemas_registry: Registry,
+        schema_file: str,
+        entity_key: str,
+    ):
+        """
+        Test that an unregistered framework key is rejected.
+
+        Given: A mappings object with made-up-framework: ["some-value"]
+        When: It is validated against the mappings schema
+        Then: ValidationError is raised (propertyNames constraint)
+        """
+        schema = _load_schema(risk_map_schemas_dir, schema_file)
+        mappings = _get_mappings_schema(schema, entity_key)
+        validator = Draft7Validator(mappings, registry=schemas_registry)
+        errors = list(validator.iter_errors({"made-up-framework": ["some-value"]}))
+        assert errors, (
+            f"{schema_file}: unknown framework key 'made-up-framework' must be rejected via propertyNames"
+        )
+
+
+# ============================================================================
+# Regression — current YAML files still validate
+# ============================================================================
+
+
+class TestCurrentYamlStillValid:
+    """
+    Current risks.yaml and controls.yaml must continue to pass check-jsonschema
+    (the hybrid wiring is additive and backward-compatible).
+    """
+
+    def test_risks_yaml_passes_check_jsonschema(self, risk_map_schemas_dir: Path, risk_map_yaml_dir: Path):
+        """
+        Test that risks.yaml continues to validate against risks.schema.json.
+
+        Given: The current risks.yaml on disk
+        When: check-jsonschema is run with risks.schema.json
+        Then: Exit code is 0
+        """
+        result = subprocess.run(
+            [
+                "check-jsonschema",
+                "--base-uri",
+                f"file://{risk_map_schemas_dir}/",
+                "--schemafile",
+                str(risk_map_schemas_dir / "risks.schema.json"),
+                str(risk_map_yaml_dir / "risks.yaml"),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"risks.yaml must remain valid against risks.schema.json:\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_controls_yaml_passes_check_jsonschema(self, risk_map_schemas_dir: Path, risk_map_yaml_dir: Path):
+        """
+        Test that controls.yaml continues to validate against controls.schema.json.
+
+        Given: The current controls.yaml on disk
+        When: check-jsonschema is run with controls.schema.json
+        Then: Exit code is 0
+        """
+        result = subprocess.run(
+            [
+                "check-jsonschema",
+                "--base-uri",
+                f"file://{risk_map_schemas_dir}/",
+                "--schemafile",
+                str(risk_map_schemas_dir / "controls.schema.json"),
+                str(risk_map_yaml_dir / "controls.yaml"),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"controls.yaml must remain valid against controls.schema.json:\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+
+# ============================================================================
+# Test summary
+# ============================================================================
+"""
+Test Summary
+============
+Test classes: 8
+
+- TestSchemaMetaValidity (2)              — risks + controls valid Draft-07
+- TestMappingsStructure                   — catch-all present, strictly-wired
+                                            keys declared (parametrized × 2 schemas
+                                            × 3 frameworks)
+- TestMitreAtlasStrictWiring              — parametrized: 3 valid + 3 invalid ×
+                                            risks + controls (12 cases)
+- TestIsoAndEuAiActStrictWiring           — iso-22989: 3 valid × risks + controls;
+                                            eu-ai-act: 3 valid × risks + controls;
+                                            eu-ai-act: 3 invalid × risks + controls
+                                            (18 cases)
+- TestLooseFrameworksPassThrough          — stride/nist-ai-rmf/owasp-top10-llm
+                                            current content accepted for BOTH
+                                            risks and controls (22 cases)
+- TestUnknownFrameworkRejected (2)        — propertyNames rejects unknown key
+                                            (parametrized × 2 schemas)
+- TestCurrentYamlStillValid (2)           — risks.yaml + controls.yaml still pass
+
+Coverage areas:
+- Hybrid wiring shape: strict per-property entries + loose catch-all
+- Strict frameworks: mitre-atlas, iso-22989, eu-ai-act
+- Loose frameworks: stride, nist-ai-rmf, owasp-top10-llm (pending content
+  normalisation to canonical forms)
+- Behavioral: valid/invalid for all strictly-wired frameworks × risks + controls;
+              loose pass-through × risks + controls; unknown key rejected
+- Regression: current YAML backward-compatible
+"""

--- a/scripts/hooks/tests/test_consumer_yaml_check_jsonschema_integration.py
+++ b/scripts/hooks/tests/test_consumer_yaml_check_jsonschema_integration.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Integration tests for check-jsonschema acceptance across the consumer YAML corpus.
+
+The load-bearing acceptance criterion for the additive schema work is that
+all current YAML files continue to pass check-jsonschema. These tests shell
+out to check-jsonschema (the same tool used by the pre-commit hook) to give
+end-to-end coverage from the file layer.
+
+This complements the unit-level behavioral tests in the individual schema
+test modules (test_consumer_external_references_refs.py,
+test_components_mappings_field.py, test_consumer_mappings_per_framework_wiring.py,
+test_lifecycle_stage_order_range.py, test_riskmap_prose_strict.py,
+test_persona_site_data_prose_items.py).
+
+Coverage:
+- risks.yaml passes risks.schema.json.
+- controls.yaml passes controls.schema.json.
+- components.yaml passes components.schema.json.
+- personas.yaml passes personas.schema.json.
+- lifecycle-stage.yaml passes lifecycle-stage.schema.json.
+
+Note: riskmap.schema.json and persona-site-data.schema.json are not paired
+with a standalone YAML file in the repo (riskmap.schema.json is a shared
+utility; persona-site-data.schema.json validates generated JSON). Those
+schemas are validated structurally in their respective unit test modules.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+# ============================================================================
+# Module-level constants
+# ============================================================================
+
+# Each tuple: (schema filename, yaml filename).
+YAML_SCHEMA_PAIRS: list[tuple[str, str]] = [
+    ("risks.schema.json", "risks.yaml"),
+    ("controls.schema.json", "controls.yaml"),
+    ("components.schema.json", "components.yaml"),
+    ("personas.schema.json", "personas.yaml"),
+    ("lifecycle-stage.schema.json", "lifecycle-stage.yaml"),
+]
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+def _run_check_jsonschema(schema_path: Path, yaml_path: Path, base_uri: str) -> subprocess.CompletedProcess:
+    """
+    Invoke check-jsonschema for one (schema, yaml) pair.
+
+    Uses list-form invocation (no shell=True) and captures output.
+    """
+    return subprocess.run(
+        [
+            "check-jsonschema",
+            "--base-uri",
+            base_uri,
+            "--schemafile",
+            str(schema_path),
+            str(yaml_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+# ============================================================================
+# Integration checks — all YAML files remain valid
+# ============================================================================
+
+
+class TestAllConsumerYamlFilesPassCheckJsonschema:
+    """
+    All five consumer YAML files must pass check-jsonschema. This is the
+    machine-readable form of the additive-edit acceptance criterion:
+    additive schema changes must not break existing content.
+    """
+
+    @pytest.mark.parametrize(
+        "schema_file,yaml_file",
+        YAML_SCHEMA_PAIRS,
+        ids=[pair[1] for pair in YAML_SCHEMA_PAIRS],
+    )
+    def test_yaml_passes_check_jsonschema(
+        self,
+        risk_map_schemas_dir: Path,
+        risk_map_yaml_dir: Path,
+        schema_file: str,
+        yaml_file: str,
+    ):
+        """
+        Test that each consumer YAML passes check-jsonschema.
+
+        Given: The current YAML file on disk and its consumer schema
+        When: check-jsonschema --base-uri --schemafile is invoked
+        Then: Exit code is 0 (additive edits must not break existing content)
+        """
+        schema_path = risk_map_schemas_dir / schema_file
+        yaml_path = risk_map_yaml_dir / yaml_file
+        base_uri = f"file://{risk_map_schemas_dir}/"
+
+        result = _run_check_jsonschema(schema_path, yaml_path, base_uri)
+        assert result.returncode == 0, (
+            f"{yaml_file} must pass {schema_file}:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+
+# ============================================================================
+# Sanity — check-jsonschema is available
+# ============================================================================
+
+
+class TestCheckJsonschemaAvailable:
+    """check-jsonschema must be installed for the integration tests to be meaningful."""
+
+    def test_check_jsonschema_is_on_path(self):
+        """
+        Test that check-jsonschema is available in the environment.
+
+        Given: The test execution environment
+        When: check-jsonschema --version is run
+        Then: Exit code is 0 and some version string is output
+
+        If this test fails the integration tests above will also fail with a
+        FileNotFoundError rather than an assertion error, which is confusing.
+        This check makes that dependency explicit.
+        """
+        result = subprocess.run(
+            ["check-jsonschema", "--version"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            "check-jsonschema is not installed or not on PATH; install with: pip install check-jsonschema"
+        )
+
+
+# ============================================================================
+# Test summary
+# ============================================================================
+"""
+Test Summary
+============
+Test classes: 2
+
+- TestAllConsumerYamlFilesPassCheckJsonschema — parametrized: 5 (schema, yaml)
+                                                pairs; each must return
+                                                check-jsonschema exit=0
+- TestCheckJsonschemaAvailable (1)            — sanity: tool present and
+                                                executable
+
+Coverage areas:
+- Acceptance criterion: all current YAML remains valid against its consumer schema
+- Schemas covered: risks, controls, components, personas, lifecycle-stage
+- End-to-end: uses check-jsonschema (same as pre-commit hook) rather than
+  Python jsonschema, giving real cross-$ref resolution and file-URI handling
+"""

--- a/scripts/hooks/tests/test_lifecycle_stage_order_range.py
+++ b/scripts/hooks/tests/test_lifecycle_stage_order_range.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""
+Tests for the lifecycle-stage.schema.json order range constraint.
+
+Per ADR-022 D4, definitions/lifecycleStage/properties/order declares
+minimum: 1 and maximum: 8 to bound the eight enumerated lifecycle stages
+(planning through maintenance). The constraint is additive: existing YAML
+with valid order values continues to pass.
+
+Coverage:
+- order property has minimum: 1 declared.
+- order property has maximum: 8 declared.
+- Values 1–8 are accepted.
+- Value 0 is rejected (below minimum).
+- Value 9 is rejected (above maximum).
+- Negative integers are rejected.
+- Non-integer types continue to be rejected (existing behavior).
+- Current lifecycle-stage.yaml passes validation unchanged.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+from jsonschema.exceptions import SchemaError
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+# ============================================================================
+# Module-level constants
+# ============================================================================
+
+SCHEMA_FILE = "lifecycle-stage.schema.json"
+ENTITY_KEY = "lifecycleStage"
+
+# Valid order values: exactly 1–8 per the 8 named lifecycle stages.
+VALID_ORDER_VALUES: list[int] = [1, 2, 3, 4, 5, 6, 7, 8]
+
+# Values that must be rejected after the minimum/maximum constraint is added.
+INVALID_ORDER_VALUES_TOO_LOW: list[int] = [0, -1, -100]
+INVALID_ORDER_VALUES_TOO_HIGH: list[int] = [9, 10, 100]
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="module")
+def lifecycle_schema(risk_map_schemas_dir: Path) -> dict:
+    """Parsed lifecycle-stage.schema.json."""
+    path = risk_map_schemas_dir / SCHEMA_FILE
+    if not path.is_file():
+        pytest.fail(f"Schema not found: {path}")
+    with open(path) as fh:
+        return json.load(fh)
+
+
+@pytest.fixture(scope="module")
+def order_property_schema(lifecycle_schema: dict) -> dict:
+    """The order property sub-schema from definitions/lifecycleStage/properties."""
+    order_schema = lifecycle_schema.get("definitions", {}).get(ENTITY_KEY, {}).get("properties", {}).get("order")
+    if order_schema is None:
+        pytest.fail(
+            f"definitions/{ENTITY_KEY}/properties/order not found in {SCHEMA_FILE}. "
+            "The schema may not yet be initialised."
+        )
+    return order_schema
+
+
+@pytest.fixture(scope="module")
+def order_validator(order_property_schema: dict) -> Draft7Validator:
+    """Draft-07 validator over the order property schema alone."""
+    return Draft7Validator(order_property_schema)
+
+
+# ============================================================================
+# Schema meta-validity
+# ============================================================================
+
+
+class TestSchemaMetaValidity:
+    """lifecycle-stage.schema.json must be valid Draft-07 after ADR-022 D4."""
+
+    def test_schema_passes_draft07_metaschema(self, lifecycle_schema: dict):
+        """
+        Test that lifecycle-stage.schema.json is a valid Draft-07 schema.
+
+        Given: lifecycle-stage.schema.json loaded
+        When: Draft7Validator.check_schema() is called
+        Then: No SchemaError is raised
+        """
+        try:
+            Draft7Validator.check_schema(lifecycle_schema)
+        except SchemaError as exc:
+            pytest.fail(f"{SCHEMA_FILE} is not valid Draft-07: {exc.message}")
+
+
+# ============================================================================
+# Order range constraint — structural declarations
+# ============================================================================
+
+
+class TestOrderRangeConstraintDeclared:
+    """
+    The order property must declare minimum: 1 and maximum: 8 after ADR-022 D4.
+    """
+
+    def test_order_property_exists(self, lifecycle_schema: dict):
+        """
+        Test that the order property is declared.
+
+        Given: definitions/lifecycleStage/properties in lifecycle-stage.schema.json
+        When: The keys are inspected
+        Then: 'order' is present
+        """
+        props = lifecycle_schema.get("definitions", {}).get(ENTITY_KEY, {}).get("properties", {})
+        assert "order" in props, f"definitions/{ENTITY_KEY}/properties/order must exist in {SCHEMA_FILE}"
+
+    def test_order_minimum_is_one(self, order_property_schema: dict):
+        """
+        Test that minimum: 1 is declared on the order property.
+
+        Given: definitions/lifecycleStage/properties/order
+        When: Its minimum is examined
+        Then: It is 1 (ADR-022 D4)
+        """
+        assert order_property_schema.get("minimum") == 1, "order property must declare minimum: 1 (ADR-022 D4)"
+
+    def test_order_maximum_is_eight(self, order_property_schema: dict):
+        """
+        Test that maximum: 8 is declared on the order property.
+
+        Given: definitions/lifecycleStage/properties/order
+        When: Its maximum is examined
+        Then: It is 8 (ADR-022 D4 — 8 lifecycle stages)
+        """
+        assert order_property_schema.get("maximum") == 8, (
+            "order property must declare maximum: 8 (ADR-022 D4 — 8 lifecycle stages)"
+        )
+
+    def test_order_type_is_integer(self, order_property_schema: dict):
+        """
+        Test that the order property type is still integer (not changed by the edit).
+
+        Given: definitions/lifecycleStage/properties/order
+        When: Its type is examined
+        Then: It is 'integer' (unchanged by ADR-022 D4)
+        """
+        assert order_property_schema.get("type") == "integer", "order property type must remain 'integer'"
+
+
+# ============================================================================
+# Order range constraint — behavioral validation
+# ============================================================================
+
+
+class TestOrderRangeBehavior:
+    """Valid values 1–8 must be accepted; out-of-range values must be rejected."""
+
+    @pytest.mark.parametrize("value", VALID_ORDER_VALUES)
+    def test_valid_order_value_accepted(self, order_validator: Draft7Validator, value: int):
+        """
+        Test that each in-range integer (1–8) is accepted.
+
+        Given: A Draft-07 validator over the order property schema
+        When: An integer from 1 to 8 is validated
+        Then: No errors are raised
+        """
+        errors = list(order_validator.iter_errors(value))
+        assert not errors, f"order value {value} must be accepted (within 1–8); got: {[e.message for e in errors]}"
+
+    @pytest.mark.parametrize("value", INVALID_ORDER_VALUES_TOO_LOW)
+    def test_order_value_below_minimum_rejected(self, order_validator: Draft7Validator, value: int):
+        """
+        Test that values below 1 (including 0 and negatives) are rejected.
+
+        Given: A Draft-07 validator over the order property schema
+        When: An integer less than 1 is validated
+        Then: ValidationError is raised (minimum: 1 violated)
+        """
+        errors = list(order_validator.iter_errors(value))
+        assert errors, f"order value {value} must be rejected (below minimum: 1)"
+
+    @pytest.mark.parametrize("value", INVALID_ORDER_VALUES_TOO_HIGH)
+    def test_order_value_above_maximum_rejected(self, order_validator: Draft7Validator, value: int):
+        """
+        Test that values above 8 are rejected.
+
+        Given: A Draft-07 validator over the order property schema
+        When: An integer greater than 8 is validated
+        Then: ValidationError is raised (maximum: 8 violated)
+        """
+        errors = list(order_validator.iter_errors(value))
+        assert errors, f"order value {value} must be rejected (above maximum: 8)"
+
+    def test_boundary_minimum_exactly_one_accepted(self, order_validator: Draft7Validator):
+        """
+        Test the lower boundary (1) explicitly.
+
+        Given: A Draft-07 validator over the order property schema
+        When: The integer 1 is validated
+        Then: No errors are raised (boundary is inclusive)
+        """
+        errors = list(order_validator.iter_errors(1))
+        assert not errors, "order value 1 must be accepted (inclusive lower boundary)"
+
+    def test_boundary_maximum_exactly_eight_accepted(self, order_validator: Draft7Validator):
+        """
+        Test the upper boundary (8) explicitly.
+
+        Given: A Draft-07 validator over the order property schema
+        When: The integer 8 is validated
+        Then: No errors are raised (boundary is inclusive)
+        """
+        errors = list(order_validator.iter_errors(8))
+        assert not errors, "order value 8 must be accepted (inclusive upper boundary)"
+
+    def test_float_order_value_rejected(self, order_validator: Draft7Validator):
+        """
+        Test that a float is rejected (type must be integer).
+
+        Given: A Draft-07 validator over the order property schema
+        When: The float 1.5 is validated
+        Then: ValidationError is raised (type: integer not satisfied by float)
+        """
+        errors = list(order_validator.iter_errors(1.5))
+        assert errors, "Float order value 1.5 must be rejected (type: integer required)"
+
+    def test_string_order_value_rejected(self, order_validator: Draft7Validator):
+        """
+        Test that a string is rejected as an order value.
+
+        Given: A Draft-07 validator over the order property schema
+        When: The string "1" is validated
+        Then: ValidationError is raised
+        """
+        errors = list(order_validator.iter_errors("1"))
+        assert errors, "String order value '1' must be rejected (type: integer required)"
+
+
+# ============================================================================
+# Regression — current lifecycle-stage.yaml still validates
+# ============================================================================
+
+
+class TestCurrentYamlStillValid:
+    """
+    The current lifecycle-stage.yaml must continue to pass check-jsonschema
+    after ADR-022 D4 (all existing order values are within 1–8).
+    """
+
+    def test_lifecycle_stage_yaml_passes_check_jsonschema(
+        self, risk_map_schemas_dir: Path, risk_map_yaml_dir: Path
+    ):
+        """
+        Test that current lifecycle-stage.yaml validates after ADR-022 D4.
+
+        Given: The current lifecycle-stage.yaml on disk
+        When: check-jsonschema is run with lifecycle-stage.schema.json
+        Then: Exit code is 0 (all existing order values are in range 1–8)
+        """
+        result = subprocess.run(
+            [
+                "check-jsonschema",
+                "--base-uri",
+                f"file://{risk_map_schemas_dir}/",
+                "--schemafile",
+                str(risk_map_schemas_dir / SCHEMA_FILE),
+                str(risk_map_yaml_dir / "lifecycle-stage.yaml"),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"lifecycle-stage.yaml must remain valid after ADR-022 D4:\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+
+# ============================================================================
+# Test summary
+# ============================================================================
+"""
+Test Summary
+============
+Test classes: 4
+
+- TestSchemaMetaValidity (1)              — schema valid Draft-07
+- TestOrderRangeConstraintDeclared (4)    — property exists, minimum=1, maximum=8,
+                                            type remains integer
+- TestOrderRangeBehavior                  — parametrized: 8 valid (1–8) accepted;
+                                            3 too-low + 3 too-high rejected;
+                                            explicit boundary tests ×2;
+                                            float + string rejected (13 total)
+- TestCurrentYamlStillValid (1)           — regression: lifecycle-stage.yaml passes
+
+Coverage areas:
+- ADR-022 D4: minimum/maximum constraint declared
+- Boundary testing: values 1 and 8 (inclusive)
+- Out-of-range rejection: 0, negatives, 9, 10, 100
+- Type enforcement: float and string rejected
+- Backward compatibility: current YAML unchanged
+"""

--- a/scripts/hooks/tests/test_persona_site_data_prose_items.py
+++ b/scripts/hooks/tests/test_persona_site_data_prose_items.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""
+Tests for the persona-site-data.schema.json prose extension.
+
+Per ADR-016 D5, persona-site-data.schema.json definitions/prose accepts the
+old array<string | array<string>> shape AND two new structured prose-item
+shapes that the site builder emits after sentinel expansion:
+
+- { "type": "ref", "id": <string>, "title": <string> }
+  Intra-document sentinel resolution: {{idRiskFoo}} → a typed reference to a
+  risk/control/persona/component ID.
+
+- { "type": "link", "title": <string>, "url": <string> }
+  External sentinel resolution: {{ref:identifier}} → a URL from a matching
+  externalReferences entry.
+
+Additionally, an optional externalReferences property is declared on the
+per-persona, per-risk, and per-control array items. Those objects use
+additionalProperties: false, so the new field MUST be explicitly declared in
+their properties blocks to be accepted.
+
+The current builder emits the old all-strings shape; that shape must continue
+to validate after the extension (forward compatibility).
+
+Coverage:
+- definitions/prose accepts string items (old shape preserved).
+- definitions/prose accepts nested string-array items (old shape preserved).
+- definitions/prose accepts ref-type objects.
+- definitions/prose accepts link-type objects.
+- definitions/prose accepts mixed arrays (strings + structured items).
+- Ref-type object missing required field is rejected.
+- Link-type object with non-https url is rejected.
+- personas[], risks[], controls[] items declare externalReferences in properties.
+- externalReferences is NOT in the required array of those items.
+- A valid externalReferences value is accepted by the extended schema.
+- persona-site-data.schema.json passes Draft-07 meta-schema check.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+from jsonschema.exceptions import SchemaError
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT7
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+# ============================================================================
+# Module-level constants
+# ============================================================================
+
+SCHEMA_FILE = "persona-site-data.schema.json"
+
+# Old-shape prose values that must continue to pass (forward compatibility).
+OLD_SHAPE_VALID: list = [
+    ["A plain string"],
+    ["First", "Second", "Third"],
+    [["bullet one", "bullet two"]],
+    ["Paragraph", ["bullet a", "bullet b"]],
+    [],  # The existing prose definition has no outer minItems, so [] is valid.
+]
+
+# New ref-type structured item shapes per ADR-016 D5.
+VALID_REF_ITEMS: list[dict] = [
+    {"type": "ref", "id": "riskDataPoisoning", "title": "Data Poisoning"},
+    {"type": "ref", "id": "controlInputValidation", "title": "Input Validation"},
+    {"type": "ref", "id": "personaModelCreator", "title": "Model Creator"},
+]
+
+# New link-type structured item shapes per ADR-016 D5.
+VALID_LINK_ITEMS: list[dict] = [
+    {"type": "link", "title": "MITRE ATLAS", "url": "https://atlas.mitre.org"},
+    {"type": "link", "title": "NIST AI RMF", "url": "https://airc.nist.gov/Home"},
+    {"type": "link", "title": "OWASP", "url": "https://owasp.org"},
+]
+
+# Prose arrays mixing strings and new structured items.
+VALID_MIXED_PROSE: list[list] = [
+    ["Plain text intro", {"type": "ref", "id": "riskFoo", "title": "Risk Foo"}],
+    [{"type": "link", "title": "Source", "url": "https://example.com"}, "Additional text"],
+]
+
+# A valid externalReferences value per external-references.schema.json.
+VALID_EXTERNAL_REFERENCES = [
+    {
+        "type": "paper",
+        "id": "smith-2024-example",
+        "title": "A Sample Paper",
+        "url": "https://example.com/paper",
+    }
+]
+
+# Top-level array property names that must gain the externalReferences field.
+TOP_LEVEL_ARRAYS = ["personas", "risks", "controls"]
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="module")
+def persona_site_schema(risk_map_schemas_dir: Path) -> dict:
+    """Parsed persona-site-data.schema.json."""
+    path = risk_map_schemas_dir / SCHEMA_FILE
+    if not path.is_file():
+        pytest.fail(f"Schema not found: {path}")
+    with open(path) as fh:
+        return json.load(fh)
+
+
+@pytest.fixture(scope="module")
+def prose_schema(persona_site_schema: dict) -> dict:
+    """The definitions/prose sub-schema."""
+    prose = persona_site_schema.get("definitions", {}).get("prose")
+    if prose is None:
+        pytest.fail(f"definitions/prose not found in {SCHEMA_FILE}")
+    return prose
+
+
+@pytest.fixture(scope="module")
+def prose_validator(prose_schema: dict) -> Draft7Validator:
+    """Draft-07 validator over definitions/prose."""
+    return Draft7Validator(prose_schema)
+
+
+@pytest.fixture(scope="module")
+def registry(risk_map_schemas_dir: Path) -> Registry:
+    """
+    referencing.Registry that resolves bare-filename $refs against the
+    schemas directory. Replaces the deprecated jsonschema.RefResolver.
+    """
+
+    def retrieve(uri: str):
+        # The validator hands us the URI portion of a $ref; for our refs the
+        # URI is a bare schema filename relative to risk_map_schemas_dir.
+        name = uri.rsplit("/", 1)[-1]
+        path = risk_map_schemas_dir / name
+        with open(path) as fh:
+            return Resource.from_contents(json.load(fh), default_specification=DRAFT7)
+
+    return Registry(retrieve=retrieve)
+
+
+# ============================================================================
+# Schema meta-validity
+# ============================================================================
+
+
+class TestSchemaMetaValidity:
+    """persona-site-data.schema.json must be valid Draft-07."""
+
+    def test_schema_passes_draft07_metaschema(self, persona_site_schema: dict):
+        """
+        Test that persona-site-data.schema.json is a valid Draft-07 schema.
+
+        Given: persona-site-data.schema.json loaded
+        When: Draft7Validator.check_schema() is called
+        Then: No SchemaError is raised
+        """
+        try:
+            Draft7Validator.check_schema(persona_site_schema)
+        except SchemaError as exc:
+            pytest.fail(f"{SCHEMA_FILE} is not valid Draft-07: {exc.message}")
+
+
+# ============================================================================
+# Forward compatibility — old all-strings shape still validates
+# ============================================================================
+
+
+class TestOldShapeStillValid:
+    """
+    The current site builder emits all-strings prose. That shape must continue
+    to validate (extension is additive).
+    """
+
+    @pytest.mark.parametrize("value", OLD_SHAPE_VALID)
+    def test_old_prose_shape_accepted(self, prose_validator: Draft7Validator, value: list):
+        """
+        Test that old-shape prose arrays continue to pass.
+
+        Given: The extended definitions/prose schema
+        When: An old-shape prose value (strings and nested string arrays) is validated
+        Then: No errors are raised (backward compatible)
+        """
+        errors = list(prose_validator.iter_errors(value))
+        assert not errors, f"Old-shape prose {value!r} must still be accepted; got: {[e.message for e in errors]}"
+
+
+# ============================================================================
+# New ref-type items accepted
+# ============================================================================
+
+
+class TestRefTypeItemsAccepted:
+    """
+    definitions/prose must accept ref-type objects as items.
+    """
+
+    @pytest.mark.parametrize("ref_item", VALID_REF_ITEMS)
+    def test_ref_type_item_accepted_in_prose(self, prose_validator: Draft7Validator, ref_item: dict):
+        """
+        Test that a ref-type prose item is accepted.
+
+        Given: A prose array containing one ref-type structured item
+        When: It is validated against definitions/prose
+        Then: No errors are raised
+
+        The ref shape is { type: "ref", id: <string>, title: <string> },
+        emitted by the site builder when {{idRiskFoo}} sentinels are resolved
+        (ADR-016 D5).
+        """
+        errors = list(prose_validator.iter_errors([ref_item]))
+        assert not errors, (
+            f"ref-type item {ref_item!r} must be accepted in prose; got: {[e.message for e in errors]}"
+        )
+
+    def test_ref_item_missing_id_rejected(self, prose_validator: Draft7Validator):
+        """
+        Test that a ref-type item missing the required 'id' field is rejected.
+
+        Given: A ref-type object without 'id'
+        When: It is validated as a prose item
+        Then: ValidationError is raised
+        """
+        bad_ref = {"type": "ref", "title": "Missing Id"}
+        errors = list(prose_validator.iter_errors([bad_ref]))
+        assert errors, "ref-type item missing 'id' must be rejected"
+
+    def test_ref_item_missing_title_rejected(self, prose_validator: Draft7Validator):
+        """
+        Test that a ref-type item missing the required 'title' field is rejected.
+
+        Given: A ref-type object without 'title'
+        When: It is validated as a prose item
+        Then: ValidationError is raised
+        """
+        bad_ref = {"type": "ref", "id": "riskFoo"}
+        errors = list(prose_validator.iter_errors([bad_ref]))
+        assert errors, "ref-type item missing 'title' must be rejected"
+
+
+# ============================================================================
+# New link-type items accepted
+# ============================================================================
+
+
+class TestLinkTypeItemsAccepted:
+    """
+    definitions/prose must accept link-type objects as items.
+    """
+
+    @pytest.mark.parametrize("link_item", VALID_LINK_ITEMS)
+    def test_link_type_item_accepted_in_prose(self, prose_validator: Draft7Validator, link_item: dict):
+        """
+        Test that a link-type prose item is accepted.
+
+        Given: A prose array containing one link-type structured item
+        When: It is validated against definitions/prose
+        Then: No errors are raised
+
+        The link shape is { type: "link", title: <string>, url: <string> },
+        emitted by the site builder when {{ref:identifier}} sentinels are
+        resolved (ADR-016 D5).
+        """
+        errors = list(prose_validator.iter_errors([link_item]))
+        assert not errors, (
+            f"link-type item {link_item!r} must be accepted in prose; got: {[e.message for e in errors]}"
+        )
+
+    def test_link_item_non_https_url_rejected(self, prose_validator: Draft7Validator):
+        """
+        Test that a link-type item with a non-https URL is rejected.
+
+        Given: A link-type object with url='http://example.com' (non-https)
+        When: It is validated as a prose item
+        Then: ValidationError is raised (url must be https)
+        """
+        bad_link = {"type": "link", "title": "Bad URL", "url": "http://example.com"}
+        errors = list(prose_validator.iter_errors([bad_link]))
+        assert errors, "link-type item with http:// url must be rejected"
+
+    def test_link_item_missing_url_rejected(self, prose_validator: Draft7Validator):
+        """
+        Test that a link-type item missing the required 'url' field is rejected.
+
+        Given: A link-type object without 'url'
+        When: It is validated as a prose item
+        Then: ValidationError is raised
+        """
+        bad_link = {"type": "link", "title": "No URL"}
+        errors = list(prose_validator.iter_errors([bad_link]))
+        assert errors, "link-type item missing 'url' must be rejected"
+
+    def test_link_item_missing_title_rejected(self, prose_validator: Draft7Validator):
+        """
+        Test that a link-type item missing the required 'title' field is rejected.
+
+        Given: A link-type object without 'title'
+        When: It is validated as a prose item
+        Then: ValidationError is raised
+        """
+        bad_link = {"type": "link", "url": "https://example.com"}
+        errors = list(prose_validator.iter_errors([bad_link]))
+        assert errors, "link-type item missing 'title' must be rejected"
+
+
+# ============================================================================
+# Mixed-content prose arrays accepted
+# ============================================================================
+
+
+class TestMixedContentProseAccepted:
+    """
+    Heterogeneous prose arrays mixing strings, nested string arrays, and
+    structured items (ref/link) must all be accepted by the extended schema.
+    """
+
+    @pytest.mark.parametrize("value", VALID_MIXED_PROSE)
+    def test_mixed_prose_array_accepted(self, prose_validator: Draft7Validator, value: list):
+        """
+        Test that mixed-content prose arrays are accepted.
+
+        Given: A prose array containing both plain strings and structured items
+        When: It is validated against the extended definitions/prose
+        Then: No errors are raised
+        """
+        errors = list(prose_validator.iter_errors(value))
+        assert not errors, f"Mixed prose array {value!r} must be accepted; got: {[e.message for e in errors]}"
+
+
+# ============================================================================
+# externalReferences property added to personas/risks/controls item objects
+# ============================================================================
+
+
+class TestExternalReferencesOnTopLevelItems:
+    """
+    The per-persona, per-risk, and per-control item objects must each declare
+    an optional externalReferences property in their properties block. Because
+    those objects use additionalProperties: false, the field must be explicitly
+    present in properties to be accepted.
+    """
+
+    @pytest.mark.parametrize("array_key", TOP_LEVEL_ARRAYS)
+    def test_external_references_declared_in_item_properties(self, persona_site_schema: dict, array_key: str):
+        """
+        Test that externalReferences is declared in each top-level item's properties.
+
+        Given: The per-item object schema for personas/risks/controls in
+               persona-site-data.schema.json
+        When: Its properties block is inspected
+        Then: 'externalReferences' is present
+        """
+        item_schema = persona_site_schema.get("properties", {}).get(array_key, {}).get("items", {})
+        item_props = item_schema.get("properties", {})
+        assert "externalReferences" in item_props, (
+            f"persona-site-data.schema.json {array_key}[].properties must declare "
+            f"'externalReferences' (additionalProperties: false requires "
+            f"explicit declaration)"
+        )
+
+    @pytest.mark.parametrize("array_key", TOP_LEVEL_ARRAYS)
+    def test_external_references_not_in_required(self, persona_site_schema: dict, array_key: str):
+        """
+        Test that externalReferences is not in the required array of item objects.
+
+        Given: The per-item object schema for personas/risks/controls
+        When: Its required array is inspected
+        Then: 'externalReferences' is absent (field is optional)
+        """
+        item_schema = persona_site_schema.get("properties", {}).get(array_key, {}).get("items", {})
+        required = item_schema.get("required", [])
+        assert "externalReferences" not in required, (
+            f"{array_key}[] item schema must NOT require externalReferences "
+            "(optional passthrough field per ADR-016 D5)"
+        )
+
+    @pytest.mark.parametrize("array_key", TOP_LEVEL_ARRAYS)
+    def test_valid_external_references_accepted_by_item(
+        self,
+        persona_site_schema: dict,
+        registry: Registry,
+        array_key: str,
+    ):
+        """
+        Test that a valid externalReferences value is accepted for each item type.
+
+        Given: The externalReferences property entry in a top-level item schema
+        When: A valid externalReferences array is validated against the $ref'd schema
+        Then: No errors are raised
+        """
+        item_schema = persona_site_schema.get("properties", {}).get(array_key, {}).get("items", {})
+        ext_ref_entry = item_schema.get("properties", {}).get("externalReferences")
+        assert ext_ref_entry is not None, f"externalReferences not in {array_key}[] item properties yet"
+        ref_target = ext_ref_entry.get("$ref")
+        assert ref_target, f"externalReferences in {array_key}[] must use $ref"
+
+        resolved_schema = registry.resolver(base_uri="").lookup(ref_target).contents
+        validator = Draft7Validator(resolved_schema, registry=registry)
+        errors = list(validator.iter_errors(VALID_EXTERNAL_REFERENCES))
+        assert not errors, (
+            f"Valid externalReferences must be accepted for {array_key}[] item; got: {[e.message for e in errors]}"
+        )
+
+    @pytest.mark.parametrize("array_key", TOP_LEVEL_ARRAYS)
+    def test_additional_properties_still_false_on_item(self, persona_site_schema: dict, array_key: str):
+        """
+        Test that additionalProperties: false is still set on each item schema.
+
+        Given: The per-item object schema for personas/risks/controls
+        When: Its additionalProperties is examined
+        Then: It is still False (unchanged; the new field is declared in properties)
+        """
+        item_schema = persona_site_schema.get("properties", {}).get(array_key, {}).get("items", {})
+        assert item_schema.get("additionalProperties") is False, (
+            f"{array_key}[] item must retain additionalProperties: false "
+            "(externalReferences was added to properties, not as a relaxation)"
+        )
+
+
+# ============================================================================
+# Test summary
+# ============================================================================
+"""
+Test Summary
+============
+Test classes: 7
+
+- TestSchemaMetaValidity (1)                  — schema valid Draft-07
+- TestOldShapeStillValid                       — parametrized: 5 old-shape prose
+                                                 values still accepted
+- TestRefTypeItemsAccepted (3)                 — 2 parametrized valid ref items
+                                                 accepted; missing-id + missing-title
+                                                 rejected
+- TestLinkTypeItemsAccepted (4)                — 3 parametrized valid link items
+                                                 accepted; non-https url + missing-url
+                                                 + missing-title rejected
+- TestMixedContentProseAccepted (2)            — parametrized: 2 mixed arrays accepted
+- TestExternalReferencesOnTopLevelItems        — parametrized × 3 arrays:
+                                                 declared in properties, not in
+                                                 required, valid value accepted,
+                                                 additionalProperties:false retained
+                                                 (12 cases)
+
+Coverage areas:
+- prose extension: ref/link items, mixed content
+- Forward compatibility: old all-strings shape still valid
+- externalReferences on personas/risks/controls items (declared, optional)
+- additionalProperties: false unchanged on item objects
+- Structured item validation: missing fields rejected, non-https url rejected
+"""

--- a/scripts/hooks/tests/test_riskmap_prose_strict.py
+++ b/scripts/hooks/tests/test_riskmap_prose_strict.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""
+Tests for the prose-strict sibling definition in riskmap.schema.json.
+
+Per ADRs 018/019/020/021 D4, riskmap.schema.json defines a constrained
+sibling at definitions/utils/prose-strict alongside the existing
+definitions/utils/text. prose-strict:
+- Accepts the same array<string | array<string>> shape (one nesting level max).
+- Adds minItems: 1 on the outer array (empty prose rejected).
+- Adds minLength: 1 on string items at both depths (empty strings rejected).
+- Keeps minItems: 1 on the inner string array.
+- Does NOT replace definitions/utils/text (coexistence required).
+- Is NOT yet referenced by any consumer schema; consumer migration is a
+  follow-on tightening.
+
+Coverage:
+- definitions/utils/text is unchanged (coexistence).
+- definitions/utils/prose-strict exists as a sibling.
+- prose-strict outer array has minItems: 1.
+- prose-strict string items at depth-1 have minLength: 1.
+- prose-strict inner array has minItems: 1 and its string items have minLength: 1.
+- Empty outer array rejected by prose-strict, accepted by text.
+- Empty string rejected by prose-strict (both depth levels).
+- Empty inner array rejected by prose-strict, accepted by text.
+- Valid non-empty strings and arrays accepted by both.
+- riskmap.schema.json passes Draft-07 meta-schema check.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+from jsonschema.exceptions import SchemaError
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+# ============================================================================
+# Module-level constants
+# ============================================================================
+
+SCHEMA_FILE = "riskmap.schema.json"
+
+# Valid prose values that both text and prose-strict must accept.
+VALID_PROSE_VALUES: list = [
+    ["A single string item"],
+    ["First item", "Second item"],
+    [["bullet one", "bullet two"]],  # inner array at depth 1
+    ["Prose paragraph", ["item a", "item b"]],  # mixed
+]
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="module")
+def riskmap_schema(risk_map_schemas_dir: Path) -> dict:
+    """Parsed riskmap.schema.json."""
+    path = risk_map_schemas_dir / SCHEMA_FILE
+    if not path.is_file():
+        pytest.fail(f"Schema not found: {path}")
+    with open(path) as fh:
+        return json.load(fh)
+
+
+@pytest.fixture(scope="module")
+def utils_definitions(riskmap_schema: dict) -> dict:
+    """The definitions/utils block from riskmap.schema.json."""
+    utils = riskmap_schema.get("definitions", {}).get("utils", {})
+    assert utils, "definitions/utils must exist in riskmap.schema.json"
+    return utils
+
+
+@pytest.fixture(scope="module")
+def text_schema(utils_definitions: dict) -> dict:
+    """The existing definitions/utils/text sub-schema."""
+    if "text" not in utils_definitions:
+        pytest.fail("definitions/utils/text not found — it must not have been removed")
+    return utils_definitions["text"]
+
+
+@pytest.fixture(scope="module")
+def prose_strict_schema(utils_definitions: dict) -> dict:
+    """The definitions/utils/prose-strict sub-schema."""
+    if "prose-strict" not in utils_definitions:
+        pytest.fail("definitions/utils/prose-strict not found in riskmap.schema.json.")
+    return utils_definitions["prose-strict"]
+
+
+@pytest.fixture(scope="module")
+def text_validator(text_schema: dict) -> Draft7Validator:
+    """Draft-07 validator over definitions/utils/text."""
+    return Draft7Validator(text_schema)
+
+
+@pytest.fixture(scope="module")
+def prose_strict_validator(prose_strict_schema: dict) -> Draft7Validator:
+    """Draft-07 validator over definitions/utils/prose-strict."""
+    return Draft7Validator(prose_strict_schema)
+
+
+# ============================================================================
+# Schema meta-validity
+# ============================================================================
+
+
+class TestSchemaMetaValidity:
+    """riskmap.schema.json must be a valid Draft-07 document."""
+
+    def test_riskmap_schema_passes_draft07_metaschema(self, riskmap_schema: dict):
+        """
+        Test that riskmap.schema.json is a valid Draft-07 schema.
+
+        Given: riskmap.schema.json loaded
+        When: Draft7Validator.check_schema() is called
+        Then: No SchemaError is raised
+        """
+        try:
+            Draft7Validator.check_schema(riskmap_schema)
+        except SchemaError as exc:
+            pytest.fail(f"{SCHEMA_FILE} is not valid Draft-07: {exc.message}")
+
+
+# ============================================================================
+# Coexistence — text must be unchanged
+# ============================================================================
+
+
+class TestTextDefinitionUnchanged:
+    """
+    definitions/utils/text must continue to exist with its original shape.
+    prose-strict is added as a sibling and does NOT replace text.
+    """
+
+    def test_text_definition_exists(self, utils_definitions: dict):
+        """
+        Test that definitions/utils/text is still present.
+
+        Given: definitions/utils in riskmap.schema.json
+        When: 'text' is looked up
+        Then: It is present (prose-strict must not replace it)
+        """
+        assert "text" in utils_definitions, (
+            "definitions/utils/text must still exist — prose-strict is a sibling, not a replacement"
+        )
+
+    def test_text_is_array_type(self, text_schema: dict):
+        """
+        Test that text remains an array shape.
+
+        Given: definitions/utils/text
+        When: Its type is examined
+        Then: It is 'array' (unchanged)
+        """
+        assert text_schema.get("type") == "array", "definitions/utils/text must remain type: array"
+
+    def test_text_has_no_min_items(self, text_schema: dict):
+        """
+        Test that text does not have minItems on the outer array.
+
+        Given: definitions/utils/text
+        When: Its minItems is checked
+        Then: It is absent (text accepts empty arrays; prose-strict does not)
+
+        This confirms the two definitions diverge intentionally.
+        """
+        assert "minItems" not in text_schema, (
+            "definitions/utils/text must NOT have minItems on the outer array "
+            "(prose-strict is the constrained sibling; text must remain permissive)"
+        )
+
+    def test_text_accepts_empty_outer_array(self, text_validator: Draft7Validator):
+        """
+        Test that text accepts an empty outer array.
+
+        Given: definitions/utils/text validator
+        When: An empty list is validated
+        Then: No errors are raised (text does not constrain outer minItems)
+        """
+        errors = list(text_validator.iter_errors([]))
+        assert not errors, (
+            "definitions/utils/text must accept empty outer array (prose-strict diverges here with minItems: 1)"
+        )
+
+
+# ============================================================================
+# prose-strict definition presence and structural shape
+# ============================================================================
+
+
+class TestProseStrictPresence:
+    """definitions/utils/prose-strict must exist as a sibling to text."""
+
+    def test_prose_strict_definition_exists(self, utils_definitions: dict):
+        """
+        Test that definitions/utils/prose-strict is declared.
+
+        Given: definitions/utils in riskmap.schema.json
+        When: 'prose-strict' is looked up
+        Then: It is present
+        """
+        assert "prose-strict" in utils_definitions, (
+            "definitions/utils/prose-strict must be declared in riskmap.schema.json"
+        )
+
+    def test_prose_strict_is_array_type(self, prose_strict_schema: dict):
+        """
+        Test that prose-strict is an array type.
+
+        Given: definitions/utils/prose-strict
+        When: Its type is examined
+        Then: It is 'array' (same outer shape as text)
+        """
+        assert prose_strict_schema.get("type") == "array", "definitions/utils/prose-strict must be type: array"
+
+    def test_prose_strict_has_outer_min_items_one(self, prose_strict_schema: dict):
+        """
+        Test that prose-strict has minItems: 1 on the outer array.
+
+        Given: definitions/utils/prose-strict
+        When: Its minItems is examined
+        Then: It is 1 (empty prose rejected per ADR-018/019/020/021 D4)
+        """
+        assert prose_strict_schema.get("minItems") == 1, (
+            "definitions/utils/prose-strict must declare minItems: 1 on the outer array"
+        )
+
+
+# ============================================================================
+# prose-strict — string item minLength constraints
+# ============================================================================
+
+
+class TestProseStrictStringConstraints:
+    """prose-strict must enforce minLength: 1 on string items at both depths."""
+
+    def test_depth1_string_items_have_min_length(self, prose_strict_schema: dict):
+        """
+        Test that depth-1 string items (direct outer array members) have minLength: 1.
+
+        Given: The items block of prose-strict
+        When: The oneOf branch for direct strings is examined
+        Then: That branch declares minLength: 1
+        """
+        items = prose_strict_schema.get("items", {})
+        one_of = items.get("oneOf", [])
+        assert one_of, "prose-strict items must use oneOf for string | array branching"
+
+        # Find the string branch.
+        string_branches = [b for b in one_of if b.get("type") == "string"]
+        assert string_branches, "prose-strict items oneOf must include a type:string branch"
+        string_branch = string_branches[0]
+        assert string_branch.get("minLength") == 1, "prose-strict depth-1 string items must have minLength: 1"
+
+    def test_depth2_string_items_have_min_length(self, prose_strict_schema: dict):
+        """
+        Test that depth-2 string items (inside the nested array) have minLength: 1.
+
+        Given: The inner array branch in prose-strict items oneOf
+        When: The inner array's items are examined
+        Then: Inner string items declare minLength: 1
+        """
+        items = prose_strict_schema.get("items", {})
+        one_of = items.get("oneOf", [])
+        array_branches = [b for b in one_of if b.get("type") == "array"]
+        assert array_branches, "prose-strict items oneOf must include a type:array branch"
+        inner_array = array_branches[0]
+        inner_items = inner_array.get("items", {})
+        assert inner_items.get("minLength") == 1, (
+            "prose-strict depth-2 string items (inside nested array) must have minLength: 1"
+        )
+
+    def test_inner_array_has_min_items_one(self, prose_strict_schema: dict):
+        """
+        Test that the inner array (nested list) requires at least one item.
+
+        Given: The inner array branch in prose-strict items oneOf
+        When: Its minItems is examined
+        Then: It is 1 (same as in definitions/utils/text)
+        """
+        items = prose_strict_schema.get("items", {})
+        one_of = items.get("oneOf", [])
+        array_branches = [b for b in one_of if b.get("type") == "array"]
+        assert array_branches, "prose-strict items oneOf must include a type:array branch"
+        inner_array = array_branches[0]
+        assert inner_array.get("minItems") == 1, "prose-strict inner array must have minItems: 1"
+
+
+# ============================================================================
+# Behavioral validation — prose-strict accepts valid prose
+# ============================================================================
+
+
+class TestProseStrictAcceptsValidProse:
+    """prose-strict must accept all non-empty, non-blank prose values."""
+
+    @pytest.mark.parametrize("value", VALID_PROSE_VALUES)
+    def test_valid_prose_accepted_by_prose_strict(self, prose_strict_validator: Draft7Validator, value: list):
+        """
+        Test that valid prose values are accepted by prose-strict.
+
+        Given: A non-empty prose array with non-empty strings
+        When: It is validated against prose-strict
+        Then: No errors are raised
+        """
+        errors = list(prose_strict_validator.iter_errors(value))
+        assert not errors, f"prose-strict must accept {value!r}; got: {[e.message for e in errors]}"
+
+    @pytest.mark.parametrize("value", VALID_PROSE_VALUES)
+    def test_valid_prose_accepted_by_text(self, text_validator: Draft7Validator, value: list):
+        """
+        Test that valid prose values are also accepted by the existing text definition.
+
+        Given: A non-empty prose array with non-empty strings
+        When: It is validated against definitions/utils/text
+        Then: No errors are raised (text must also accept these valid values)
+        """
+        errors = list(text_validator.iter_errors(value))
+        assert not errors, f"definitions/utils/text must accept {value!r}; got: {[e.message for e in errors]}"
+
+
+# ============================================================================
+# Behavioral validation — prose-strict rejects empty/blank values
+# ============================================================================
+
+
+class TestProseStrictRejectsEmptyValues:
+    """prose-strict must reject empty outer arrays and empty strings."""
+
+    def test_empty_outer_array_rejected_by_prose_strict(self, prose_strict_validator: Draft7Validator):
+        """
+        Test that an empty outer array is rejected by prose-strict.
+
+        Given: An empty list []
+        When: It is validated against prose-strict
+        Then: ValidationError is raised (minItems: 1 on outer array)
+        """
+        errors = list(prose_strict_validator.iter_errors([]))
+        assert errors, "prose-strict must reject empty outer array (minItems: 1)"
+
+    def test_empty_string_at_depth1_rejected_by_prose_strict(self, prose_strict_validator: Draft7Validator):
+        """
+        Test that an empty string at depth-1 is rejected by prose-strict.
+
+        Given: [""] — one empty-string item in the outer array
+        When: It is validated against prose-strict
+        Then: ValidationError is raised (minLength: 1)
+        """
+        errors = list(prose_strict_validator.iter_errors([""]))
+        assert errors, 'prose-strict must reject [""] (empty depth-1 string; minLength: 1)'
+
+    def test_empty_string_at_depth2_rejected_by_prose_strict(self, prose_strict_validator: Draft7Validator):
+        """
+        Test that an empty string inside a nested array is rejected by prose-strict.
+
+        Given: [[""]] — one nested array containing one empty string
+        When: It is validated against prose-strict
+        Then: ValidationError is raised (minLength: 1 on depth-2 items)
+        """
+        errors = list(prose_strict_validator.iter_errors([[""]]))
+        assert errors, 'prose-strict must reject [[""]] (empty depth-2 string; minLength: 1)'
+
+    def test_empty_inner_array_rejected_by_prose_strict(self, prose_strict_validator: Draft7Validator):
+        """
+        Test that an empty nested array is rejected by prose-strict.
+
+        Given: [[]] — an outer array containing one empty inner array
+        When: It is validated against prose-strict
+        Then: ValidationError is raised (minItems: 1 on inner array)
+        """
+        errors = list(prose_strict_validator.iter_errors([[]]))
+        assert errors, "prose-strict must reject [[]] (empty inner array; minItems: 1)"
+
+    def test_non_null_null_rejected_by_prose_strict(self, prose_strict_validator: Draft7Validator):
+        """
+        Test that null is rejected as a prose value.
+
+        Given: [null] — an outer array containing null
+        When: It is validated against prose-strict
+        Then: ValidationError is raised
+        """
+        errors = list(prose_strict_validator.iter_errors([None]))
+        assert errors, "prose-strict must reject [null]"
+
+
+# ============================================================================
+# Independence — text and prose-strict can be used independently
+# ============================================================================
+
+
+class TestDefinitionsAreIndependent:
+    """text and prose-strict are independent; neither references the other."""
+
+    def test_text_does_not_ref_prose_strict(self, text_schema: dict):
+        """
+        Test that definitions/utils/text does not reference prose-strict.
+
+        Given: definitions/utils/text
+        When: It is serialised to a string
+        Then: 'prose-strict' does not appear in it (no accidental cross-ref)
+        """
+        serialised = json.dumps(text_schema)
+        assert "prose-strict" not in serialised, "definitions/utils/text must not reference prose-strict"
+
+    def test_prose_strict_does_not_ref_text(self, prose_strict_schema: dict):
+        """
+        Test that definitions/utils/prose-strict does not reference text.
+
+        Given: definitions/utils/prose-strict
+        When: It is serialised to a string
+        Then: '/text' does not appear in it (no accidental cross-ref)
+        """
+        serialised = json.dumps(prose_strict_schema)
+        # Guard against accidental $ref to utils/text.
+        assert "utils/text" not in serialised, "definitions/utils/prose-strict must not $ref utils/text"
+
+
+# ============================================================================
+# Test summary
+# ============================================================================
+"""
+Test Summary
+============
+Test classes: 8
+
+- TestSchemaMetaValidity (1)               — riskmap.schema.json valid Draft-07
+- TestTextDefinitionUnchanged (4)          — text present, type=array, no outer
+                                             minItems, accepts empty outer array
+- TestProseStrictPresence (3)              — exists as sibling, type=array,
+                                             outer minItems=1
+- TestProseStrictStringConstraints (3)     — depth-1 minLength, depth-2 minLength,
+                                             inner array minItems
+- TestProseStrictAcceptsValidProse         — parametrized: 4 valid values accepted
+                                             by prose-strict AND text
+- TestProseStrictRejectsEmptyValues (5)    — empty outer, empty depth-1 string,
+                                             empty depth-2 string, empty inner
+                                             array, null item
+- TestDefinitionsAreIndependent (2)        — text does not ref prose-strict;
+                                             prose-strict does not ref text
+
+Coverage areas:
+- prose-strict existence, outer minItems, depth-1 minLength,
+  depth-2 minLength, inner array minItems
+- Coexistence: text unchanged (no minItems on outer, empty array accepted)
+- Behavioral: valid prose accepted; empty/blank rejected
+- Independence: no cross-referencing between text and prose-strict
+"""


### PR DESCRIPTION
## Conformance sweep A2: additive schema edits (consumer + prose-strict)

Closes #246

## Summary

- Wires the shared `external-references.schema.json` (from A1) and the per-framework `framework-mapping-patterns` regexes into the four consumer schemas (`risks` / `controls` / `components` / `personas`).
- Adds the `mappings` field to `components.schema.json` per ADR-018 D6 + ADR-022 D5c, activating `applicableTo: components` for framework cross-walks (supersedes the earlier "components do not participate" framing).
- Introduces `definitions/utils/prose-strict` as a sibling of `definitions/utils/text` in `riskmap.schema.json` per ADR-018/019/020/021 D4. Uses the constrained-sibling approach: consumer schemas migrate `$ref` independently in later sweep sub-PRs (no flag-day).
- Tightens `lifecycleStage.order` with `[1, 8]` range constraint per ADR-022 D4.
- Extends `persona-site-data.schema.json` for the new prose-item shapes (`{type: "ref", ...}` and `{type: "link", ...}`) per ADR-016 D5; passes `externalReferences` through to JSON output.
- **Hybrid wiring on `mappings`** keeps current YAML valid: the three non-canonical-form frameworks (`stride`, `nist-ai-rmf`, `owasp-top10-llm`) route through a loose catch-all rather than a strict regex. Strict tightening for those frameworks is deferred to a content-fix sub-PR in a later sweep wave; the deferral is hedged in `working-plans/phase-2-conformance-plan.md` § Phase B.
- 211 tests added across 7 new test files; 1760 full-repo pass / 6 skip with **0 deprecation warnings** — A2 also migrates the (deprecated) `jsonschema.RefResolver` pattern across 4 test files to the supported `referencing` library, setting a clean template for downstream sub-PRs that need cross-file `$ref` test patterns.

## Scope boundaries

In scope (this PR):
- Edits: `risk-map/schemas/{risks,controls,components,personas,riskmap,lifecycle-stage,persona-site-data}.schema.json` (7 schemas)
- New tests: 7 test files under `scripts/hooks/tests/` (`test_components_mappings_field.py`, `test_consumer_external_references_refs.py`, `test_consumer_mappings_per_framework_wiring.py`, `test_consumer_yaml_check_jsonschema_integration.py`, `test_lifecycle_stage_order_range.py`, `test_persona_site_data_prose_items.py`, `test_riskmap_prose_strict.py`)

Out of scope (deferred to later sweep sub-PRs):
- `additionalProperties: false` on any definition (task 2.2.6)
- `relevantQuestions` removal from `risks.schema.json` (task 2.2.5)
- `title.maxLength` constraints (task 2.2.7)
- Per-consumer `prose-strict` migrations (tasks 2.2.9b/c/d/e)
- Builder updates (`yaml_to_markdown.py`, `build_persona_site_data.py`) → A7
- Validator extensions (`controls`↔`components` mirror, category/subcategory nesting, lifecycle order uniqueness, MermaidConfigLoader fallback) → A4
- YAML content migration → the content-migration sub-PRs (B1, B2)
- B-series content-fix sub-issue for `stride`/`nist-ai-rmf`/`owasp-top10-llm` canonical-form normalization — deferred-with-hedge in plan § Phase B; promote at Phase B planning if a strict-tightening sub-PR (C1) expands to tighten mappings

## Test plan

- [ ] `pytest scripts/hooks/tests/test_components_mappings_field.py scripts/hooks/tests/test_consumer_external_references_refs.py scripts/hooks/tests/test_consumer_mappings_per_framework_wiring.py scripts/hooks/tests/test_consumer_yaml_check_jsonschema_integration.py scripts/hooks/tests/test_lifecycle_stage_order_range.py scripts/hooks/tests/test_persona_site_data_prose_items.py scripts/hooks/tests/test_riskmap_prose_strict.py` — all 211 A2 tests pass
- [ ] Full repo regression: `pytest` reports no new failures (1760 pass / 6 skip; A1+A2 baseline)
- [ ] **0 deprecation warnings** under `pytest -W error::DeprecationWarning` (RefResolver→referencing migration verified clean)
- [ ] `pre-commit run --all-files` clean
- [ ] `check-jsonschema` validates all current YAML against the updated schemas — develop's existing content remains valid under the additive constraints
- [ ] Spot-check: hybrid-wired frameworks (`stride`/`nist-ai-rmf`/`owasp-top10-llm`) accept current YAML via the loose catch-all; canonical-form frameworks (`mitre-atlas`/`iso-22989`/`eu-ai-act`) accept the existing strict-form entries
- [ ] Confirm no `additionalProperties: false`, no `relevantQuestions` removal, and no `prose-strict` consumer migration are present (additive-only invariant)



Co-Authored-By: AI Assistant <ai-assistant@coalitionforsecureai.org>

