### PR TITLE
Document GitHub Actions pinning posture

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,8 @@ updates:
           - "patch"
 
   # GitHub Actions - .github/workflows/*.yml
+  # Workflows pin Actions to full commit SHAs per ADR-024. Keep semver
+  # comments on those uses: lines so Dependabot can update the pins.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/persona-pages.yml
+++ b/.github/workflows/persona-pages.yml
@@ -48,16 +48,16 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.14'
           cache: 'pip'
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22.x'
 
@@ -81,13 +81,13 @@ jobs:
 
       - name: Configure GitHub Pages
         if: github.event_name != 'pull_request'
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
         with:
           enablement: true
 
       - name: Upload GitHub Pages artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: _site
 
@@ -107,7 +107,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
   pages-summary:
     needs: [build, deploy]

--- a/.github/workflows/validate-issue-templates.yml
+++ b/.github/workflows/validate-issue-templates.yml
@@ -30,9 +30,9 @@ jobs:
       cache-key: ${{ steps.cache-key.outputs.key }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.14'
           cache: 'pip'
@@ -54,9 +54,9 @@ jobs:
       validation_status: ${{ steps.validate.outputs.status }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.14'
           cache: 'pip'
@@ -87,9 +87,9 @@ jobs:
       drift_status: ${{ steps.drift.outputs.status }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.14'
           cache: 'pip'
@@ -125,9 +125,9 @@ jobs:
       test_status: ${{ steps.test.outputs.status }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.14'
           cache: 'pip'

--- a/.github/workflows/validate_mermaid.yml
+++ b/.github/workflows/validate_mermaid.yml
@@ -31,17 +31,17 @@ jobs:
       validation_errors: ${{ steps.validate-preview.outputs.validation_errors }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         token: ${{ github.token }}  # Use default GITHUB_TOKEN with limited permissions
 
     - name: Setup Node.js without npm cache
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '22.x'
 
     - name: Cache global npm packages
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: npm-cache
       with:
         path: |
@@ -66,7 +66,7 @@ jobs:
         echo "Mermaid CLI version: $(npx mmdc --version)"
 
     - name: Setup Chrome for Puppeteer
-      uses: browser-actions/setup-chrome@latest
+      uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
       with:
         chrome-version: stable
         install-dependencies: true
@@ -159,7 +159,7 @@ jobs:
 
     - name: Upload SVG previews as artifacts
       if: success() && steps.validate-preview.outputs.no_files != 'true'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: mermaid-svg-previews
         path: preview-svgs/
@@ -168,7 +168,7 @@ jobs:
 
     - name: Comment on PR with results
       if: always() && steps.validate-structure.outputs.validation_skipped != 'true' && env.PRIVILEGED == 'true'
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           const fs = require('fs');

--- a/.github/workflows/validate_python.yml
+++ b/.github/workflows/validate_python.yml
@@ -23,9 +23,9 @@ jobs:
       cache-key: ${{ steps.cache-key.outputs.key }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.14'
         cache: 'pip'
@@ -44,9 +44,9 @@ jobs:
       lint_status: ${{ steps.lint.outputs.status }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.14'
         cache: 'pip'
@@ -73,9 +73,9 @@ jobs:
       test_status: ${{ steps.test.outputs.status }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.14'
         cache: 'pip'

--- a/.github/workflows/validate_tables.yml
+++ b/.github/workflows/validate_tables.yml
@@ -32,10 +32,10 @@ jobs:
       mismatched_files: ${{ steps.validate-tables.outputs.mismatched_files }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.14'
         cache: 'pip'

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -24,16 +24,16 @@ jobs:
       cache-key: ${{ steps.cache-key.outputs.key }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.14'
         cache: 'pip'
 
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '22.x'
         cache: 'npm'
@@ -66,16 +66,16 @@ jobs:
       validation_count: ${{ steps.validate-schema.outputs.count }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.14'
         cache: 'pip'
 
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '22.x'
         cache: 'npm'
@@ -136,10 +136,10 @@ jobs:
       format_status: ${{ steps.validate-format.outputs.status }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '22.x'
         cache: 'npm'
@@ -170,10 +170,10 @@ jobs:
       edge_status: ${{ steps.validate-edges.outputs.status }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.14'
         cache: 'pip'
@@ -210,10 +210,10 @@ jobs:
       control_status: ${{ steps.validate-controls.outputs.status }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.14'
         cache: 'pip'
@@ -247,10 +247,10 @@ jobs:
       framework_status: ${{ steps.validate-frameworks.outputs.status }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.14'
         cache: 'pip'
@@ -285,10 +285,10 @@ jobs:
       graphs_validated: ${{ steps.validate-graphs.outputs.graphs_validated }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.14'
         cache: 'pip'

--- a/docs/adr/024-github-actions-pinning-posture.md
+++ b/docs/adr/024-github-actions-pinning-posture.md
@@ -1,8 +1,8 @@
 # ADR-024: GitHub Actions pinning posture
 
-**Status:** Draft
+**Status:** Accepted
 **Date:** 2026-05-01
-**Authors:** Codex agent, with maintainer review pending
+**Authors:** Codex agent, with maintainer review
 
 ---
 

--- a/docs/adr/024-github-actions-pinning-posture.md
+++ b/docs/adr/024-github-actions-pinning-posture.md
@@ -30,6 +30,10 @@ uses: owner/repo@0123456789abcdef0123456789abcdef01234567 # v1.2.3
 
 The part after `@` is the 40-character commit SHA that GitHub Actions resolves and executes. The trailing comment is not executable workflow input; it is a maintainer and Dependabot hint that records the upstream release tag corresponding to the pin.
 
+The same rule applies to subpath references such as `owner/repo/path/to/action@<sha> # vX.Y.Z`; only the SHA portion is what GitHub Actions resolves and executes, so the pinning rule is identical regardless of subpath.
+
+This ADR does not address `docker://image:tag` references in `uses:` fields. The repository does not currently use that shape; if a workflow ever introduces a containerized Action, that reference's pinning policy is governed by the future devcontainer / Docker-image policy in ADR-023, not by this ADR.
+
 This applies to GitHub-owned Actions and third-party Actions alike. The repository currently uses both (`actions/*` and `browser-actions/setup-chrome`), and a single rule is easier to review and enforce than a split policy.
 
 ### D2. Do not use floating refs for external Actions
@@ -48,6 +52,8 @@ Those references are mutable. They may still be acceptable for local reusable wo
 The `github-actions` entry in `.github/dependabot.yml` remains enabled. Dependabot version updates can update SHA-pinned Actions when the line includes a version comment, so the semver comment is required whenever a SHA pin corresponds to a tagged release.
 
 Reviewers should reject SHA-pinned Action updates that drop the version comment. Without the comment, the pin remains immutable but maintenance becomes manual and Dependabot cannot produce useful version-update PRs.
+
+The comment format is ` # vX.Y.Z` (single leading space, `#`, single space, `v` prefix, semver). Dependabot's update-comments-in-workflows feature parses that shape; deviations may degrade silently to a SHA-only diff with no version context.
 
 ### D4. Treat security alerts and version updates as separate signals
 
@@ -80,15 +86,17 @@ This ADR does not decide Docker image digest pinning, devcontainer feature exact
 - Workflow `uses:` lines are less readable because the executable reference is a SHA.
 - Maintainers must preserve the version comments during manual edits.
 - Reviewers must verify that a SHA update corresponds to the commented release tag when a change is not produced by Dependabot.
+- Routine Action-update PRs are SHA diffs rather than tag bumps; the volume is dominated by GitHub-published `actions/*` updates, which a third-party-only pinning policy would have left on tag pins. The repository accepts this review surface in exchange for a uniform rule that does not require reviewers to remember per-publisher exceptions.
 
 **Follow-up**
 
-- Add an automated lint that rejects external `uses:` references not pinned to 40-character SHAs and rejects SHA pins without semver comments.
-- Once ADR-023 lands, keep `docs/devcontainer-maintenance.md` and this ADR cross-linked so dependency maintenance decisions for workflows and devcontainers remain discoverable together.
+- Add an automated lint that rejects external `uses:` references not pinned to 40-character SHAs and rejects SHA pins without semver comments. Tracked at [#264](https://github.com/cosai-oasis/secure-ai-tooling/issues/264).
+- Once ADR-023 lands and creates `docs/devcontainer-maintenance.md` with cadence content, add a back-link from there to this ADR so dependency maintenance decisions for workflows and devcontainers remain discoverable together.
 
 ## References
 
 - [Issue #251: GitHub Actions pinning posture](https://github.com/cosai-oasis/secure-ai-tooling/issues/251)
+- [Issue #248: devcontainer lifecycle maintenance (ADR-023 parent)](https://github.com/cosai-oasis/secure-ai-tooling/issues/248) — sibling decision; ADR-023 will cover devcontainer / Docker-image pinning deferred from D5
 - [GitHub Actions security hardening guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
 - [Dependabot changelog: update comments in SHA-pinned GitHub Actions workflows](https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/)
 - [OpenSSF Scorecard pinned-dependencies check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)

--- a/docs/adr/024-github-actions-pinning-posture.md
+++ b/docs/adr/024-github-actions-pinning-posture.md
@@ -1,0 +1,94 @@
+# ADR-024: GitHub Actions pinning posture
+
+**Status:** Draft
+**Date:** 2026-05-01
+**Authors:** Codex agent, with maintainer review pending
+
+---
+
+## Context
+
+Issue [#251](https://github.com/cosai-oasis/secure-ai-tooling/issues/251) asks the repository to choose a posture for GitHub Actions `uses:` references. The workflows under `.github/workflows/` run against pull-request payloads, including external-contributor pull requests, and some jobs receive repository-scoped `GITHUB_TOKEN` permissions for validation summaries, Pages publishing, or pull-request comments. That makes workflow dependency integrity part of the repository supply-chain boundary.
+
+Before this ADR, workflow references used movable tags such as `actions/checkout@v6`, `actions/cache@v5`, and `browser-actions/setup-chrome@latest`. Tags and branch names are convenient for updates, but they are mutable references. If a referenced Action maintainer account, repository, or tag is compromised, the workflow can execute different code without a visible diff in this repository.
+
+GitHub's security guidance identifies a full-length commit SHA as the immutable way to reference third-party Actions. OpenSSF Scorecard's pinned-dependencies check also treats dependency pinning as a supply-chain hardening signal. Dependabot is already configured for the `github-actions` ecosystem in `.github/dependabot.yml`, so the remaining decision is whether to keep tag-major references for convenience or switch to commit SHAs while preserving update automation through semver comments.
+
+This ADR is a tooling/infrastructure decision under [ADR-002](002-branching-strategy.md): it targets `main`, not `develop`.
+
+## Decision
+
+Use full-length commit SHA pins for every non-local GitHub Actions `uses:` reference in `.github/workflows/*.yml`. Keep the human-readable semver release tag as a trailing comment on the same line so Dependabot can track and update the pinned Action version.
+
+### D1. Pin all external Actions by full commit SHA
+
+Every external workflow reference uses this form:
+
+```yaml
+uses: owner/repo@0123456789abcdef0123456789abcdef01234567 # v1.2.3
+```
+
+The part after `@` is the 40-character commit SHA that GitHub Actions resolves and executes. The trailing comment is not executable workflow input; it is a maintainer and Dependabot hint that records the upstream release tag corresponding to the pin.
+
+This applies to GitHub-owned Actions and third-party Actions alike. The repository currently uses both (`actions/*` and `browser-actions/setup-chrome`), and a single rule is easier to review and enforce than a split policy.
+
+### D2. Do not use floating refs for external Actions
+
+External `uses:` references must not use:
+
+- branch names such as `main` or `master`
+- moving tags such as `latest`
+- major-only tags such as `v6`
+- minor-only tags such as `v6.2`
+
+Those references are mutable. They may still be acceptable for local reusable workflows or local composite Actions referenced with `./...`, because those paths are versioned by this repository's own commit. This ADR does not introduce any local reusable workflow path.
+
+### D3. Preserve Dependabot version-update compatibility with comments
+
+The `github-actions` entry in `.github/dependabot.yml` remains enabled. Dependabot version updates can update SHA-pinned Actions when the line includes a version comment, so the semver comment is required whenever a SHA pin corresponds to a tagged release.
+
+Reviewers should reject SHA-pinned Action updates that drop the version comment. Without the comment, the pin remains immutable but maintenance becomes manual and Dependabot cannot produce useful version-update PRs.
+
+### D4. Treat security alerts and version updates as separate signals
+
+SHA pinning protects against silent upstream tag movement, but it changes the update workflow. Maintainers still review Dependabot PRs for Action updates, and security-relevant Action updates should be prioritized like other dependency updates.
+
+The repository accepts the operational cost because the workflow threat model is not read-only documentation: workflows execute code from external repositories and process pull-request-controlled files.
+
+### D5. Keep the policy small
+
+This ADR does not decide Docker image digest pinning, devcontainer feature exact-version pinning, or base-image date-stamping. Those are tracked by issue [#248](https://github.com/cosai-oasis/secure-ai-tooling/issues/248) and the planned ADR-023 devcontainer maintenance policy.
+
+## Alternatives Considered
+
+- **Keep major tags (`actions/checkout@v6`).** Rejected. It preserves easy updates, but the executed code can change when the upstream tag moves. That leaves no visible diff in this repository for a supply-chain-relevant change.
+- **Pin only third-party Actions, leave `actions/*` on tags.** Rejected. It creates an exception reviewers must remember, and GitHub-owned Actions are still external code fetched at workflow runtime. A uniform rule is easier to audit.
+- **Pin SHAs without semver comments.** Rejected. It gives immutability but weakens routine maintenance because maintainers lose the version context and Dependabot comment-based update tracking.
+- **Vendor Actions into this repository.** Rejected. Vendoring would give strong control but adds ongoing maintenance burden, makes updates harder to review, and is disproportionate for this repository's workflow surface.
+
+## Consequences
+
+**Positive**
+
+- Workflow execution is bound to immutable commits, not mutable upstream refs.
+- Pull requests that update Action code now show an explicit diff in this repository.
+- The previous `browser-actions/setup-chrome@latest` reference is removed.
+- Dependabot remains useful because semver comments preserve update tracking.
+
+**Negative**
+
+- Workflow `uses:` lines are less readable because the executable reference is a SHA.
+- Maintainers must preserve the version comments during manual edits.
+- Reviewers must verify that a SHA update corresponds to the commented release tag when a change is not produced by Dependabot.
+
+**Follow-up**
+
+- Add an automated lint that rejects external `uses:` references not pinned to 40-character SHAs and rejects SHA pins without semver comments.
+- Once ADR-023 lands, keep `docs/devcontainer-maintenance.md` and this ADR cross-linked so dependency maintenance decisions for workflows and devcontainers remain discoverable together.
+
+## References
+
+- [Issue #251: GitHub Actions pinning posture](https://github.com/cosai-oasis/secure-ai-tooling/issues/251)
+- [GitHub Actions security hardening guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
+- [Dependabot changelog: update comments in SHA-pinned GitHub Actions workflows](https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/)
+- [OpenSSF Scorecard pinned-dependencies check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,7 +39,7 @@ If a decision is about *how the Risk Map content model is shaped*, it belongs in
 | [021](021-personas-and-self-assessment-schema.md) | `personas.schema.json` design + `self-assessment.yaml` archiving (GAP-9) | Accepted | 2026-04-25 |
 | [022](022-supporting-schemas.md) | Supporting schemas grouped — actor-access, impact-type, lifecycle-stage, frameworks (mapping-ID regex), mermaid-styles | Accepted | 2026-04-25 |
 | 023 | Devcontainer dependency-pinning policy and lifecycle cadence | Reserved ([#248](https://github.com/cosai-oasis/secure-ai-tooling/issues/248)) | — |
-| [024](024-github-actions-pinning-posture.md) | GitHub Actions pinning posture | Draft | 2026-05-01 |
+| [024](024-github-actions-pinning-posture.md) | GitHub Actions pinning posture | Accepted | 2026-05-01 |
 
 ## Conventions
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,6 +38,7 @@ If a decision is about *how the Risk Map content model is shaped*, it belongs in
 | [020](020-controls-schema.md) | `controls.schema.json` design — closed enums, controls↔components mirror, folded-bullet drift heuristic | Accepted | 2026-04-25 |
 | [021](021-personas-and-self-assessment-schema.md) | `personas.schema.json` design + `self-assessment.yaml` archiving (GAP-9) | Accepted | 2026-04-25 |
 | [022](022-supporting-schemas.md) | Supporting schemas grouped — actor-access, impact-type, lifecycle-stage, frameworks (mapping-ID regex), mermaid-styles | Accepted | 2026-04-25 |
+| 023 | Devcontainer dependency-pinning policy and lifecycle cadence | Reserved ([#248](https://github.com/cosai-oasis/secure-ai-tooling/issues/248)) | — |
 | [024](024-github-actions-pinning-posture.md) | GitHub Actions pinning posture | Draft | 2026-05-01 |
 
 ## Conventions

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,6 +38,7 @@ If a decision is about *how the Risk Map content model is shaped*, it belongs in
 | [020](020-controls-schema.md) | `controls.schema.json` design — closed enums, controls↔components mirror, folded-bullet drift heuristic | Accepted | 2026-04-25 |
 | [021](021-personas-and-self-assessment-schema.md) | `personas.schema.json` design + `self-assessment.yaml` archiving (GAP-9) | Accepted | 2026-04-25 |
 | [022](022-supporting-schemas.md) | Supporting schemas grouped — actor-access, impact-type, lifecycle-stage, frameworks (mapping-ID regex), mermaid-styles | Accepted | 2026-04-25 |
+| [024](024-github-actions-pinning-posture.md) | GitHub Actions pinning posture | Draft | 2026-05-01 |
 
 ## Conventions
 

--- a/docs/devcontainer-maintenance.md
+++ b/docs/devcontainer-maintenance.md
@@ -1,8 +1,0 @@
-# Devcontainer Maintenance
-
-Devcontainer dependency lifecycle policy is tracked by issue
-[#248](https://github.com/cosai-oasis/secure-ai-tooling/issues/248) and the
-planned ADR-023 devcontainer maintenance decision.
-
-Workflow Action pinning is a related but separate CI/CD supply-chain decision.
-For that policy, see [ADR-024: GitHub Actions pinning posture](adr/024-github-actions-pinning-posture.md).

--- a/docs/devcontainer-maintenance.md
+++ b/docs/devcontainer-maintenance.md
@@ -1,0 +1,8 @@
+# Devcontainer Maintenance
+
+Devcontainer dependency lifecycle policy is tracked by issue
+[#248](https://github.com/cosai-oasis/secure-ai-tooling/issues/248) and the
+planned ADR-023 devcontainer maintenance decision.
+
+Workflow Action pinning is a related but separate CI/CD supply-chain decision.
+For that policy, see [ADR-024: GitHub Actions pinning posture](adr/024-github-actions-pinning-posture.md).


### PR DESCRIPTION
## Summary
- add draft ADR-024 for GitHub Actions SHA pinning posture
- pin all external workflow `uses:` references to full commit SHAs with semver comments for Dependabot tracking
- add an ADR-023 / issue #248 cross-link in ADR-024's References

## Notes
- This targets `main` per the contribution guidelines and ADR-002 because it is tooling/CI infrastructure work.
- ADR-023 / issue #248 has not landed yet. This PR cross-links the planned ADR-023 work from ADR-024's References section so the two decisions remain discoverable together

## Validation
- `PATH=/Users/sbagga/Desktop/CoSAI/secure-ai-tooling/.venv/bin:$PATH .venv/bin/python scripts/hooks/validate_issue_templates.py --force`
- `PATH=/Users/sbagga/Desktop/CoSAI/secure-ai-tooling/.venv/bin:$PATH .venv/bin/python -c 'from pathlib import Path; import yaml; paths=list(Path(".github/workflows").glob("*.yml"))+[Path(".github/dependabot.yml")]; [yaml.safe_load(p.read_text()) for p in paths]; print(f"parsed {len(paths)} yaml files")'`
- `rg -n "uses: [^#\n]*@(v[0-9]+|latest|main|master)" .github/workflows` returns no matches
- `uses=44 pinned=44` for full-SHA + semver-comment scan
- `PATH=/Users/sbagga/Desktop/CoSAI/secure-ai-tooling/.venv/bin:$PATH .venv/bin/pytest scripts/hooks/tests/test_validate_issue_templates.py` (72 passed)
- `npx prettier --check docs/adr/024-github-actions-pinning-posture.md 
- `git diff --check`

Closes #251