### PR TITLE
[codex] Add workflow uses pinning lint

### DIFF
--- a/.github/workflows/validate_python.yml
+++ b/.github/workflows/validate_python.yml
@@ -3,11 +3,17 @@ on:
   push:
     paths:
       - '**.py'
+      - '.github/workflows/*.yml'
+      - '.github/workflows/**/*.yml'
+      - '.pre-commit-config.yaml'
       - 'requirements*.txt'
       - 'pyproject.toml'
   pull_request:
     paths:
       - '**.py'
+      - '.github/workflows/*.yml'
+      - '.github/workflows/**/*.yml'
+      - '.pre-commit-config.yaml'
       - 'requirements*.txt'
       - 'pyproject.toml'
 
@@ -94,11 +100,37 @@ jobs:
           echo "status=failed" >> $GITHUB_OUTPUT
           exit 1
         fi
+  workflow-uses-pinning:
+    runs-on: ubuntu-latest
+    name: GitHub Actions Uses Pinning
+    needs: setup
+    outputs:
+      pinning_status: ${{ steps.workflow-pinning.outputs.status }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: '3.14'
+    - name: Validate GitHub Actions uses pinning
+      id: workflow-pinning
+      run: |
+        echo "🔍 Validating GitHub Actions uses pinning..."
+        if python scripts/hooks/precommit/validate_workflow_uses_pinning.py; then
+          echo "✅ GitHub Actions uses pinning validation completed successfully"
+          echo "status=success" >> $GITHUB_OUTPUT
+        else
+          echo "❌ GitHub Actions uses pinning validation failed"
+          echo "::error::GitHub Actions uses pinning validation failed"
+          echo "status=failed" >> $GITHUB_OUTPUT
+          exit 1
+        fi
   # Summary job that requires all other jobs but doesn't fail
   validation-summary:
     runs-on: ubuntu-latest
     name: Validation Summary
-    needs: [python-linting, python-testing]
+    needs: [python-linting, python-testing, workflow-uses-pinning]
     if: always()
     steps:
     - name: Generate Summary
@@ -109,8 +141,10 @@ jobs:
         # Check individual job results
         lint_result="${{ needs.python-linting.result }}"
         test_result="${{ needs.python-testing.result }}"
+        pinning_result="${{ needs.workflow-uses-pinning.result }}"
         lint_status="${{ needs.python-linting.outputs.lint_status }}"
         test_status="${{ needs.python-testing.outputs.test_status }}"
+        pinning_status="${{ needs.workflow-uses-pinning.outputs.pinning_status }}"
         overall_success=true
         
         echo "## Individual Job Results:" >> $GITHUB_STEP_SUMMARY
@@ -127,6 +161,13 @@ jobs:
           echo "- ✅ **Python test validation**: Passed" >> $GITHUB_STEP_SUMMARY
         else
           echo "- ❌ **Python test validation**: $test_result" >> $GITHUB_STEP_SUMMARY
+          overall_success=false
+        fi
+
+        if [ "$pinning_result" = "success" ]; then
+          echo "- ✅ **GitHub Actions uses pinning validation**: Passed" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "- ❌ **GitHub Actions uses pinning validation**: $pinning_result" >> $GITHUB_STEP_SUMMARY
           overall_success=false
         fi
         

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@
 #   1. Schema validation (check-jsonschema, per yaml/schema pair)
 #   2. Prettier formatting (yaml in risk-map/yaml/)
 #   3. Ruff linting (Python)
-#   4. Local validators (component edges, control-risk, framework refs)
+#   4. Local validators (component edges, control-risk, framework refs, workflow action pins)
 #   5. Issue template regeneration + validation
 #   6. Mermaid graph, markdown table, and SVG regeneration (Mode B auto-stage)
 
@@ -224,6 +224,13 @@ repos:
         entry: python3 scripts/hooks/validate_framework_references.py
         files: ^risk-map/yaml/(controls|frameworks|personas|risks)\.yaml$
         pass_filenames: false
+
+      - id: validate-workflow-uses-pinning
+        name: 'github-actions: enforce SHA-pinned uses references'
+        language: system
+        entry: python3 scripts/hooks/precommit/validate_workflow_uses_pinning.py
+        files: ^\.github/workflows/.*\.yml$
+        pass_filenames: true
 
       - id: validate-identification-questions
         name: 'validate: identification-questions structural rules'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -198,9 +198,9 @@ repos:
 
   # ---------------------------------------------------------------------------
   # Local validators. Each runs only when its dependency files are staged
-  # (framework filters via `files:`); validators do their own internal staged-
-  # file detection, which is now redundant but harmless and preserves bash
-  # behavior. pass_filenames is false because each validator scans the repo.
+  # (framework filters via `files:`). The risk-map validators self-scan the
+  # repo and therefore use pass_filenames: false; file-scoped validators such
+  # as workflow pinning keep pass_filenames: true.
   # ---------------------------------------------------------------------------
   - repo: local
     hooks:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,7 +19,7 @@ Development tools and utilities for this project.
 
 **[Hook Validations](docs/hook-validations.md)**
 
-- What the pre-commit hook validates (10 validation and generation types)
+- What the pre-commit hook validates
 - YAML schema validation, Prettier formatting, Ruff linting
 - Component edge validation and graph generation
 - Control-to-risk reference validation
@@ -99,6 +99,7 @@ Development tools and utilities for this project.
 - `hooks/validate_riskmap.py` - Component edge validation and graph generation
 - `hooks/validate_control_risk_references.py` - Control-risk cross-reference validation
 - `hooks/validate_framework_references.py` - Framework reference validation
+- `hooks/precommit/validate_workflow_uses_pinning.py` - GitHub Actions `uses:` pinning validation for ADR-024
 - `hooks/validate_issue_templates.py` - Issue template schema validation
 - `generate_issue_templates.py` - Issue template generator from sources
 - `hooks/yaml_to_markdown.py` - Markdown table generation from YAML

--- a/scripts/docs/github-actions.md
+++ b/scripts/docs/github-actions.md
@@ -9,6 +9,8 @@ In addition to local pre-commit validation, the repository includes GitHub Actio
 - **YAML Schema Validation**: Validates all YAML files against their JSON schemas
 - **YAML Format Validation**: Checks prettier formatting compliance
 - **Python Linting**: Runs ruff linting on all Python files
+- **GitHub Actions Uses Pinning**: Enforces ADR-024 SHA-pinned `uses:`
+  references in `.github/workflows/*.yml`
 - **Component Edge Validation**: Verifies component relationship consistency
 - **Control-Risk Reference Validation**: Checks control-risk cross-reference integrity
 - **Graph Validation**: Generates and compares graphs against committed versions
@@ -25,6 +27,14 @@ In addition to local pre-commit validation, the repository includes GitHub Actio
   - Components tables (`components-full.md`, `components-summary.md`)
   - Risks tables (`risks-full.md`, `risks-summary.md`)
   - Controls tables (`controls-full.md`, `controls-summary.md`, `controls-xref-risks.md`, `controls-xref-components.md`)
+
+## GitHub Actions Uses Pinning
+
+Workflow-only PRs trigger the Python validation workflow so
+`scripts/hooks/precommit/validate_workflow_uses_pinning.py` can enforce the
+same ADR-024 rule as pre-commit. External `uses:` references must be pinned as
+`owner/repo@<40-character-SHA> # vX.Y.Z`; local `./...` references are
+allowed. The CI failure names the offending workflow file and line.
 
 ## Different Roles
 

--- a/scripts/docs/hook-validations.md
+++ b/scripts/docs/hook-validations.md
@@ -134,7 +134,39 @@ risks:
 - `frameworks.yaml` configuration and structure
 - `personas.yaml` framework applicability
 
-## 9. Issue Template Regeneration
+## 9. GitHub Actions `uses:` Pinning Validation
+
+`validate-workflow-uses-pinning` hook runs
+`scripts/hooks/precommit/validate_workflow_uses_pinning.py` when a workflow
+file under `.github/workflows/*.yml` or `.github/workflows/**/*.yml` is
+staged.
+
+**Validation:**
+
+- External `uses:` references must use
+  `owner/repo@<40-character-SHA> # vX.Y.Z`
+- External action subpaths and reusable workflows must use
+  `owner/repo/path@<40-character-SHA> # vX.Y.Z`
+- Local `./...` references are allowed without a SHA or version comment
+- `docker://` action references fail until a separate Docker pinning policy is
+  defined
+
+**Example:**
+
+```yaml
+# Valid external action reference
+- uses: actions/checkout@0123456789abcdef0123456789abcdef01234567 # v6.0.2
+
+# Valid local reference
+- uses: ./.github/actions/build
+
+# Invalid: mutable tag
+- uses: actions/checkout@v6
+```
+
+Violations name the offending workflow file and line number.
+
+## 10. Issue Template Regeneration
 
 `regenerate-issue-templates` hook (`scripts/hooks/precommit/regenerate_issue_templates.py`)
 triggers when any of these is staged:
@@ -157,12 +189,12 @@ regenerated templates land in the same commit.
 - `new_persona.yml`, `update_persona.yml`
 - `infrastructure.yml`
 
-## 10. Issue Template Validation
+## 11. Issue Template Validation
 
 `validate-issue-templates` hook runs
 `scripts/hooks/validate_issue_templates.py` when anything under
 `.github/ISSUE_TEMPLATE/*.yml` or `scripts/TEMPLATES/*.yml` is staged
-(including the files just regenerated in step 9).
+(including the files just regenerated in step 10).
 
 **Validates against vendored schemas:**
 
@@ -185,7 +217,7 @@ regenerated templates land in the same commit.
   validations: { required: true }   # ❌ checkboxes don't support top-level validations
 ```
 
-## 11. Graph Regeneration
+## 12. Graph Regeneration
 
 `regenerate-graphs` hook (`scripts/hooks/precommit/regenerate_graphs.py`)
 produces three Mermaid graph pairs based on which source yaml is staged:
@@ -199,7 +231,7 @@ produces three Mermaid graph pairs based on which source yaml is staged:
 Each output pair is `git add`-ed on success. The wrapper delegates to
 `validate_riskmap.py --to-graph / --to-controls-graph / --to-risk-graph`.
 
-## 12. Table Regeneration
+## 13. Table Regeneration
 
 `regenerate-tables` hook (`scripts/hooks/precommit/regenerate_tables.py`)
 produces 8 generation operations across 4 source triggers. The ordering
@@ -219,7 +251,7 @@ trigger) run — matches bash behavior.
 
 See [Table Generation](table-generation.md) for output filename conventions.
 
-## 13. Mermaid SVG Regeneration
+## 14. Mermaid SVG Regeneration
 
 `regenerate-svgs` hook (`scripts/hooks/precommit/regenerate_svgs.py`)
 converts staged `.mmd` or `.mermaid` files under `risk-map/diagrams/` into

--- a/scripts/docs/manual-validation.md
+++ b/scripts/docs/manual-validation.md
@@ -55,6 +55,9 @@ python3 scripts/hooks/validate_control_risk_references.py --force
 # Framework references
 python3 scripts/hooks/validate_framework_references.py --force
 
+# GitHub Actions `uses:` pinning
+python3 scripts/hooks/precommit/validate_workflow_uses_pinning.py
+
 # Issue template schemas
 python3 scripts/hooks/validate_issue_templates.py --force
 ```
@@ -66,10 +69,12 @@ To exercise a single hook declaratively (using the framework's config), run:
 ```bash
 # By hook id, against all files in the repo:
 pre-commit run validate-component-edges --all-files
+pre-commit run validate-workflow-uses-pinning --all-files
 pre-commit run check-jsonschema --all-files
 
 # Against a specific file set:
 pre-commit run validate-component-edges --files risk-map/yaml/components.yaml
+pre-commit run validate-workflow-uses-pinning --files .github/workflows/validation.yml
 ```
 
 Note: framework hooks with `pass_filenames: false` (the validators) will

--- a/scripts/docs/validation-flow.md
+++ b/scripts/docs/validation-flow.md
@@ -24,19 +24,22 @@ hooks show `(no files to check) Skipped` in the output.
    runs when `controls.yaml` or `risks.yaml` is staged.
 9. **Framework Reference Validation** — `validate_framework_references.py`
    runs when `controls`, `frameworks`, `personas`, or `risks` yaml is staged.
-10. **Issue Template Regeneration** — `regenerate_issue_templates.py` runs
+10. **GitHub Actions `uses:` Pinning Validation** —
+    `validate_workflow_uses_pinning.py` runs when `.github/workflows/*.yml`
+    or nested workflow `.yml` files are staged.
+11. **Issue Template Regeneration** — `regenerate_issue_templates.py` runs
     when any template source, any schema, or `frameworks.yaml` is staged;
     generates `.github/ISSUE_TEMPLATE/*.yml` and stages them.
-11. **Issue Template Validation** — `validate_issue_templates.py` runs when
+12. **Issue Template Validation** — `validate_issue_templates.py` runs when
     anything under `.github/ISSUE_TEMPLATE/` or `scripts/TEMPLATES/` is
-    staged (including the files just regenerated in step 10).
-12. **Graph Regeneration** — `regenerate_graphs.py` produces risk-map graph,
+    staged (including the files just regenerated in step 11).
+13. **Graph Regeneration** — `regenerate_graphs.py` produces risk-map graph,
     controls graph, and controls-to-risk graph (3 markdown + 3 mermaid outputs)
     based on which of `components.yaml`, `controls.yaml`, `risks.yaml` is
     staged. Each output pair is `git add`-ed on success.
-13. **Table Regeneration** — `regenerate_tables.py` regenerates 8 table
+14. **Table Regeneration** — `regenerate_tables.py` regenerates 8 table
     outputs across 4 triggers (see `scripts/docs/table-generation.md`).
-14. **SVG Regeneration** — `regenerate_svgs.py` converts staged
+15. **SVG Regeneration** — `regenerate_svgs.py` converts staged
     `risk-map/diagrams/*.mmd` or `*.mermaid` files to SVG.
 
 The commit is blocked if any hook returns non-zero.

--- a/scripts/hooks/precommit/validate_workflow_uses_pinning.py
+++ b/scripts/hooks/precommit/validate_workflow_uses_pinning.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+Pre-commit lint: enforce ADR-024 pinning for GitHub Actions `uses:` references.
+
+External workflow dependencies must use a full 40-character commit SHA and a
+same-line `# vX.Y.Z` semver comment so Dependabot can keep updating the pin.
+Local `./...` references are exempt. `docker://` references are rejected until
+a separate ADR defines the repository's Docker action pinning policy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+HOOK_NAME = "validate-workflow-uses-pinning"
+
+USES_LINE_RE = re.compile(r"^\s*(?:-\s*)?uses\s*:\s*(?P<rest>.*?)\s*$")
+PINNED_EXTERNAL_REF_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*@[0-9A-Fa-f]{40}$")
+SEMVER_COMMENT_RE = re.compile(
+    r"v(0|[1-9]\d*)\."
+    r"(0|[1-9]\d*)\."
+    r"(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z.-]+)?"
+    r"(?:\+[0-9A-Za-z.-]+)?"
+)
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A single workflow `uses:` pinning violation."""
+
+    path: Path
+    line: int
+    reference: str
+    message: str
+
+
+def _strip_optional_quotes(value: str) -> str:
+    """Remove one balanced layer of single or double quotes around a scalar."""
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _parse_uses_line(line: str) -> tuple[str, str | None, bool] | None:
+    """
+    Extract the `uses:` reference, same-line comment, and exact separator flag.
+
+    Comments matter for ADR-024, so this intentionally works on source lines
+    rather than parsed YAML. GitHub Actions `uses:` values do not contain `#`,
+    which keeps the split deterministic for the workflow shapes this repository
+    accepts.
+    """
+    match = USES_LINE_RE.match(line)
+    if match is None:
+        return None
+
+    rest = match.group("rest").rstrip()
+    value_part, separator, comment_part = rest.partition("#")
+    reference = _strip_optional_quotes(value_part.strip())
+
+    if not separator:
+        return reference, None, False
+
+    has_required_separator = value_part.endswith(" ") and comment_part.startswith(" ")
+    return reference, comment_part.strip(), has_required_separator
+
+
+def _validate_reference(
+    path: Path,
+    line_number: int,
+    reference: str,
+    comment: str | None,
+    separator_ok: bool,
+) -> Violation | None:
+    """Validate one parsed `uses:` reference and return a violation if it fails."""
+    if reference.startswith("./"):
+        return None
+
+    if reference.startswith("docker://"):
+        return Violation(
+            path=path,
+            line=line_number,
+            reference=reference,
+            message=(
+                "docker:// action references require maintainer review until a Docker action "
+                "pinning policy is defined"
+            ),
+        )
+
+    if not PINNED_EXTERNAL_REF_RE.fullmatch(reference):
+        return Violation(
+            path=path,
+            line=line_number,
+            reference=reference,
+            message=(
+                "external `uses:` reference must use owner/repo[/path]@<full "
+                "40-character commit SHA>; tags, branches, missing refs, and short SHAs are not allowed"
+            ),
+        )
+
+    if comment is None or not separator_ok or SEMVER_COMMENT_RE.fullmatch(comment) is None:
+        return Violation(
+            path=path,
+            line=line_number,
+            reference=reference,
+            message="SHA-pinned external `uses:` reference is missing required ` # vX.Y.Z` semver comment",
+        )
+
+    return None
+
+
+def validate_file(path: Path) -> list[Violation]:
+    """
+    Validate every `uses:` line in one workflow file.
+
+    Args:
+        path: Path to a GitHub Actions workflow `.yml` file.
+
+    Returns:
+        A list of pinning violations. Empty means the file passed.
+    """
+    violations: list[Violation] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        parsed = _parse_uses_line(line)
+        if parsed is None:
+            continue
+        reference, comment, separator_ok = parsed
+        violation = _validate_reference(path, line_number, reference, comment, separator_ok)
+        if violation is not None:
+            violations.append(violation)
+    return violations
+
+
+def discover_workflow_files(root: Path) -> list[Path]:
+    """
+    Return `.github/workflows/*.yml` and nested `.github/workflows/**/*.yml`.
+
+    Root-level workflows are returned before nested workflows so output order
+    mirrors the issue #264 scan scope.
+    """
+    workflows_dir = root / ".github" / "workflows"
+    if not workflows_dir.is_dir():
+        return []
+
+    root_workflows = sorted(workflows_dir.glob("*.yml"))
+    nested_workflows = sorted(path for path in workflows_dir.rglob("*.yml") if path.parent != workflows_dir)
+    return root_workflows + nested_workflows
+
+
+def format_violation(violation: Violation) -> str:
+    """Format one violation for stderr with actionable file:line context."""
+    return f"{HOOK_NAME}: {violation.path}:{violation.line}: {violation.message} (uses: {violation.reference})"
+
+
+def main(argv: list[str]) -> int:
+    """
+    CLI entry point for pre-commit and manual validation.
+
+    Pre-commit passes matched workflow filenames. With no filenames, the command
+    discovers `.github/workflows/*.yml` and nested `.yml` workflows from the
+    current working directory.
+    """
+    parser = argparse.ArgumentParser(description="Validate ADR-024 GitHub Actions `uses:` pinning.")
+    parser.add_argument("files", nargs="*", help="Workflow .yml files to validate.")
+    args = parser.parse_args(argv)
+
+    files = [Path(file) for file in args.files] if args.files else discover_workflow_files(Path.cwd())
+    violations: list[Violation] = []
+    for path in files:
+        if not path.exists():
+            continue
+        violations.extend(validate_file(path))
+
+    for violation in violations:
+        print(format_violation(violation), file=sys.stderr)
+
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/hooks/precommit/validate_workflow_uses_pinning.py
+++ b/scripts/hooks/precommit/validate_workflow_uses_pinning.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 HOOK_NAME = "validate-workflow-uses-pinning"
 
-USES_LINE_RE = re.compile(r"^\s*(?:-\s*)?uses\s*:\s*(?P<rest>.*?)\s*$")
+USES_LINE_RE = re.compile(r"^\s*(?:-\s*)?(?:uses|\"uses\"|'uses')\s*:\s*(?P<rest>.*?)\s*$")
 PINNED_EXTERNAL_REF_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*@[0-9A-Fa-f]{40}$")
 SEMVER_COMMENT_RE = re.compile(
     r"v(0|[1-9]\d*)\."

--- a/scripts/hooks/tests/test_precommit_hook_install.py
+++ b/scripts/hooks/tests/test_precommit_hook_install.py
@@ -112,6 +112,7 @@ _REQUIRED_HOOK_IDS = {
     "validate-component-edges",
     "validate-control-risk-references",
     "validate-framework-references",
+    "validate-workflow-uses-pinning",
     # Issue templates:
     "regenerate-issue-templates",
     "validate-issue-templates",
@@ -229,6 +230,16 @@ class TestValidatorHookContracts:
         for token in ("controls", "frameworks", "personas", "risks"):
             assert token in files, f"framework refs files regex missing `{token}`: {files!r}"
         assert hook.get("pass_filenames") is False
+
+    def test_validate_workflow_uses_pinning_targets_workflow_yml_files(self):
+        hooks = _hooks_by_id("validate-workflow-uses-pinning")
+        assert len(hooks) == 1
+        hook = hooks[0]
+        assert "validate_workflow_uses_pinning.py" in hook.get("entry", "")
+        files = hook.get("files", "")
+        assert ".github/workflows" in files
+        assert "yml" in files
+        assert hook.get("pass_filenames") is True
 
 
 # ===========================================================================

--- a/scripts/hooks/tests/test_validate_workflow_uses_pinning.py
+++ b/scripts/hooks/tests/test_validate_workflow_uses_pinning.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""
+Tests for scripts/hooks/precommit/validate_workflow_uses_pinning.py.
+
+The validator enforces ADR-024 for GitHub Actions workflow `uses:` references:
+external actions must be pinned to a full 40-character commit SHA and carry a
+same-line `# vX.Y.Z` release comment for Dependabot update tracking. Local
+`./...` references are exempt. Docker action references are rejected until a
+separate ADR defines their pinning policy.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "precommit"))
+
+from validate_workflow_uses_pinning import (  # noqa: E402
+    discover_workflow_files,
+    format_violation,
+    main,
+    validate_file,
+)
+
+FULL_SHA = "0123456789abcdef0123456789abcdef01234567"
+SHORT_SHA = "0123456789abcdef"
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+
+
+def _write_workflow(tmp_path: Path, content: str, name: str = "workflow.yml") -> Path:
+    """Write a synthetic workflow and return its path."""
+    workflow = tmp_path / name
+    workflow.parent.mkdir(parents=True, exist_ok=True)
+    workflow.write_text(content, encoding="utf-8")
+    return workflow
+
+
+class TestPassingReferences:
+    """Valid `uses:` references produce no violations."""
+
+    def test_external_action_with_full_sha_and_semver_comment_passes(self, tmp_path):
+        """
+        Given: An external action pinned to a 40-character SHA with `# vX.Y.Z`
+        When: validate_file scans the workflow
+        Then: It returns no violations
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            f"""
+name: valid
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@{FULL_SHA} # v6.0.2
+""".lstrip(),
+        )
+
+        assert validate_file(workflow) == []
+
+    def test_external_action_with_path_and_prerelease_comment_passes(self, tmp_path):
+        """
+        Given: An external action subpath pinned to a SHA with a prerelease tag comment
+        When: validate_file scans the workflow
+        Then: The owner/repo/path@sha form is accepted
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            f"""
+name: reusable
+jobs:
+  test:
+    steps:
+      - uses: octo-org/example/.github/actions/build@{FULL_SHA} # v1.2.3-rc.1
+""".lstrip(),
+        )
+
+        assert validate_file(workflow) == []
+
+    def test_local_relative_action_is_allowed_without_sha_or_comment(self, tmp_path):
+        """
+        Given: A local composite action reference using `./...`
+        When: validate_file scans the workflow
+        Then: The ADR-024 external-action pinning rule is not applied
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            """
+name: local
+jobs:
+  test:
+    steps:
+      - uses: ./.github/actions/build
+""".lstrip(),
+        )
+
+        assert validate_file(workflow) == []
+
+    def test_local_reusable_workflow_is_allowed_without_sha_or_comment(self, tmp_path):
+        """
+        Given: A local reusable workflow reference using `./...`
+        When: validate_file scans the workflow
+        Then: The local ADR-024 carve-out is accepted
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            """
+name: local reusable
+jobs:
+  test:
+    uses: ./.github/workflows/reusable.yml
+""".lstrip(),
+        )
+
+        assert validate_file(workflow) == []
+
+
+class TestFailingReferences:
+    """Invalid external `uses:` references produce actionable violations."""
+
+    @pytest.mark.parametrize(
+        ("line", "expected"),
+        [
+            ("uses: actions/checkout@v6", "full 40-character commit SHA"),
+            (f"uses: actions/checkout@{SHORT_SHA} # v6.0.2", "full 40-character commit SHA"),
+            ("uses: actions/checkout", "full 40-character commit SHA"),
+            (f"uses: actions/checkout@{FULL_SHA}", "missing required ` # vX.Y.Z`"),
+            (f"uses: actions/checkout@{FULL_SHA} # v6", "missing required ` # vX.Y.Z`"),
+            (f"uses: actions/checkout@{FULL_SHA} # 6.0.2", "missing required ` # vX.Y.Z`"),
+            (f"uses: actions/checkout@{FULL_SHA}# v6.0.2", "missing required ` # vX.Y.Z`"),
+        ],
+    )
+    def test_invalid_external_action_references_fail(self, tmp_path, line, expected):
+        """
+        Given: An external `uses:` reference that violates ADR-024
+        When: validate_file scans the workflow
+        Then: One violation identifies the specific policy gap
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            f"""
+name: invalid
+jobs:
+  test:
+    steps:
+      - {line}
+""".lstrip(),
+        )
+
+        violations = validate_file(workflow)
+
+        assert len(violations) == 1
+        assert expected in violations[0].message
+
+    def test_docker_action_reference_fails_for_maintainer_review(self, tmp_path):
+        """
+        Given: A `docker://` action reference
+        When: validate_file scans the workflow
+        Then: The validator rejects it until a Docker pinning policy exists
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            """
+name: docker action
+jobs:
+  test:
+    steps:
+      - uses: docker://alpine:3.20
+""".lstrip(),
+        )
+
+        violations = validate_file(workflow)
+
+        assert len(violations) == 1
+        assert "docker:// action references require maintainer review" in violations[0].message
+
+    def test_violation_format_includes_file_line_and_reference(self, tmp_path):
+        """
+        Given: A workflow with an invalid external action on line 6
+        When: format_violation renders the finding
+        Then: The message names the offending file, line, and reference
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            """
+name: line numbers
+jobs:
+  test:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+""".lstrip(),
+        )
+
+        violation = validate_file(workflow)[0]
+        rendered = format_violation(violation)
+
+        assert f"{workflow}:6:" in rendered
+        assert "actions/checkout@v6" in rendered
+
+
+class TestWorkflowDiscovery:
+    """Workflow discovery matches the issue #264 scan scope."""
+
+    def test_discovery_finds_root_and_nested_yml_workflows_only(self, tmp_path):
+        """
+        Given: Root, nested, and non-yml files under .github/workflows
+        When: discover_workflow_files scans the repository root
+        Then: It returns only .yml workflows, including nested paths
+        """
+        root_workflow = _write_workflow(tmp_path / ".github" / "workflows", "name: root\n", "root.yml")
+        nested_workflow = _write_workflow(
+            tmp_path / ".github" / "workflows" / "nested",
+            "name: nested\n",
+            "nested.yml",
+        )
+        _write_workflow(tmp_path / ".github" / "workflows", "name: yaml\n", "ignored.yaml")
+        _write_workflow(tmp_path / ".github" / "not-workflows", "name: ignored\n", "ignored.yml")
+
+        discovered = discover_workflow_files(tmp_path)
+
+        assert discovered == [root_workflow, nested_workflow]
+
+
+class TestCli:
+    """The CLI exits non-zero only when violations are present."""
+
+    def test_main_returns_zero_for_valid_workflow(self, tmp_path, capsys):
+        """
+        Given: A valid workflow file
+        When: main is invoked with the workflow path
+        Then: It returns 0 and emits no stderr output
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            f"jobs:\n  test:\n    steps:\n      - uses: actions/checkout@{FULL_SHA} # v6.0.2\n",
+        )
+
+        exit_code = main([str(workflow)])
+
+        assert exit_code == 0
+        assert capsys.readouterr().err == ""
+
+    def test_main_returns_one_and_writes_violations_to_stderr(self, tmp_path, capsys):
+        """
+        Given: An invalid workflow file
+        When: main is invoked with the workflow path
+        Then: It returns 1 and writes the file:line violation to stderr
+        """
+        workflow = _write_workflow(tmp_path, "jobs:\n  test:\n    steps:\n      - uses: actions/checkout@v6\n")
+
+        exit_code = main([str(workflow)])
+        captured = capsys.readouterr()
+
+        assert exit_code == 1
+        assert f"{workflow}:4:" in captured.err
+        assert "full 40-character commit SHA" in captured.err
+
+
+class TestCiIntegration:
+    """The existing CI workflow runs the same validator for workflow changes."""
+
+    def test_python_validation_workflow_runs_pinning_validator(self):
+        """
+        Given: The repository's Python validation workflow
+        When: its source is inspected
+        Then: Workflow YAML changes trigger the validator in CI
+        """
+        workflow = REPO_ROOT / ".github" / "workflows" / "validate_python.yml"
+        content = workflow.read_text(encoding="utf-8")
+
+        assert "'.github/workflows/*.yml'" in content
+        assert "'.github/workflows/**/*.yml'" in content
+        assert "scripts/hooks/precommit/validate_workflow_uses_pinning.py" in content

--- a/scripts/hooks/tests/test_validate_workflow_uses_pinning.py
+++ b/scripts/hooks/tests/test_validate_workflow_uses_pinning.py
@@ -122,6 +122,8 @@ class TestFailingReferences:
         ("line", "expected"),
         [
             ("uses: actions/checkout@v6", "full 40-character commit SHA"),
+            ('"uses": actions/checkout@v6', "full 40-character commit SHA"),
+            ("'uses': actions/checkout@v6", "full 40-character commit SHA"),
             (f"uses: actions/checkout@{SHORT_SHA} # v6.0.2", "full 40-character commit SHA"),
             ("uses: actions/checkout", "full 40-character commit SHA"),
             (f"uses: actions/checkout@{FULL_SHA}", "missing required ` # vX.Y.Z`"),
@@ -151,6 +153,27 @@ jobs:
 
         assert len(violations) == 1
         assert expected in violations[0].message
+
+    def test_quoted_job_level_uses_key_fails(self, tmp_path):
+        """
+        Given: A job-level reusable workflow reference with a quoted `uses` key
+        When: validate_file scans the workflow
+        Then: It treats the quoted key as a real GitHub Actions `uses` field
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            """
+name: quoted job key
+jobs:
+  reusable:
+    "uses": octo-org/example/.github/workflows/build.yml@main
+""".lstrip(),
+        )
+
+        violations = validate_file(workflow)
+
+        assert len(violations) == 1
+        assert "full 40-character commit SHA" in violations[0].message
 
     def test_docker_action_reference_fails_for_maintainer_review(self, tmp_path):
         """


### PR DESCRIPTION
## Summary

Closes #264.

- Adds `validate_workflow_uses_pinning.py` to enforce ADR-024 for GitHub Actions `uses:` references.
- Wires the validator into the existing pre-commit framework and Python validation workflow so workflow-only PRs run the check in CI.
- Adds targeted tests for valid SHA pins, missing/short SHAs, missing or malformed semver comments, local `./...` exemptions, and `docker://` review failures.
- Updates scripts documentation with the hook behavior and manual validation commands.

## Validation

- `.venv/bin/pytest scripts/hooks/tests/test_validate_workflow_uses_pinning.py scripts/hooks/tests/test_precommit_hook_install.py`
- `.venv/bin/ruff check scripts/hooks/precommit/validate_workflow_uses_pinning.py scripts/hooks/tests/test_validate_workflow_uses_pinning.py scripts/hooks/tests/test_precommit_hook_install.py`
- `.venv/bin/python scripts/hooks/precommit/validate_workflow_uses_pinning.py`
- `pre-commit run validate-workflow-uses-pinning --all-files`

## Notes

A broader local hooks test run with the repo venv on `PATH` had one unrelated pre-existing failure in `test_install_deps.py::TestSkipChromiumWhenPresent::test_chromium_in_cache_emits_skip`; the new validator tests passed.