### PR TITLE
Add workflow uses pinning lint

### DIFF
--- a/.github/workflows/validate_python.yml
+++ b/.github/workflows/validate_python.yml
@@ -3,11 +3,17 @@ on:
   push:
     paths:
       - '**.py'
+      - '.github/workflows/*.yml'
+      - '.github/workflows/**/*.yml'
+      - '.pre-commit-config.yaml'
       - 'requirements*.txt'
       - 'pyproject.toml'
   pull_request:
     paths:
       - '**.py'
+      - '.github/workflows/*.yml'
+      - '.github/workflows/**/*.yml'
+      - '.pre-commit-config.yaml'
       - 'requirements*.txt'
       - 'pyproject.toml'
 
@@ -94,11 +100,37 @@ jobs:
           echo "status=failed" >> $GITHUB_OUTPUT
           exit 1
         fi
+  workflow-uses-pinning:
+    runs-on: ubuntu-latest
+    name: GitHub Actions Uses Pinning
+    needs: setup
+    outputs:
+      pinning_status: ${{ steps.workflow-pinning.outputs.status }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: '3.14'
+    - name: Validate GitHub Actions uses pinning
+      id: workflow-pinning
+      run: |
+        echo "🔍 Validating GitHub Actions uses pinning..."
+        if python scripts/hooks/precommit/validate_workflow_uses_pinning.py; then
+          echo "✅ GitHub Actions uses pinning validation completed successfully"
+          echo "status=success" >> $GITHUB_OUTPUT
+        else
+          echo "❌ GitHub Actions uses pinning validation failed"
+          echo "::error::GitHub Actions uses pinning validation failed"
+          echo "status=failed" >> $GITHUB_OUTPUT
+          exit 1
+        fi
   # Summary job that requires all other jobs but doesn't fail
   validation-summary:
     runs-on: ubuntu-latest
     name: Validation Summary
-    needs: [python-linting, python-testing]
+    needs: [python-linting, python-testing, workflow-uses-pinning]
     if: always()
     steps:
     - name: Generate Summary
@@ -109,8 +141,10 @@ jobs:
         # Check individual job results
         lint_result="${{ needs.python-linting.result }}"
         test_result="${{ needs.python-testing.result }}"
+        pinning_result="${{ needs.workflow-uses-pinning.result }}"
         lint_status="${{ needs.python-linting.outputs.lint_status }}"
         test_status="${{ needs.python-testing.outputs.test_status }}"
+        pinning_status="${{ needs.workflow-uses-pinning.outputs.pinning_status }}"
         overall_success=true
         
         echo "## Individual Job Results:" >> $GITHUB_STEP_SUMMARY
@@ -127,6 +161,13 @@ jobs:
           echo "- ✅ **Python test validation**: Passed" >> $GITHUB_STEP_SUMMARY
         else
           echo "- ❌ **Python test validation**: $test_result" >> $GITHUB_STEP_SUMMARY
+          overall_success=false
+        fi
+
+        if [ "$pinning_result" = "success" ]; then
+          echo "- ✅ **GitHub Actions uses pinning validation**: Passed" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "- ❌ **GitHub Actions uses pinning validation**: $pinning_result" >> $GITHUB_STEP_SUMMARY
           overall_success=false
         fi
         

--- a/.github/workflows/validate_python.yml
+++ b/.github/workflows/validate_python.yml
@@ -3,16 +3,12 @@ on:
   push:
     paths:
       - '**.py'
-      - '.github/workflows/*.yml'
-      - '.github/workflows/**/*.yml'
       - '.pre-commit-config.yaml'
       - 'requirements*.txt'
       - 'pyproject.toml'
   pull_request:
     paths:
       - '**.py'
-      - '.github/workflows/*.yml'
-      - '.github/workflows/**/*.yml'
       - '.pre-commit-config.yaml'
       - 'requirements*.txt'
       - 'pyproject.toml'
@@ -100,63 +96,35 @@ jobs:
           echo "status=failed" >> $GITHUB_OUTPUT
           exit 1
         fi
-  workflow-uses-pinning:
-    runs-on: ubuntu-latest
-    name: GitHub Actions Uses Pinning
-    needs: setup
-    outputs:
-      pinning_status: ${{ steps.workflow-pinning.outputs.status }}
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: '3.14'
-    - name: Validate GitHub Actions uses pinning
-      id: workflow-pinning
-      run: |
-        echo "🔍 Validating GitHub Actions uses pinning..."
-        if python scripts/hooks/precommit/validate_workflow_uses_pinning.py; then
-          echo "✅ GitHub Actions uses pinning validation completed successfully"
-          echo "status=success" >> $GITHUB_OUTPUT
-        else
-          echo "❌ GitHub Actions uses pinning validation failed"
-          echo "::error::GitHub Actions uses pinning validation failed"
-          echo "status=failed" >> $GITHUB_OUTPUT
-          exit 1
-        fi
   # Summary job that requires all other jobs but doesn't fail
   validation-summary:
     runs-on: ubuntu-latest
     name: Validation Summary
-    needs: [python-linting, python-testing, workflow-uses-pinning]
+    needs: [python-linting, python-testing]
     if: always()
     steps:
     - name: Generate Summary
       run: |
         echo "# 📋 Python Validation Summary" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        
+
         # Check individual job results
         lint_result="${{ needs.python-linting.result }}"
         test_result="${{ needs.python-testing.result }}"
-        pinning_result="${{ needs.workflow-uses-pinning.result }}"
         lint_status="${{ needs.python-linting.outputs.lint_status }}"
         test_status="${{ needs.python-testing.outputs.test_status }}"
-        pinning_status="${{ needs.workflow-uses-pinning.outputs.pinning_status }}"
         overall_success=true
-        
+
         echo "## Individual Job Results:" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        
+
         if [ "$lint_result" = "success" ]; then
           echo "- ✅ **Python linting validation**: Passed" >> $GITHUB_STEP_SUMMARY
         else
           echo "- ❌ **Python linting validation**: $lint_result" >> $GITHUB_STEP_SUMMARY
           overall_success=false
         fi
-        
+
         if [ "$test_result" = "success" ]; then
           echo "- ✅ **Python test validation**: Passed" >> $GITHUB_STEP_SUMMARY
         else
@@ -164,15 +132,8 @@ jobs:
           overall_success=false
         fi
 
-        if [ "$pinning_result" = "success" ]; then
-          echo "- ✅ **GitHub Actions uses pinning validation**: Passed" >> $GITHUB_STEP_SUMMARY
-        else
-          echo "- ❌ **GitHub Actions uses pinning validation**: $pinning_result" >> $GITHUB_STEP_SUMMARY
-          overall_success=false
-        fi
-        
         echo "" >> $GITHUB_STEP_SUMMARY
-        
+
         if [ "$overall_success" = "true" ]; then
           echo "## ✅ Overall Status: Success" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/validate_workflows.yml
+++ b/.github/workflows/validate_workflows.yml
@@ -1,0 +1,84 @@
+name: Workflow Validation
+on:
+  push:
+    paths:
+      - '.github/workflows/**/*.yml'
+      - 'docs/adr/024-*.md'
+      - '.pre-commit-config.yaml'
+      - 'scripts/hooks/precommit/validate_workflow_uses_pinning.py'
+  pull_request:
+    paths:
+      - '.github/workflows/**/*.yml'
+      - 'docs/adr/024-*.md'
+      - '.pre-commit-config.yaml'
+      - 'scripts/hooks/precommit/validate_workflow_uses_pinning.py'
+
+permissions:
+  contents: read
+
+jobs:
+  # The lint workflow itself uses ADR-024 D6 pin form, so this workflow is the
+  # most visible self-test for the policy it enforces.
+  workflow-uses-pinning:
+    runs-on: ubuntu-latest
+    name: GitHub Actions Uses Pinning
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.14'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Validate GitHub Actions uses pinning
+        id: workflow-pinning
+        run: |
+          echo "🔍 Validating GitHub Actions uses pinning..."
+          if python scripts/hooks/precommit/validate_workflow_uses_pinning.py; then
+            echo "✅ GitHub Actions uses pinning validation completed successfully"
+            echo "status=success" >> $GITHUB_OUTPUT
+          else
+            echo "❌ GitHub Actions uses pinning validation failed"
+            echo "::error::GitHub Actions uses pinning validation failed"
+            echo "status=failed" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+  validation-summary:
+    runs-on: ubuntu-latest
+    name: Validation Summary
+    needs: [workflow-uses-pinning]
+    if: always()
+    steps:
+      - name: Generate Summary
+        run: |
+          echo "# 📋 Workflow Validation Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          pinning_result="${{ needs.workflow-uses-pinning.result }}"
+          overall_success=true
+
+          echo "## Individual Job Results:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ "$pinning_result" = "success" ]; then
+            echo "- ✅ **GitHub Actions uses pinning validation**: Passed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- ❌ **GitHub Actions uses pinning validation**: $pinning_result" >> $GITHUB_STEP_SUMMARY
+            overall_success=false
+          fi
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ "$overall_success" = "true" ]; then
+            echo "## ✅ Overall Status: Success" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "🎉 All workflow validations passed!" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "## ❌ Overall Status: Failed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "💥 Some workflow validations failed. Check individual job details above." >> $GITHUB_STEP_SUMMARY
+            echo "::error::Some workflow validations failed"
+            exit 1
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@
 #   1. Schema validation (check-jsonschema, per yaml/schema pair)
 #   2. Prettier formatting (yaml in risk-map/yaml/)
 #   3. Ruff linting (Python)
-#   4. Local validators (component edges, control-risk, framework refs)
+#   4. Local validators (component edges, control-risk, framework refs, workflow action pins)
 #   5. Issue template regeneration + validation
 #   6. Mermaid graph, markdown table, and SVG regeneration (Mode B auto-stage)
 
@@ -224,6 +224,13 @@ repos:
         entry: python3 scripts/hooks/validate_framework_references.py
         files: ^risk-map/yaml/(controls|frameworks|personas|risks)\.yaml$
         pass_filenames: false
+
+      - id: validate-workflow-uses-pinning
+        name: 'github-actions: enforce SHA-pinned uses references'
+        language: system
+        entry: python3 scripts/hooks/precommit/validate_workflow_uses_pinning.py
+        files: ^\.github/workflows/.*\.yml$
+        pass_filenames: true
 
       - id: validate-identification-questions
         name: 'validate: identification-questions structural rules'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -198,9 +198,9 @@ repos:
 
   # ---------------------------------------------------------------------------
   # Local validators. Each runs only when its dependency files are staged
-  # (framework filters via `files:`); validators do their own internal staged-
-  # file detection, which is now redundant but harmless and preserves bash
-  # behavior. pass_filenames is false because each validator scans the repo.
+  # (framework filters via `files:`). The risk-map validators self-scan the
+  # repo and therefore use pass_filenames: false; file-scoped validators such
+  # as workflow pinning keep pass_filenames: true.
   # ---------------------------------------------------------------------------
   - repo: local
     hooks:

--- a/docs/adr/024-github-actions-pinning-posture.md
+++ b/docs/adr/024-github-actions-pinning-posture.md
@@ -59,6 +59,24 @@ The repository accepts the operational cost because the workflow threat model is
 
 This ADR does not decide Docker image digest pinning, devcontainer feature exact-version pinning, or base-image date-stamping. Those are tracked by issue [#248](https://github.com/cosai-oasis/secure-ai-tooling/issues/248) and the planned ADR-023 devcontainer maintenance policy.
 
+### D6. Pin form
+
+Every external `uses:` reference matches this form exactly:
+
+```
+uses: owner/repo@<40-hex-sha> # v<MAJOR>.<MINOR>.<PATCH>[-<prerelease>][+<build>]
+```
+
+The version comment uses the three-part `vMAJOR.MINOR.PATCH` shape, with optional `-prerelease` and `+build` suffixes for Actions that publish them. Two-part tags such as `v6` or `v6.2` are not accepted in the comment, even when the upstream Action also publishes a three-part release, because the comment must record the specific pinned release.
+
+The separator between the SHA and the comment is exactly one space, then `#`, then one space — the literal sequence ` # `. This makes the form mechanically checkable and keeps reviewer scanning consistent.
+
+The version comment is required whenever the pinned SHA corresponds to a tagged release. SHA pins without a corresponding upstream release tag (for example, a fix commit not yet released) are out of scope for this ADR and should be raised in PR review.
+
+### D7. `docker://` references warned, not blocked
+
+`uses: docker://...` references are advisory-warned by the lint, not rejected. Docker image pinning (digest vs. tag, registry trust) is a distinct decision tracked under issue [#248](https://github.com/cosai-oasis/secure-ai-tooling/issues/248) and the planned ADR-023. Until that ADR lands, `docker://` references surface as warnings so contributors and reviewers see them, without blocking PRs on a policy this ADR does not yet cover.
+
 ## Alternatives Considered
 
 - **Keep major tags (`actions/checkout@v6`).** Rejected. It preserves easy updates, but the executed code can change when the upstream tag moves. That leaves no visible diff in this repository for a supply-chain-relevant change.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,7 +19,7 @@ Development tools and utilities for this project.
 
 **[Hook Validations](docs/hook-validations.md)**
 
-- What the pre-commit hook validates (10 validation and generation types)
+- What the pre-commit hook validates
 - YAML schema validation, Prettier formatting, Ruff linting
 - Component edge validation and graph generation
 - Control-to-risk reference validation
@@ -99,6 +99,7 @@ Development tools and utilities for this project.
 - `hooks/validate_riskmap.py` - Component edge validation and graph generation
 - `hooks/validate_control_risk_references.py` - Control-risk cross-reference validation
 - `hooks/validate_framework_references.py` - Framework reference validation
+- `hooks/precommit/validate_workflow_uses_pinning.py` - GitHub Actions `uses:` pinning validation for ADR-024
 - `hooks/validate_issue_templates.py` - Issue template schema validation
 - `generate_issue_templates.py` - Issue template generator from sources
 - `hooks/yaml_to_markdown.py` - Markdown table generation from YAML

--- a/scripts/docs/github-actions.md
+++ b/scripts/docs/github-actions.md
@@ -30,11 +30,13 @@ In addition to local pre-commit validation, the repository includes GitHub Actio
 
 ## GitHub Actions Uses Pinning
 
-Workflow-only PRs trigger the Python validation workflow so
+Workflow-only PRs trigger the dedicated `validate_workflows.yml` workflow so
 `scripts/hooks/precommit/validate_workflow_uses_pinning.py` can enforce the
 same ADR-024 rule as pre-commit. External `uses:` references must be pinned as
-`owner/repo@<40-character-SHA> # vX.Y.Z`; local `./...` references are
-allowed. The CI failure names the offending workflow file and line.
+`owner/repo@<40-character-SHA> # vX.Y.Z` per ADR-024 D6; local `./...`
+references are allowed. `docker://` references emit an advisory warning per
+ADR-024 D7 (not a build failure) until the planned ADR-023 defines Docker
+pinning. The CI failure names the offending workflow file and line.
 
 ## Different Roles
 

--- a/scripts/docs/github-actions.md
+++ b/scripts/docs/github-actions.md
@@ -9,6 +9,8 @@ In addition to local pre-commit validation, the repository includes GitHub Actio
 - **YAML Schema Validation**: Validates all YAML files against their JSON schemas
 - **YAML Format Validation**: Checks prettier formatting compliance
 - **Python Linting**: Runs ruff linting on all Python files
+- **GitHub Actions Uses Pinning**: Enforces ADR-024 SHA-pinned `uses:`
+  references in `.github/workflows/*.yml`
 - **Component Edge Validation**: Verifies component relationship consistency
 - **Control-Risk Reference Validation**: Checks control-risk cross-reference integrity
 - **Graph Validation**: Generates and compares graphs against committed versions
@@ -25,6 +27,14 @@ In addition to local pre-commit validation, the repository includes GitHub Actio
   - Components tables (`components-full.md`, `components-summary.md`)
   - Risks tables (`risks-full.md`, `risks-summary.md`)
   - Controls tables (`controls-full.md`, `controls-summary.md`, `controls-xref-risks.md`, `controls-xref-components.md`)
+
+## GitHub Actions Uses Pinning
+
+Workflow-only PRs trigger the Python validation workflow so
+`scripts/hooks/precommit/validate_workflow_uses_pinning.py` can enforce the
+same ADR-024 rule as pre-commit. External `uses:` references must be pinned as
+`owner/repo@<40-character-SHA> # vX.Y.Z`; local `./...` references are
+allowed. The CI failure names the offending workflow file and line.
 
 ## Different Roles
 

--- a/scripts/docs/hook-validations.md
+++ b/scripts/docs/hook-validations.md
@@ -134,7 +134,39 @@ risks:
 - `frameworks.yaml` configuration and structure
 - `personas.yaml` framework applicability
 
-## 9. Issue Template Regeneration
+## 9. GitHub Actions `uses:` Pinning Validation
+
+`validate-workflow-uses-pinning` hook runs
+`scripts/hooks/precommit/validate_workflow_uses_pinning.py` when a workflow
+file under `.github/workflows/*.yml` or `.github/workflows/**/*.yml` is
+staged.
+
+**Validation:**
+
+- External `uses:` references must use
+  `owner/repo@<40-character-SHA> # vX.Y.Z`
+- External action subpaths and reusable workflows must use
+  `owner/repo/path@<40-character-SHA> # vX.Y.Z`
+- Local `./...` references are allowed without a SHA or version comment
+- `docker://` action references fail until a separate Docker pinning policy is
+  defined
+
+**Example:**
+
+```yaml
+# Valid external action reference
+- uses: actions/checkout@0123456789abcdef0123456789abcdef01234567 # v6.0.2
+
+# Valid local reference
+- uses: ./.github/actions/build
+
+# Invalid: mutable tag
+- uses: actions/checkout@v6
+```
+
+Violations name the offending workflow file and line number.
+
+## 10. Issue Template Regeneration
 
 `regenerate-issue-templates` hook (`scripts/hooks/precommit/regenerate_issue_templates.py`)
 triggers when any of these is staged:
@@ -157,12 +189,12 @@ regenerated templates land in the same commit.
 - `new_persona.yml`, `update_persona.yml`
 - `infrastructure.yml`
 
-## 10. Issue Template Validation
+## 11. Issue Template Validation
 
 `validate-issue-templates` hook runs
 `scripts/hooks/validate_issue_templates.py` when anything under
 `.github/ISSUE_TEMPLATE/*.yml` or `scripts/TEMPLATES/*.yml` is staged
-(including the files just regenerated in step 9).
+(including the files just regenerated in step 10).
 
 **Validates against vendored schemas:**
 
@@ -185,7 +217,7 @@ regenerated templates land in the same commit.
   validations: { required: true }   # ❌ checkboxes don't support top-level validations
 ```
 
-## 11. Graph Regeneration
+## 12. Graph Regeneration
 
 `regenerate-graphs` hook (`scripts/hooks/precommit/regenerate_graphs.py`)
 produces three Mermaid graph pairs based on which source yaml is staged:
@@ -199,7 +231,7 @@ produces three Mermaid graph pairs based on which source yaml is staged:
 Each output pair is `git add`-ed on success. The wrapper delegates to
 `validate_riskmap.py --to-graph / --to-controls-graph / --to-risk-graph`.
 
-## 12. Table Regeneration
+## 13. Table Regeneration
 
 `regenerate-tables` hook (`scripts/hooks/precommit/regenerate_tables.py`)
 produces 8 generation operations across 4 source triggers. The ordering
@@ -219,7 +251,7 @@ trigger) run — matches bash behavior.
 
 See [Table Generation](table-generation.md) for output filename conventions.
 
-## 13. Mermaid SVG Regeneration
+## 14. Mermaid SVG Regeneration
 
 `regenerate-svgs` hook (`scripts/hooks/precommit/regenerate_svgs.py`)
 converts staged `.mmd` or `.mermaid` files under `risk-map/diagrams/` into

--- a/scripts/docs/hook-validations.md
+++ b/scripts/docs/hook-validations.md
@@ -141,15 +141,16 @@ risks:
 file under `.github/workflows/*.yml` or `.github/workflows/**/*.yml` is
 staged.
 
-**Validation:**
+**Validation (ADR-024 D6 pin form):**
 
 - External `uses:` references must use
   `owner/repo@<40-character-SHA> # vX.Y.Z`
 - External action subpaths and reusable workflows must use
   `owner/repo/path@<40-character-SHA> # vX.Y.Z`
 - Local `./...` references are allowed without a SHA or version comment
-- `docker://` action references fail until a separate Docker pinning policy is
-  defined
+- `docker://` action references emit an advisory warning per ADR-024 D7
+  (not a commit-blocking failure) until the planned ADR-023 defines Docker
+  pinning
 
 **Example:**
 

--- a/scripts/docs/manual-validation.md
+++ b/scripts/docs/manual-validation.md
@@ -55,6 +55,9 @@ python3 scripts/hooks/validate_control_risk_references.py --force
 # Framework references
 python3 scripts/hooks/validate_framework_references.py --force
 
+# GitHub Actions `uses:` pinning
+python3 scripts/hooks/precommit/validate_workflow_uses_pinning.py
+
 # Issue template schemas
 python3 scripts/hooks/validate_issue_templates.py --force
 ```
@@ -66,10 +69,12 @@ To exercise a single hook declaratively (using the framework's config), run:
 ```bash
 # By hook id, against all files in the repo:
 pre-commit run validate-component-edges --all-files
+pre-commit run validate-workflow-uses-pinning --all-files
 pre-commit run check-jsonschema --all-files
 
 # Against a specific file set:
 pre-commit run validate-component-edges --files risk-map/yaml/components.yaml
+pre-commit run validate-workflow-uses-pinning --files .github/workflows/validation.yml
 ```
 
 Note: framework hooks with `pass_filenames: false` (the validators) will

--- a/scripts/docs/validation-flow.md
+++ b/scripts/docs/validation-flow.md
@@ -24,19 +24,22 @@ hooks show `(no files to check) Skipped` in the output.
    runs when `controls.yaml` or `risks.yaml` is staged.
 9. **Framework Reference Validation** — `validate_framework_references.py`
    runs when `controls`, `frameworks`, `personas`, or `risks` yaml is staged.
-10. **Issue Template Regeneration** — `regenerate_issue_templates.py` runs
+10. **GitHub Actions `uses:` Pinning Validation** —
+    `validate_workflow_uses_pinning.py` runs when `.github/workflows/*.yml`
+    or nested workflow `.yml` files are staged.
+11. **Issue Template Regeneration** — `regenerate_issue_templates.py` runs
     when any template source, any schema, or `frameworks.yaml` is staged;
     generates `.github/ISSUE_TEMPLATE/*.yml` and stages them.
-11. **Issue Template Validation** — `validate_issue_templates.py` runs when
+12. **Issue Template Validation** — `validate_issue_templates.py` runs when
     anything under `.github/ISSUE_TEMPLATE/` or `scripts/TEMPLATES/` is
-    staged (including the files just regenerated in step 10).
-12. **Graph Regeneration** — `regenerate_graphs.py` produces risk-map graph,
+    staged (including the files just regenerated in step 11).
+13. **Graph Regeneration** — `regenerate_graphs.py` produces risk-map graph,
     controls graph, and controls-to-risk graph (3 markdown + 3 mermaid outputs)
     based on which of `components.yaml`, `controls.yaml`, `risks.yaml` is
     staged. Each output pair is `git add`-ed on success.
-13. **Table Regeneration** — `regenerate_tables.py` regenerates 8 table
+14. **Table Regeneration** — `regenerate_tables.py` regenerates 8 table
     outputs across 4 triggers (see `scripts/docs/table-generation.md`).
-14. **SVG Regeneration** — `regenerate_svgs.py` converts staged
+15. **SVG Regeneration** — `regenerate_svgs.py` converts staged
     `risk-map/diagrams/*.mmd` or `*.mermaid` files to SVG.
 
 The commit is blocked if any hook returns non-zero.

--- a/scripts/hooks/precommit/validate_workflow_uses_pinning.py
+++ b/scripts/hooks/precommit/validate_workflow_uses_pinning.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+Pre-commit lint: enforce ADR-024 pinning for GitHub Actions `uses:` references.
+
+External workflow dependencies must use a full 40-character commit SHA and a
+same-line `# vX.Y.Z` semver comment so Dependabot can keep updating the pin.
+Local `./...` references are exempt. `docker://` references are rejected until
+a separate ADR defines the repository's Docker action pinning policy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+HOOK_NAME = "validate-workflow-uses-pinning"
+
+USES_LINE_RE = re.compile(r"^\s*(?:-\s*)?uses\s*:\s*(?P<rest>.*?)\s*$")
+PINNED_EXTERNAL_REF_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*@[0-9A-Fa-f]{40}$")
+SEMVER_COMMENT_RE = re.compile(
+    r"v(0|[1-9]\d*)\."
+    r"(0|[1-9]\d*)\."
+    r"(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z.-]+)?"
+    r"(?:\+[0-9A-Za-z.-]+)?"
+)
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A single workflow `uses:` pinning violation."""
+
+    path: Path
+    line: int
+    reference: str
+    message: str
+
+
+def _strip_optional_quotes(value: str) -> str:
+    """Remove one balanced layer of single or double quotes around a scalar."""
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _parse_uses_line(line: str) -> tuple[str, str | None, bool] | None:
+    """
+    Extract the `uses:` reference, same-line comment, and exact separator flag.
+
+    Comments matter for ADR-024, so this intentionally works on source lines
+    rather than parsed YAML. GitHub Actions `uses:` values do not contain `#`,
+    which keeps the split deterministic for the workflow shapes this repository
+    accepts.
+    """
+    match = USES_LINE_RE.match(line)
+    if match is None:
+        return None
+
+    rest = match.group("rest").rstrip()
+    value_part, separator, comment_part = rest.partition("#")
+    reference = _strip_optional_quotes(value_part.strip())
+
+    if not separator:
+        return reference, None, False
+
+    has_required_separator = value_part.endswith(" ") and comment_part.startswith(" ")
+    return reference, comment_part.strip(), has_required_separator
+
+
+def _validate_reference(
+    path: Path,
+    line_number: int,
+    reference: str,
+    comment: str | None,
+    separator_ok: bool,
+) -> Violation | None:
+    """Validate one parsed `uses:` reference and return a violation if it fails."""
+    if reference.startswith("./"):
+        return None
+
+    if reference.startswith("docker://"):
+        return Violation(
+            path=path,
+            line=line_number,
+            reference=reference,
+            message=(
+                "docker:// action references require maintainer review until a Docker action "
+                "pinning policy is defined"
+            ),
+        )
+
+    if not PINNED_EXTERNAL_REF_RE.fullmatch(reference):
+        return Violation(
+            path=path,
+            line=line_number,
+            reference=reference,
+            message=(
+                "external `uses:` reference must use owner/repo[/path]@<full "
+                "40-character commit SHA>; tags, branches, missing refs, and short SHAs are not allowed"
+            ),
+        )
+
+    if comment is None or not separator_ok or SEMVER_COMMENT_RE.fullmatch(comment) is None:
+        return Violation(
+            path=path,
+            line=line_number,
+            reference=reference,
+            message="SHA-pinned external `uses:` reference is missing required ` # vX.Y.Z` semver comment",
+        )
+
+    return None
+
+
+def validate_file(path: Path) -> list[Violation]:
+    """
+    Validate every `uses:` line in one workflow file.
+
+    Args:
+        path: Path to a GitHub Actions workflow `.yml` file.
+
+    Returns:
+        A list of pinning violations. Empty means the file passed.
+    """
+    violations: list[Violation] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        parsed = _parse_uses_line(line)
+        if parsed is None:
+            continue
+        reference, comment, separator_ok = parsed
+        violation = _validate_reference(path, line_number, reference, comment, separator_ok)
+        if violation is not None:
+            violations.append(violation)
+    return violations
+
+
+def discover_workflow_files(root: Path) -> list[Path]:
+    """
+    Return `.github/workflows/*.yml` and nested `.github/workflows/**/*.yml`.
+
+    Root-level workflows are returned before nested workflows so output order
+    mirrors the issue #264 scan scope.
+    """
+    workflows_dir = root / ".github" / "workflows"
+    if not workflows_dir.is_dir():
+        return []
+
+    root_workflows = sorted(workflows_dir.glob("*.yml"))
+    nested_workflows = sorted(path for path in workflows_dir.rglob("*.yml") if path.parent != workflows_dir)
+    return root_workflows + nested_workflows
+
+
+def format_violation(violation: Violation) -> str:
+    """Format one violation for stderr with actionable file:line context."""
+    return f"{HOOK_NAME}: {violation.path}:{violation.line}: {violation.message} (uses: {violation.reference})"
+
+
+def main(argv: list[str]) -> int:
+    """
+    CLI entry point for pre-commit and manual validation.
+
+    Pre-commit passes matched workflow filenames. With no filenames, the command
+    discovers `.github/workflows/*.yml` and nested `.yml` workflows from the
+    current working directory.
+    """
+    parser = argparse.ArgumentParser(description="Validate ADR-024 GitHub Actions `uses:` pinning.")
+    parser.add_argument("files", nargs="*", help="Workflow .yml files to validate.")
+    args = parser.parse_args(argv)
+
+    files = [Path(file) for file in args.files] if args.files else discover_workflow_files(Path.cwd())
+    violations: list[Violation] = []
+    for path in files:
+        if not path.exists():
+            continue
+        violations.extend(validate_file(path))
+
+    for violation in violations:
+        print(format_violation(violation), file=sys.stderr)
+
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/hooks/precommit/validate_workflow_uses_pinning.py
+++ b/scripts/hooks/precommit/validate_workflow_uses_pinning.py
@@ -2,10 +2,22 @@
 """
 Pre-commit lint: enforce ADR-024 pinning for GitHub Actions `uses:` references.
 
-External workflow dependencies must use a full 40-character commit SHA and a
-same-line `# vX.Y.Z` semver comment so Dependabot can keep updating the pin.
-Local `./...` references are exempt. `docker://` references are rejected until
-a separate ADR defines the repository's Docker action pinning policy.
+Parses each workflow file via PyYAML's `yaml.compose()` to obtain an AST with
+source line numbers. Walking the AST finds every `uses:` key at any nesting
+depth, including quoted keys and keys inside matrix-strategy mappings.
+
+For each `uses:` value the validator re-reads the corresponding source line to
+extract any trailing `# comment` (PyYAML does not preserve comments). If the
+value is a block scalar (folded `>` or literal `|`), it spans multiple source
+lines and can carry no same-line comment; that is an ADR-024 D6 violation.
+
+ADR-024 D6: external references must be pinned to a full 40-character SHA with
+a same-line ` # vX.Y.Z` comment (exactly one space before and after `#`).
+
+ADR-024 D7: `docker://` references produce an advisory warning (stderr prefix
+`validate-workflow-uses-pinning: warning:`) but do not fail the build.
+
+Local `./...` references are exempt from all pinning rules.
 """
 
 from __future__ import annotations
@@ -16,10 +28,19 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+import yaml
+
 HOOK_NAME = "validate-workflow-uses-pinning"
 
-USES_LINE_RE = re.compile(r"^\s*(?:-\s*)?(?:uses|\"uses\"|'uses')\s*:\s*(?P<rest>.*?)\s*$")
+# Matches owner/repo[@...] with an exactly-40-hex SHA after `@`.
 PINNED_EXTERNAL_REF_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*@[0-9A-Fa-f]{40}$")
+
+# Matches values where a valid SHA pin was written but `#` was appended without
+# a preceding space (e.g., `owner/repo@<sha># v1.2.3`). PyYAML absorbs the
+# `# ...` into the scalar value when there is no space before `#`.
+_SHA_NO_SPACE_HASH_RE = re.compile(r"^([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*@[0-9A-Fa-f]{40})#")
+
+# Matches a full semver version comment: vMAJOR.MINOR.PATCH[-prerelease][+build]
 SEMVER_COMMENT_RE = re.compile(
     r"v(0|[1-9]\d*)\."
     r"(0|[1-9]\d*)\."
@@ -31,7 +52,7 @@ SEMVER_COMMENT_RE = re.compile(
 
 @dataclass(frozen=True)
 class Violation:
-    """A single workflow `uses:` pinning violation."""
+    """A single workflow `uses:` pinning violation or advisory warning."""
 
     path: Path
     line: int
@@ -39,35 +60,106 @@ class Violation:
     message: str
 
 
-def _strip_optional_quotes(value: str) -> str:
-    """Remove one balanced layer of single or double quotes around a scalar."""
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-        return value[1:-1]
-    return value
-
-
-def _parse_uses_line(line: str) -> tuple[str, str | None, bool] | None:
+def _walk_nodes(node: yaml.Node) -> list[tuple[yaml.ScalarNode, yaml.Node]]:
     """
-    Extract the `uses:` reference, same-line comment, and exact separator flag.
+    Recursively collect (key_node, value_node) pairs where the key is `uses`.
 
-    Comments matter for ADR-024, so this intentionally works on source lines
-    rather than parsed YAML. GitHub Actions `uses:` values do not contain `#`,
-    which keeps the split deterministic for the workflow shapes this repository
-    accepts.
+    Descends into MappingNode and SequenceNode values at any depth. Quoted keys
+    parse to the same string as unquoted keys in PyYAML, so no special handling
+    is needed for quoted `uses:` keys.
+
+    Args:
+        node: A PyYAML node (MappingNode, SequenceNode, or ScalarNode).
+
+    Returns:
+        List of (key_node, value_node) tuples for every `uses:` key found.
     """
-    match = USES_LINE_RE.match(line)
-    if match is None:
+    results: list[tuple[yaml.ScalarNode, yaml.Node]] = []
+
+    if isinstance(node, yaml.MappingNode):
+        for key_node, value_node in node.value:
+            if isinstance(key_node, yaml.ScalarNode) and key_node.value == "uses":
+                results.append((key_node, value_node))
+            # Always recurse into both sides of the mapping.
+            results.extend(_walk_nodes(key_node))
+            results.extend(_walk_nodes(value_node))
+    elif isinstance(node, yaml.SequenceNode):
+        for item in node.value:
+            results.extend(_walk_nodes(item))
+
+    return results
+
+
+def _extract_trailing_comment(source_lines: list[str], value_node: yaml.Node, resolved_value: str) -> str | None:
+    """
+    Find the inline comment that follows the scalar value on its source line.
+
+    Strategy: locate the source line at the value node's start_mark. If the
+    resolved value string appears as a substring of that line, everything after
+    it (stripped of leading whitespace and a single `#`) is the comment. If the
+    resolved value is not on the same line (e.g., a block scalar), return None.
+
+    This works for the inline scalar case — the common and only valid ADR-024
+    form. Block scalars (folded `>` / literal `|`) never appear on the same
+    source line as their resolved content; None correctly signals no comment.
+
+    Args:
+        source_lines: All lines of the workflow file (0-indexed).
+        value_node:   PyYAML node for the `uses:` value.
+        resolved_value: The string PyYAML resolved from the node.
+
+    Returns:
+        The comment text (e.g., `v6.0.2`) if present, or None.
+    """
+    line_index = value_node.start_mark.line
+    if line_index >= len(source_lines):
         return None
 
-    rest = match.group("rest").rstrip()
-    value_part, separator, comment_part = rest.partition("#")
-    reference = _strip_optional_quotes(value_part.strip())
+    source_line = source_lines[line_index]
 
-    if not separator:
-        return reference, None, False
+    # Strip the YAML-resolved value from the source line to isolate the comment.
+    # The resolved value must appear literally in the source line for inline scalars.
+    pos = source_line.find(resolved_value)
+    if pos == -1:
+        # Block scalar: value is not on the same line as the `uses:` key.
+        return None
 
-    has_required_separator = value_part.endswith(" ") and comment_part.startswith(" ")
-    return reference, comment_part.strip(), has_required_separator
+    after_value = source_line[pos + len(resolved_value) :]
+    stripped = after_value.lstrip()
+    if not stripped.startswith("#"):
+        return None
+
+    # Return just the comment body (after `#` and leading space).
+    return stripped[1:].lstrip()
+
+
+def _check_separator(source_lines: list[str], value_node: yaml.Node, resolved_value: str) -> bool:
+    """
+    Return True if the value-to-comment separator is exactly ` # ` (one space each side).
+
+    ADR-024 D6 requires exactly one space before `#` and one space after it.
+    Two spaces before `#` (or no space after) is a violation.
+
+    Args:
+        source_lines:   All source lines of the workflow file (0-indexed).
+        value_node:     PyYAML node for the `uses:` value.
+        resolved_value: The string PyYAML resolved from the node.
+
+    Returns:
+        True if the separator is exactly ` # `, False otherwise.
+    """
+    line_index = value_node.start_mark.line
+    if line_index >= len(source_lines):
+        return False
+
+    source_line = source_lines[line_index]
+    pos = source_line.find(resolved_value)
+    if pos == -1:
+        return False
+
+    after_value = source_line[pos + len(resolved_value) :]
+    # Must be exactly one space, then `#`, then one space.
+    return after_value.startswith(" #") and len(after_value) > 2 and after_value[2] == " "
 
 
 def _validate_reference(
@@ -76,64 +168,139 @@ def _validate_reference(
     reference: str,
     comment: str | None,
     separator_ok: bool,
-) -> Violation | None:
-    """Validate one parsed `uses:` reference and return a violation if it fails."""
+) -> tuple[Violation | None, Violation | None]:
+    """
+    Validate one resolved `uses:` reference value.
+
+    Args:
+        path:         Workflow file path.
+        line_number:  1-based line number of the value node.
+        reference:    The resolved YAML scalar string (stripped of surrounding newlines).
+        comment:      Trailing comment body if found on the source line, else None.
+        separator_ok: True if the separator between SHA and `#` is exactly ` # `.
+
+    Returns:
+        (error, warning) where at most one of the two is a Violation.
+        Both None means the reference is valid.
+    """
     if reference.startswith("./"):
-        return None
+        return None, None
 
     if reference.startswith("docker://"):
-        return Violation(
+        warning = Violation(
             path=path,
             line=line_number,
             reference=reference,
             message=(
-                "docker:// action references require maintainer review until a Docker action "
-                "pinning policy is defined"
+                "docker:// action references emit an advisory warning until the planned "
+                "ADR-023 defines Docker pinning; see ADR-024 D7"
             ),
+        )
+        return None, warning
+
+    # Detect `owner/repo@<sha>#...` (no space before `#`): PyYAML absorbs the
+    # comment text into the scalar value. The SHA is intact; the violation is the
+    # missing separator, not a bad SHA.
+    no_space_match = _SHA_NO_SPACE_HASH_RE.match(reference)
+    if no_space_match:
+        return (
+            Violation(
+                path=path,
+                line=line_number,
+                reference=no_space_match.group(1),
+                message="SHA-pinned external `uses:` reference is missing required ` # vX.Y.Z` semver comment",
+            ),
+            None,
         )
 
     if not PINNED_EXTERNAL_REF_RE.fullmatch(reference):
-        return Violation(
-            path=path,
-            line=line_number,
-            reference=reference,
-            message=(
-                "external `uses:` reference must use owner/repo[/path]@<full "
-                "40-character commit SHA>; tags, branches, missing refs, and short SHAs are not allowed"
+        return (
+            Violation(
+                path=path,
+                line=line_number,
+                reference=reference,
+                message=(
+                    "external `uses:` reference must use owner/repo[/path]@<full "
+                    "40-character commit SHA>; tags, branches, missing refs, and short SHAs are not allowed"
+                ),
             ),
+            None,
         )
 
     if comment is None or not separator_ok or SEMVER_COMMENT_RE.fullmatch(comment) is None:
-        return Violation(
-            path=path,
-            line=line_number,
-            reference=reference,
-            message="SHA-pinned external `uses:` reference is missing required ` # vX.Y.Z` semver comment",
+        return (
+            Violation(
+                path=path,
+                line=line_number,
+                reference=reference,
+                message="SHA-pinned external `uses:` reference is missing required ` # vX.Y.Z` semver comment",
+            ),
+            None,
         )
 
-    return None
+    return None, None
 
 
-def validate_file(path: Path) -> list[Violation]:
+def validate_file(path: Path) -> tuple[list[Violation], list[Violation]]:
     """
-    Validate every `uses:` line in one workflow file.
+    Validate every `uses:` entry in one workflow file using the PyYAML AST.
 
     Args:
         path: Path to a GitHub Actions workflow `.yml` file.
 
     Returns:
-        A list of pinning violations. Empty means the file passed.
+        (errors, warnings) — errors cause exit code 1; warnings are advisory only.
     """
-    violations: list[Violation] = []
-    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-        parsed = _parse_uses_line(line)
-        if parsed is None:
+    errors: list[Violation] = []
+    warnings: list[Violation] = []
+
+    raw = path.read_text(encoding="utf-8")
+    # splitlines() handles both LF and CRLF transparently.
+    source_lines = raw.splitlines()
+
+    try:
+        root = yaml.compose(raw)
+    except yaml.YAMLError as exc:
+        # Surfacing a parse error as a violation avoids a hard crash.
+        mark = getattr(exc, "problem_mark", None)
+        line_number = (mark.line + 1) if mark is not None else 1
+        errors.append(
+            Violation(
+                path=path,
+                line=line_number,
+                reference="",
+                message=f"workflow file is not valid YAML: {exc}",
+            )
+        )
+        return errors, warnings
+
+    if root is None:
+        # Empty file — nothing to validate.
+        return errors, warnings
+
+    for _key_node, value_node in _walk_nodes(root):
+        if not isinstance(value_node, yaml.ScalarNode):
+            # Non-scalar `uses:` values are structurally invalid YAML for
+            # GitHub Actions but won't be caught here; schema validation handles it.
             continue
-        reference, comment, separator_ok = parsed
-        violation = _validate_reference(path, line_number, reference, comment, separator_ok)
-        if violation is not None:
-            violations.append(violation)
-    return violations
+
+        # 1-based line number of where the value starts in the source.
+        line_number = value_node.start_mark.line + 1
+
+        # PyYAML resolves the scalar (handles folded/literal block scalars).
+        # Strip trailing newlines that PyYAML appends for block scalars.
+        resolved = value_node.value.strip()
+
+        comment = _extract_trailing_comment(source_lines, value_node, value_node.value.rstrip("\n"))
+        separator_ok = _check_separator(source_lines, value_node, value_node.value.rstrip("\n"))
+
+        error, warning = _validate_reference(path, line_number, resolved, comment, separator_ok)
+        if error is not None:
+            errors.append(error)
+        if warning is not None:
+            warnings.append(warning)
+
+    return errors, warnings
 
 
 def discover_workflow_files(root: Path) -> list[Path]:
@@ -157,6 +324,11 @@ def format_violation(violation: Violation) -> str:
     return f"{HOOK_NAME}: {violation.path}:{violation.line}: {violation.message} (uses: {violation.reference})"
 
 
+def format_warning(warning: Violation) -> str:
+    """Format one advisory warning for stderr."""
+    return f"{HOOK_NAME}: warning: {warning.path}:{warning.line}: {warning.message} (uses: {warning.reference})"
+
+
 def main(argv: list[str]) -> int:
     """
     CLI entry point for pre-commit and manual validation.
@@ -164,22 +336,31 @@ def main(argv: list[str]) -> int:
     Pre-commit passes matched workflow filenames. With no filenames, the command
     discovers `.github/workflows/*.yml` and nested `.yml` workflows from the
     current working directory.
+
+    Returns 1 if any errors are found; 0 if only warnings or clean.
     """
     parser = argparse.ArgumentParser(description="Validate ADR-024 GitHub Actions `uses:` pinning.")
     parser.add_argument("files", nargs="*", help="Workflow .yml files to validate.")
     args = parser.parse_args(argv)
 
     files = [Path(file) for file in args.files] if args.files else discover_workflow_files(Path.cwd())
-    violations: list[Violation] = []
+    all_errors: list[Violation] = []
+    all_warnings: list[Violation] = []
+
     for path in files:
         if not path.exists():
             continue
-        violations.extend(validate_file(path))
+        file_errors, file_warnings = validate_file(path)
+        all_errors.extend(file_errors)
+        all_warnings.extend(file_warnings)
 
-    for violation in violations:
+    for violation in all_errors:
         print(format_violation(violation), file=sys.stderr)
 
-    return 1 if violations else 0
+    for warning in all_warnings:
+        print(format_warning(warning), file=sys.stderr)
+
+    return 1 if all_errors else 0
 
 
 if __name__ == "__main__":

--- a/scripts/hooks/precommit/validate_workflow_uses_pinning.py
+++ b/scripts/hooks/precommit/validate_workflow_uses_pinning.py
@@ -90,76 +90,53 @@ def _walk_nodes(node: yaml.Node) -> list[tuple[yaml.ScalarNode, yaml.Node]]:
     return results
 
 
-def _extract_trailing_comment(source_lines: list[str], value_node: yaml.Node, resolved_value: str) -> str | None:
+def _extract_pin_comment(
+    source_lines: list[str], value_node: yaml.Node, resolved_value: str
+) -> tuple[str | None, bool]:
     """
-    Find the inline comment that follows the scalar value on its source line.
+    Locate the inline comment after the scalar value and check separator shape.
 
-    Strategy: locate the source line at the value node's start_mark. If the
-    resolved value string appears as a substring of that line, everything after
-    it (stripped of leading whitespace and a single `#`) is the comment. If the
-    resolved value is not on the same line (e.g., a block scalar), return None.
-
-    This works for the inline scalar case — the common and only valid ADR-024
-    form. Block scalars (folded `>` / literal `|`) never appear on the same
-    source line as their resolved content; None correctly signals no comment.
+    Strategy: find the resolved value as a substring of the value's source line.
+    For quoted scalars the resolved value sits inside the quotes, so the cursor
+    must advance past the closing quote before inspecting the ` # ` separator.
+    Block scalars (folded `>` / literal `|`) and other forms where the value is
+    not on the same source line return (None, False).
 
     Args:
-        source_lines: All lines of the workflow file (0-indexed).
-        value_node:   PyYAML node for the `uses:` value.
-        resolved_value: The string PyYAML resolved from the node.
-
-    Returns:
-        The comment text (e.g., `v6.0.2`) if present, or None.
-    """
-    line_index = value_node.start_mark.line
-    if line_index >= len(source_lines):
-        return None
-
-    source_line = source_lines[line_index]
-
-    # Strip the YAML-resolved value from the source line to isolate the comment.
-    # The resolved value must appear literally in the source line for inline scalars.
-    pos = source_line.find(resolved_value)
-    if pos == -1:
-        # Block scalar: value is not on the same line as the `uses:` key.
-        return None
-
-    after_value = source_line[pos + len(resolved_value) :]
-    stripped = after_value.lstrip()
-    if not stripped.startswith("#"):
-        return None
-
-    # Return just the comment body (after `#` and leading space).
-    return stripped[1:].lstrip()
-
-
-def _check_separator(source_lines: list[str], value_node: yaml.Node, resolved_value: str) -> bool:
-    """
-    Return True if the value-to-comment separator is exactly ` # ` (one space each side).
-
-    ADR-024 D6 requires exactly one space before `#` and one space after it.
-    Two spaces before `#` (or no space after) is a violation.
-
-    Args:
-        source_lines:   All source lines of the workflow file (0-indexed).
+        source_lines:   All lines of the workflow file (0-indexed).
         value_node:     PyYAML node for the `uses:` value.
         resolved_value: The string PyYAML resolved from the node.
 
     Returns:
-        True if the separator is exactly ` # `, False otherwise.
+        (comment_or_None, separator_ok). The comment is the text after `#` with
+        leading space stripped, or None when no inline comment is found.
+        separator_ok is True only when the separator is exactly ` # ` (one
+        space, hash, one space) per ADR-024 D6.
     """
     line_index = value_node.start_mark.line
     if line_index >= len(source_lines):
-        return False
+        return None, False
 
     source_line = source_lines[line_index]
     pos = source_line.find(resolved_value)
     if pos == -1:
-        return False
+        # Block scalar: value is not on the same line as the `uses:` key.
+        return None, False
 
-    after_value = source_line[pos + len(resolved_value) :]
-    # Must be exactly one space, then `#`, then one space.
-    return after_value.startswith(" #") and len(after_value) > 2 and after_value[2] == " "
+    cursor = pos + len(resolved_value)
+    # Quoted scalars have a closing quote between the resolved value and the
+    # ` # ` separator; PyYAML stores the quote style on the node.
+    if getattr(value_node, "style", None) in ('"', "'"):
+        cursor += 1
+
+    after_value = source_line[cursor:]
+    separator_ok = after_value.startswith(" #") and len(after_value) > 2 and after_value[2] == " "
+
+    stripped = after_value.lstrip()
+    if not stripped.startswith("#"):
+        return None, separator_ok
+
+    return stripped[1:].lstrip(), separator_ok
 
 
 def _validate_reference(
@@ -291,8 +268,7 @@ def validate_file(path: Path) -> tuple[list[Violation], list[Violation]]:
         # Strip trailing newlines that PyYAML appends for block scalars.
         resolved = value_node.value.strip()
 
-        comment = _extract_trailing_comment(source_lines, value_node, value_node.value.rstrip("\n"))
-        separator_ok = _check_separator(source_lines, value_node, value_node.value.rstrip("\n"))
+        comment, separator_ok = _extract_pin_comment(source_lines, value_node, value_node.value.rstrip("\n"))
 
         error, warning = _validate_reference(path, line_number, resolved, comment, separator_ok)
         if error is not None:

--- a/scripts/hooks/precommit/validate_workflow_uses_pinning.py
+++ b/scripts/hooks/precommit/validate_workflow_uses_pinning.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 HOOK_NAME = "validate-workflow-uses-pinning"
 
-USES_LINE_RE = re.compile(r"^\s*(?:-\s*)?uses\s*:\s*(?P<rest>.*?)\s*$")
+USES_LINE_RE = re.compile(r"^\s*(?:-\s*)?(?:uses|\"uses\"|'uses')\s*:\s*(?P<rest>.*?)\s*$")
 PINNED_EXTERNAL_REF_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*@[0-9A-Fa-f]{40}$")
 SEMVER_COMMENT_RE = re.compile(
     r"v(0|[1-9]\d*)\."

--- a/scripts/hooks/tests/test_precommit_hook_install.py
+++ b/scripts/hooks/tests/test_precommit_hook_install.py
@@ -112,6 +112,7 @@ _REQUIRED_HOOK_IDS = {
     "validate-component-edges",
     "validate-control-risk-references",
     "validate-framework-references",
+    "validate-workflow-uses-pinning",
     # Issue templates:
     "regenerate-issue-templates",
     "validate-issue-templates",
@@ -229,6 +230,16 @@ class TestValidatorHookContracts:
         for token in ("controls", "frameworks", "personas", "risks"):
             assert token in files, f"framework refs files regex missing `{token}`: {files!r}"
         assert hook.get("pass_filenames") is False
+
+    def test_validate_workflow_uses_pinning_targets_workflow_yml_files(self):
+        hooks = _hooks_by_id("validate-workflow-uses-pinning")
+        assert len(hooks) == 1
+        hook = hooks[0]
+        assert "validate_workflow_uses_pinning.py" in hook.get("entry", "")
+        files = hook.get("files", "")
+        assert ".github/workflows" in files
+        assert "yml" in files
+        assert hook.get("pass_filenames") is True
 
 
 # ===========================================================================

--- a/scripts/hooks/tests/test_validate_workflow_uses_pinning.py
+++ b/scripts/hooks/tests/test_validate_workflow_uses_pinning.py
@@ -5,8 +5,27 @@ Tests for scripts/hooks/precommit/validate_workflow_uses_pinning.py.
 The validator enforces ADR-024 for GitHub Actions workflow `uses:` references:
 external actions must be pinned to a full 40-character commit SHA and carry a
 same-line `# vX.Y.Z` release comment for Dependabot update tracking. Local
-`./...` references are exempt. Docker action references are rejected until a
-separate ADR defines their pinning policy.
+`./...` references are exempt.
+
+ADR-024 D7: `docker://` references are warned (stderr, prefix
+`validate-workflow-uses-pinning: warning:`) but do not fail the build (exit 0).
+
+ADR-024 D6: the separator between SHA and comment is exactly ` # ` (one space,
+hash, one space). Two spaces before `#` is a violation.
+
+API CONTRACT for `validate_file`:
+    validate_file(path: Path) -> tuple[list[Violation], list[Violation]]
+
+    The return value is (errors, warnings).
+    - errors: violations that cause exit code 1
+    - warnings: findings that are emitted to stderr but do not affect exit code
+    - Both lists are empty for a fully-compliant file.
+
+    The SWE agent must update `validate_file` to return this tuple shape.
+    `main()` continues to return int (0 or 1). Warnings from `validate_file`
+    are printed to stderr with the prefix
+    `validate-workflow-uses-pinning: warning:` and do not contribute to the
+    exit code.
 """
 
 import sys
@@ -56,7 +75,9 @@ jobs:
 """.lstrip(),
         )
 
-        assert validate_file(workflow) == []
+        errors, warnings = validate_file(workflow)
+        assert errors == []
+        assert warnings == []
 
     def test_external_action_with_path_and_prerelease_comment_passes(self, tmp_path):
         """
@@ -75,7 +96,9 @@ jobs:
 """.lstrip(),
         )
 
-        assert validate_file(workflow) == []
+        errors, warnings = validate_file(workflow)
+        assert errors == []
+        assert warnings == []
 
     def test_local_relative_action_is_allowed_without_sha_or_comment(self, tmp_path):
         """
@@ -94,7 +117,9 @@ jobs:
 """.lstrip(),
         )
 
-        assert validate_file(workflow) == []
+        errors, warnings = validate_file(workflow)
+        assert errors == []
+        assert warnings == []
 
     def test_local_reusable_workflow_is_allowed_without_sha_or_comment(self, tmp_path):
         """
@@ -112,7 +137,37 @@ jobs:
 """.lstrip(),
         )
 
-        assert validate_file(workflow) == []
+        errors, warnings = validate_file(workflow)
+        assert errors == []
+        assert warnings == []
+
+    def test_standard_happy_path_at_step_indentation_passes(self, tmp_path):
+        """
+        Regression-safety pin alongside the new adversarial cases.
+
+        Given: A correctly-pinned step `uses:` at normal indentation
+        When: validate_file scans the workflow
+        Then: No errors and no warnings are returned
+
+        This is the same form validated by ADR-024 D6 and serves as a stable
+        baseline to run alongside block-scalar and other adversarial cases.
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            f"""
+name: happy path
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@{FULL_SHA} # v6.0.2
+""".lstrip(),
+        )
+
+        errors, warnings = validate_file(workflow)
+        assert errors == []
+        assert warnings == []
 
 
 class TestFailingReferences:
@@ -136,7 +191,7 @@ class TestFailingReferences:
         """
         Given: An external `uses:` reference that violates ADR-024
         When: validate_file scans the workflow
-        Then: One violation identifies the specific policy gap
+        Then: One error identifies the specific policy gap
         """
         workflow = _write_workflow(
             tmp_path,
@@ -149,10 +204,10 @@ jobs:
 """.lstrip(),
         )
 
-        violations = validate_file(workflow)
+        errors, warnings = validate_file(workflow)
 
-        assert len(violations) == 1
-        assert expected in violations[0].message
+        assert len(errors) == 1
+        assert expected in errors[0].message
 
     def test_quoted_job_level_uses_key_fails(self, tmp_path):
         """
@@ -170,32 +225,10 @@ jobs:
 """.lstrip(),
         )
 
-        violations = validate_file(workflow)
+        errors, warnings = validate_file(workflow)
 
-        assert len(violations) == 1
-        assert "full 40-character commit SHA" in violations[0].message
-
-    def test_docker_action_reference_fails_for_maintainer_review(self, tmp_path):
-        """
-        Given: A `docker://` action reference
-        When: validate_file scans the workflow
-        Then: The validator rejects it until a Docker pinning policy exists
-        """
-        workflow = _write_workflow(
-            tmp_path,
-            """
-name: docker action
-jobs:
-  test:
-    steps:
-      - uses: docker://alpine:3.20
-""".lstrip(),
-        )
-
-        violations = validate_file(workflow)
-
-        assert len(violations) == 1
-        assert "docker:// action references require maintainer review" in violations[0].message
+        assert len(errors) == 1
+        assert "full 40-character commit SHA" in errors[0].message
 
     def test_violation_format_includes_file_line_and_reference(self, tmp_path):
         """
@@ -215,11 +248,335 @@ jobs:
 """.lstrip(),
         )
 
-        violation = validate_file(workflow)[0]
+        errors, _warnings = validate_file(workflow)
+        violation = errors[0]
         rendered = format_violation(violation)
 
         assert f"{workflow}:6:" in rendered
         assert "actions/checkout@v6" in rendered
+
+
+class TestDockerWarning:
+    """ADR-024 D7: `docker://` references are warned, not blocked."""
+
+    def test_docker_action_reference_warns_for_maintainer_review(self, tmp_path):
+        """
+        Given: A `docker://` action reference (ADR-024 D7)
+        When: validate_file scans the workflow
+        Then: No errors are produced; one warning identifies the reference with ADR-024 D7
+
+        The warning message must contain `ADR-024 D7` so consumers can grep
+        for the specific policy context.
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            """
+name: docker action
+jobs:
+  test:
+    steps:
+      - uses: docker://alpine:3.20
+""".lstrip(),
+        )
+
+        errors, warnings = validate_file(workflow)
+
+        assert errors == [], "docker:// reference must not produce an error (ADR-024 D7)"
+        assert len(warnings) == 1
+        assert "ADR-024 D7" in warnings[0].message
+        assert "docker://alpine:3.20" in warnings[0].reference
+
+    def test_docker_action_main_returns_zero(self, tmp_path, capsys):
+        """
+        Given: A workflow with only a `docker://` reference
+        When: main is invoked with the workflow path
+        Then: Exit code is 0 (warnings don't fail the build per ADR-024 D7)
+
+        The stderr output must contain the warning prefix
+        `validate-workflow-uses-pinning: warning:` and `ADR-024 D7`.
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            """
+name: docker action
+jobs:
+  test:
+    steps:
+      - uses: docker://alpine:3.20
+""".lstrip(),
+        )
+
+        exit_code = main([str(workflow)])
+        captured = capsys.readouterr()
+
+        assert exit_code == 0
+        assert "validate-workflow-uses-pinning: warning:" in captured.err
+        assert "ADR-024 D7" in captured.err
+
+    def test_docker_warning_stderr_includes_file_and_line(self, tmp_path, capsys):
+        """
+        Given: A workflow with a `docker://` reference
+        When: main is invoked
+        Then: stderr identifies the file path and line number of the warning
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            """
+name: docker action
+jobs:
+  test:
+    steps:
+      - uses: docker://alpine:3.20
+""".lstrip(),
+        )
+
+        main([str(workflow)])
+        captured = capsys.readouterr()
+
+        # The warning line must embed the file path and the reference.
+        assert str(workflow) in captured.err
+        assert "docker://alpine:3.20" in captured.err
+
+    def test_docker_warning_with_real_violation_returns_one(self, tmp_path, capsys):
+        """
+        Given: A workflow with both a `docker://` reference and a real pinning error
+        When: main is invoked
+        Then: Exit code is 1 (the error drives the exit) and stderr contains both findings
+
+        The docker:// warning is still emitted even when errors are present.
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            """
+name: mixed
+jobs:
+  test:
+    steps:
+      - uses: docker://alpine:3.20
+      - uses: actions/checkout@v6
+""".lstrip(),
+        )
+
+        exit_code = main([str(workflow)])
+        captured = capsys.readouterr()
+
+        assert exit_code == 1
+        # The docker warning must still appear.
+        assert "validate-workflow-uses-pinning: warning:" in captured.err
+        assert "ADR-024 D7" in captured.err
+        # The pinning error must also appear.
+        assert "full 40-character commit SHA" in captured.err
+
+
+class TestAdversarialParsing:
+    """
+    Edge cases that exercise PyYAML AST-based parsing.
+
+    These cases either silently pass (false negatives) or fail incorrectly
+    under the current line-regex implementation. The tests define the contract
+    for the AST-based implementation the SWE agent will write.
+
+    PyYAML parses structure and provides line numbers; the validator re-reads
+    the source line for comment extraction (PyYAML does not preserve comments).
+    """
+
+    def test_latest_tag_reference_fails(self, tmp_path):
+        """
+        Given: A `uses:` with the `@latest` floating tag (ADR-024 D2)
+        When: validate_file scans the workflow
+        Then: One error citing the missing full SHA is produced
+
+        `@latest` is a mutable tag; it must be replaced with a pinned SHA.
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            """
+name: latest
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@latest
+""".lstrip(),
+        )
+
+        errors, warnings = validate_file(workflow)
+
+        assert len(errors) == 1
+        assert "full 40-character commit SHA" in errors[0].message
+
+    def test_two_spaces_before_hash_fails(self, tmp_path):
+        """
+        Given: A SHA-pinned `uses:` with two spaces before `#` instead of one
+        When: validate_file scans the workflow
+        Then: One error citing the missing ` # vX.Y.Z` separator is produced
+
+        ADR-024 D6 requires exactly one space before and after `#`. Two spaces
+        fail the mechanical separator check.
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            # Two spaces between SHA and `#` — note the double-space in the f-string.
+            f"""
+name: two-space separator
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@{FULL_SHA}  # v1.2.3
+""".lstrip(),
+        )
+
+        errors, warnings = validate_file(workflow)
+
+        assert len(errors) == 1
+        assert "missing required ` # vX.Y.Z`" in errors[0].message
+
+    def test_crlf_line_endings_pass(self, tmp_path):
+        """
+        Given: A valid workflow file with CRLF (`\\r\\n`) line endings
+        When: validate_file scans the workflow
+        Then: No errors and no warnings are produced
+
+        CRLF is the native line ending on Windows. The validator must strip
+        carriage returns before applying line-level checks.
+        """
+        content = (
+            f"name: crlf\r\n"
+            f"jobs:\r\n"
+            f"  test:\r\n"
+            f"    steps:\r\n"
+            f"      - uses: actions/checkout@{FULL_SHA} # v6.0.2\r\n"
+        )
+        workflow = _write_workflow(tmp_path, content)
+
+        errors, warnings = validate_file(workflow)
+
+        assert errors == []
+        assert warnings == []
+
+    def test_hash_inside_quoted_reference_fails(self, tmp_path):
+        """
+        Given: A `uses:` value with the SHA and `# v1.2.3` inside double quotes
+        When: validate_file scans the workflow (via PyYAML AST)
+        Then: One error is produced because the quoted value is not a bare SHA
+
+        PyYAML parses `"actions/checkout@<sha> # v1.2.3"` as the literal string
+        value `actions/checkout@<sha> # v1.2.3` (including the `# v1.2.3` part).
+        That value does not match the `owner/repo@<40-hex>` pattern, so the
+        validator must report a violation. There is no real trailing comment.
+
+        Under line-regex parsing this case passes incorrectly because the regex
+        sees a `#` and treats the text after it as a comment. PyYAML AST
+        corrects this.
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            # The entire string including `# v1.2.3` is the YAML value.
+            f"""
+name: quoted hash
+jobs:
+  test:
+    steps:
+      - uses: "actions/checkout@{FULL_SHA} # v1.2.3"
+""".lstrip(),
+        )
+
+        errors, warnings = validate_file(workflow)
+
+        assert len(errors) == 1, (
+            "A `#` embedded in a quoted scalar is part of the value, not a comment; "
+            "the resulting reference is not a bare SHA and must fail"
+        )
+
+    def test_matrix_nested_uses_is_detected(self, tmp_path):
+        """
+        Given: A workflow with `strategy.matrix` and a step `uses:` inside a matrix job
+        When: validate_file scans the workflow (via PyYAML AST)
+        Then: The `uses:` violation is detected regardless of nesting depth
+
+        The AST walk must reach `uses:` keys at any nesting level, not only in
+        flat step lists. This confirms the validator is not fooled by the
+        `strategy:` mapping wrapping the job.
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            """
+name: matrix
+jobs:
+  build:
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+""".lstrip(),
+        )
+
+        errors, warnings = validate_file(workflow)
+
+        assert len(errors) == 1
+        assert "full 40-character commit SHA" in errors[0].message
+
+    def test_folded_scalar_uses_value_fails(self, tmp_path):
+        """
+        Given: A `uses:` key whose value is a folded block scalar (`>`)
+        When: validate_file scans the workflow (via PyYAML AST)
+        Then: One error is produced for the missing ` # vX.Y.Z` comment
+
+        PyYAML resolves `uses: >\\n  actions/checkout@<sha>\\n` to the string
+        `actions/checkout@<sha>` (SHA only, no trailing newline after folding).
+        The source lines for a block scalar cannot carry a same-line `# vX.Y.Z`
+        comment on the `uses:` key line itself, so the validator must report a
+        violation. The line-regex implementation silently skips this case.
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            f"""
+name: folded scalar
+jobs:
+  test:
+    steps:
+      - uses: >
+          actions/checkout@{FULL_SHA}
+""".lstrip(),
+        )
+
+        errors, warnings = validate_file(workflow)
+
+        assert len(errors) == 1, (
+            "A folded-scalar `uses:` value cannot carry a same-line comment; it must be reported as a violation"
+        )
+        assert "missing required ` # vX.Y.Z`" in errors[0].message
+
+    def test_literal_scalar_uses_value_fails(self, tmp_path):
+        """
+        Given: A `uses:` key whose value is a literal block scalar (`|`)
+        When: validate_file scans the workflow (via PyYAML AST)
+        Then: One error is produced for the missing ` # vX.Y.Z` comment
+
+        Same reasoning as the folded-scalar case: `uses: |\\n  ...` resolves to
+        the reference string with a trailing newline. No same-line comment is
+        possible on the `uses:` key line. The line-regex implementation silently
+        skips this case.
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            f"""
+name: literal scalar
+jobs:
+  test:
+    steps:
+      - uses: |
+          actions/checkout@{FULL_SHA}
+""".lstrip(),
+        )
+
+        errors, warnings = validate_file(workflow)
+
+        assert len(errors) == 1, (
+            "A literal-scalar `uses:` value cannot carry a same-line comment; it must be reported as a violation"
+        )
+        assert "missing required ` # vX.Y.Z`" in errors[0].message
 
 
 class TestWorkflowDiscovery:
@@ -281,17 +638,90 @@ class TestCli:
 
 
 class TestCiIntegration:
-    """The existing CI workflow runs the same validator for workflow changes."""
+    """The validate_workflows.yml CI workflow runs the validator for workflow changes."""
 
-    def test_python_validation_workflow_runs_pinning_validator(self):
+    def test_validate_workflows_workflow_runs_pinning_validator(self):
         """
-        Given: The repository's Python validation workflow
+        Given: The repository's workflow validation CI file at
+               `.github/workflows/validate_workflows.yml`
         When: its source is inspected
-        Then: Workflow YAML changes trigger the validator in CI
-        """
-        workflow = REPO_ROOT / ".github" / "workflows" / "validate_python.yml"
-        content = workflow.read_text(encoding="utf-8")
+        Then:
+          - The file exists
+          - It references `scripts/hooks/precommit/validate_workflow_uses_pinning.py`
+          - Its `paths:` triggers include `.github/workflows/**/*.yml`
+          - `validate_python.yml` does NOT reference the pinning validator
+          - `validate_python.yml` does NOT have `.github/workflows/*.yml` in its
+            `paths:` filter (confirms the validator was not re-bolted there)
 
-        assert "'.github/workflows/*.yml'" in content
-        assert "'.github/workflows/**/*.yml'" in content
-        assert "scripts/hooks/precommit/validate_workflow_uses_pinning.py" in content
+        The negative assertion on `validate_python.yml` prevents accidental
+        re-addition of the validator to the Python workflow after it was moved
+        to `validate_workflows.yml`.
+        """
+        validate_workflows = REPO_ROOT / ".github" / "workflows" / "validate_workflows.yml"
+        validate_python = REPO_ROOT / ".github" / "workflows" / "validate_python.yml"
+
+        assert validate_workflows.exists(), (
+            f"validate_workflows.yml not found at {validate_workflows}; "
+            "the pinning validator CI must live in this file (not validate_python.yml)"
+        )
+
+        wf_content = validate_workflows.read_text(encoding="utf-8")
+        assert "scripts/hooks/precommit/validate_workflow_uses_pinning.py" in wf_content, (
+            "validate_workflows.yml must invoke validate_workflow_uses_pinning.py"
+        )
+        assert ".github/workflows/**/*.yml" in wf_content, (
+            "validate_workflows.yml paths trigger must include `.github/workflows/**/*.yml`"
+        )
+
+        py_content = validate_python.read_text(encoding="utf-8")
+        assert "validate_workflow_uses_pinning.py" not in py_content, (
+            "validate_python.yml must not reference validate_workflow_uses_pinning.py; "
+            "the validator now lives in validate_workflows.yml"
+        )
+        assert ".github/workflows/" not in py_content, (
+            "validate_python.yml must not have `.github/workflows/` in its paths filter; "
+            "workflow path triggers belong in validate_workflows.yml"
+        )
+
+    def test_validate_workflows_workflow_itself_uses_adr024_pin_form(self):
+        """
+        Given: `.github/workflows/validate_workflows.yml`
+        When: its `uses:` references are inspected
+        Then: Every external `uses:` line in the file follows ADR-024 D6 pin form
+              (full 40-char SHA + ` # vX.Y.Z` comment)
+
+        This is the self-test property: the lint workflow must be a correct
+        example of the policy it enforces. If this test fails, the CI workflow
+        is breaking its own rule.
+        """
+        validate_workflows = REPO_ROOT / ".github" / "workflows" / "validate_workflows.yml"
+        assert validate_workflows.exists(), f"validate_workflows.yml missing at {validate_workflows}"
+
+        errors, warnings = validate_file(validate_workflows)
+
+        assert errors == [], "validate_workflows.yml has pinning errors (self-test failure): " + "; ".join(
+            e.message for e in errors
+        )
+
+
+"""
+Test Summary
+============
+Total Tests: 32
+- TestPassingReferences: 5 (happy path + regression pin)
+- TestFailingReferences: 11 (parametrized 9 + quoted key + format test)
+- TestDockerWarning: 4 (D7 warning contract)
+- TestAdversarialParsing: 7 (new AST-gap cases)
+- TestWorkflowDiscovery: 1
+- TestCli: 2
+- TestCiIntegration: 2 (rewritten)
+
+Coverage Areas:
+- ADR-024 D6 pin form (single-space separator, two-space rejection)
+- ADR-024 D7 docker:// warning (not error, exit 0)
+- PyYAML AST parsing gaps: folded scalar, literal scalar, quoted hash, matrix nesting
+- CRLF line ending tolerance
+- @latest tag rejection
+- CI workflow routing (validate_workflows.yml, not validate_python.yml)
+- Self-test: validate_workflows.yml follows its own pinning policy
+"""

--- a/scripts/hooks/tests/test_validate_workflow_uses_pinning.py
+++ b/scripts/hooks/tests/test_validate_workflow_uses_pinning.py
@@ -13,19 +13,11 @@ ADR-024 D7: `docker://` references are warned (stderr, prefix
 ADR-024 D6: the separator between SHA and comment is exactly ` # ` (one space,
 hash, one space). Two spaces before `#` is a violation.
 
-API CONTRACT for `validate_file`:
-    validate_file(path: Path) -> tuple[list[Violation], list[Violation]]
-
-    The return value is (errors, warnings).
-    - errors: violations that cause exit code 1
-    - warnings: findings that are emitted to stderr but do not affect exit code
-    - Both lists are empty for a fully-compliant file.
-
-    The SWE agent must update `validate_file` to return this tuple shape.
-    `main()` continues to return int (0 or 1). Warnings from `validate_file`
-    are printed to stderr with the prefix
-    `validate-workflow-uses-pinning: warning:` and do not contribute to the
-    exit code.
+`validate_file` returns `(errors, warnings)`:
+    - errors drive `main()` exit code 1
+    - warnings are emitted to stderr with the prefix
+      `validate-workflow-uses-pinning: warning:` and do not affect exit code
+    - both lists empty means the file is fully compliant
 """
 
 import sys
@@ -162,6 +154,41 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@{FULL_SHA} # v6.0.2
+""".lstrip(),
+        )
+
+        errors, warnings = validate_file(workflow)
+        assert errors == []
+        assert warnings == []
+
+    @pytest.mark.parametrize(
+        "value_form",
+        [
+            f'"actions/checkout@{FULL_SHA}"',
+            f"'actions/checkout@{FULL_SHA}'",
+        ],
+        ids=["double_quoted", "single_quoted"],
+    )
+    def test_quoted_value_with_valid_pin_passes(self, tmp_path, value_form):
+        """
+        Given: A correctly-pinned `uses:` value wrapped in double or single quotes
+        When: validate_file scans the workflow
+        Then: No errors are returned
+
+        PyYAML resolves the quoted scalar to the unquoted SHA, but the source
+        line still has the closing quote between the value and the ` # `
+        separator. The validator must skip past the closing quote when
+        locating the separator.
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            f"""
+name: quoted value
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {value_form} # v6.0.2
 """.lstrip(),
         )
 
@@ -372,12 +399,10 @@ class TestAdversarialParsing:
     """
     Edge cases that exercise PyYAML AST-based parsing.
 
-    These cases either silently pass (false negatives) or fail incorrectly
-    under the current line-regex implementation. The tests define the contract
-    for the AST-based implementation the SWE agent will write.
-
-    PyYAML parses structure and provides line numbers; the validator re-reads
-    the source line for comment extraction (PyYAML does not preserve comments).
+    These forms silently pass (false negatives) or fail incorrectly under a
+    naive line-regex implementation. The validator parses YAML structure for
+    line numbers and re-reads source lines for comment extraction (PyYAML
+    does not preserve comments), so these cases resolve correctly.
     """
 
     def test_latest_tag_reference_fails(self, tmp_path):
@@ -678,9 +703,19 @@ class TestCiIntegration:
             "validate_python.yml must not reference validate_workflow_uses_pinning.py; "
             "the validator now lives in validate_workflows.yml"
         )
-        assert ".github/workflows/" not in py_content, (
-            "validate_python.yml must not have `.github/workflows/` in its paths filter; "
-            "workflow path triggers belong in validate_workflows.yml"
+        # Scope the negative check to actual `paths:` entries so a future
+        # comment in validate_python.yml that mentions `.github/workflows/`
+        # cannot silently break this regression guard.
+        import yaml as _yaml
+
+        py_parsed = _yaml.safe_load(py_content)
+        py_paths: list[str] = []
+        for trigger in ("push", "pull_request"):
+            trigger_cfg = (py_parsed.get("on", {}) or {}).get(trigger) or {}
+            py_paths.extend(trigger_cfg.get("paths") or [])
+        assert not any(p.startswith(".github/workflows/") for p in py_paths), (
+            "validate_python.yml `paths:` filter must not target workflow files; "
+            f"workflow path triggers belong in validate_workflows.yml. Got: {py_paths}"
         )
 
     def test_validate_workflows_workflow_itself_uses_adr024_pin_form(self):
@@ -707,14 +742,14 @@ class TestCiIntegration:
 """
 Test Summary
 ============
-Total Tests: 32
-- TestPassingReferences: 5 (happy path + regression pin)
+Total Tests: 34
+- TestPassingReferences: 7 (happy path + regression pins, incl. quoted-scalar)
 - TestFailingReferences: 11 (parametrized 9 + quoted key + format test)
 - TestDockerWarning: 4 (D7 warning contract)
-- TestAdversarialParsing: 7 (new AST-gap cases)
+- TestAdversarialParsing: 7 (AST-gap cases)
 - TestWorkflowDiscovery: 1
 - TestCli: 2
-- TestCiIntegration: 2 (rewritten)
+- TestCiIntegration: 2
 
 Coverage Areas:
 - ADR-024 D6 pin form (single-space separator, two-space rejection)

--- a/scripts/hooks/tests/test_validate_workflow_uses_pinning.py
+++ b/scripts/hooks/tests/test_validate_workflow_uses_pinning.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""
+Tests for scripts/hooks/precommit/validate_workflow_uses_pinning.py.
+
+The validator enforces ADR-024 for GitHub Actions workflow `uses:` references:
+external actions must be pinned to a full 40-character commit SHA and carry a
+same-line `# vX.Y.Z` release comment for Dependabot update tracking. Local
+`./...` references are exempt. Docker action references are rejected until a
+separate ADR defines their pinning policy.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "precommit"))
+
+from validate_workflow_uses_pinning import (  # noqa: E402
+    discover_workflow_files,
+    format_violation,
+    main,
+    validate_file,
+)
+
+FULL_SHA = "0123456789abcdef0123456789abcdef01234567"
+SHORT_SHA = "0123456789abcdef"
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+
+
+def _write_workflow(tmp_path: Path, content: str, name: str = "workflow.yml") -> Path:
+    """Write a synthetic workflow and return its path."""
+    workflow = tmp_path / name
+    workflow.parent.mkdir(parents=True, exist_ok=True)
+    workflow.write_text(content, encoding="utf-8")
+    return workflow
+
+
+class TestPassingReferences:
+    """Valid `uses:` references produce no violations."""
+
+    def test_external_action_with_full_sha_and_semver_comment_passes(self, tmp_path):
+        """
+        Given: An external action pinned to a 40-character SHA with `# vX.Y.Z`
+        When: validate_file scans the workflow
+        Then: It returns no violations
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            f"""
+name: valid
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@{FULL_SHA} # v6.0.2
+""".lstrip(),
+        )
+
+        assert validate_file(workflow) == []
+
+    def test_external_action_with_path_and_prerelease_comment_passes(self, tmp_path):
+        """
+        Given: An external action subpath pinned to a SHA with a prerelease tag comment
+        When: validate_file scans the workflow
+        Then: The owner/repo/path@sha form is accepted
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            f"""
+name: reusable
+jobs:
+  test:
+    steps:
+      - uses: octo-org/example/.github/actions/build@{FULL_SHA} # v1.2.3-rc.1
+""".lstrip(),
+        )
+
+        assert validate_file(workflow) == []
+
+    def test_local_relative_action_is_allowed_without_sha_or_comment(self, tmp_path):
+        """
+        Given: A local composite action reference using `./...`
+        When: validate_file scans the workflow
+        Then: The ADR-024 external-action pinning rule is not applied
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            """
+name: local
+jobs:
+  test:
+    steps:
+      - uses: ./.github/actions/build
+""".lstrip(),
+        )
+
+        assert validate_file(workflow) == []
+
+    def test_local_reusable_workflow_is_allowed_without_sha_or_comment(self, tmp_path):
+        """
+        Given: A local reusable workflow reference using `./...`
+        When: validate_file scans the workflow
+        Then: The local ADR-024 carve-out is accepted
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            """
+name: local reusable
+jobs:
+  test:
+    uses: ./.github/workflows/reusable.yml
+""".lstrip(),
+        )
+
+        assert validate_file(workflow) == []
+
+
+class TestFailingReferences:
+    """Invalid external `uses:` references produce actionable violations."""
+
+    @pytest.mark.parametrize(
+        ("line", "expected"),
+        [
+            ("uses: actions/checkout@v6", "full 40-character commit SHA"),
+            (f"uses: actions/checkout@{SHORT_SHA} # v6.0.2", "full 40-character commit SHA"),
+            ("uses: actions/checkout", "full 40-character commit SHA"),
+            (f"uses: actions/checkout@{FULL_SHA}", "missing required ` # vX.Y.Z`"),
+            (f"uses: actions/checkout@{FULL_SHA} # v6", "missing required ` # vX.Y.Z`"),
+            (f"uses: actions/checkout@{FULL_SHA} # 6.0.2", "missing required ` # vX.Y.Z`"),
+            (f"uses: actions/checkout@{FULL_SHA}# v6.0.2", "missing required ` # vX.Y.Z`"),
+        ],
+    )
+    def test_invalid_external_action_references_fail(self, tmp_path, line, expected):
+        """
+        Given: An external `uses:` reference that violates ADR-024
+        When: validate_file scans the workflow
+        Then: One violation identifies the specific policy gap
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            f"""
+name: invalid
+jobs:
+  test:
+    steps:
+      - {line}
+""".lstrip(),
+        )
+
+        violations = validate_file(workflow)
+
+        assert len(violations) == 1
+        assert expected in violations[0].message
+
+    def test_docker_action_reference_fails_for_maintainer_review(self, tmp_path):
+        """
+        Given: A `docker://` action reference
+        When: validate_file scans the workflow
+        Then: The validator rejects it until a Docker pinning policy exists
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            """
+name: docker action
+jobs:
+  test:
+    steps:
+      - uses: docker://alpine:3.20
+""".lstrip(),
+        )
+
+        violations = validate_file(workflow)
+
+        assert len(violations) == 1
+        assert "docker:// action references require maintainer review" in violations[0].message
+
+    def test_violation_format_includes_file_line_and_reference(self, tmp_path):
+        """
+        Given: A workflow with an invalid external action on line 6
+        When: format_violation renders the finding
+        Then: The message names the offending file, line, and reference
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            """
+name: line numbers
+jobs:
+  test:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+""".lstrip(),
+        )
+
+        violation = validate_file(workflow)[0]
+        rendered = format_violation(violation)
+
+        assert f"{workflow}:6:" in rendered
+        assert "actions/checkout@v6" in rendered
+
+
+class TestWorkflowDiscovery:
+    """Workflow discovery matches the issue #264 scan scope."""
+
+    def test_discovery_finds_root_and_nested_yml_workflows_only(self, tmp_path):
+        """
+        Given: Root, nested, and non-yml files under .github/workflows
+        When: discover_workflow_files scans the repository root
+        Then: It returns only .yml workflows, including nested paths
+        """
+        root_workflow = _write_workflow(tmp_path / ".github" / "workflows", "name: root\n", "root.yml")
+        nested_workflow = _write_workflow(
+            tmp_path / ".github" / "workflows" / "nested",
+            "name: nested\n",
+            "nested.yml",
+        )
+        _write_workflow(tmp_path / ".github" / "workflows", "name: yaml\n", "ignored.yaml")
+        _write_workflow(tmp_path / ".github" / "not-workflows", "name: ignored\n", "ignored.yml")
+
+        discovered = discover_workflow_files(tmp_path)
+
+        assert discovered == [root_workflow, nested_workflow]
+
+
+class TestCli:
+    """The CLI exits non-zero only when violations are present."""
+
+    def test_main_returns_zero_for_valid_workflow(self, tmp_path, capsys):
+        """
+        Given: A valid workflow file
+        When: main is invoked with the workflow path
+        Then: It returns 0 and emits no stderr output
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            f"jobs:\n  test:\n    steps:\n      - uses: actions/checkout@{FULL_SHA} # v6.0.2\n",
+        )
+
+        exit_code = main([str(workflow)])
+
+        assert exit_code == 0
+        assert capsys.readouterr().err == ""
+
+    def test_main_returns_one_and_writes_violations_to_stderr(self, tmp_path, capsys):
+        """
+        Given: An invalid workflow file
+        When: main is invoked with the workflow path
+        Then: It returns 1 and writes the file:line violation to stderr
+        """
+        workflow = _write_workflow(tmp_path, "jobs:\n  test:\n    steps:\n      - uses: actions/checkout@v6\n")
+
+        exit_code = main([str(workflow)])
+        captured = capsys.readouterr()
+
+        assert exit_code == 1
+        assert f"{workflow}:4:" in captured.err
+        assert "full 40-character commit SHA" in captured.err
+
+
+class TestCiIntegration:
+    """The existing CI workflow runs the same validator for workflow changes."""
+
+    def test_python_validation_workflow_runs_pinning_validator(self):
+        """
+        Given: The repository's Python validation workflow
+        When: its source is inspected
+        Then: Workflow YAML changes trigger the validator in CI
+        """
+        workflow = REPO_ROOT / ".github" / "workflows" / "validate_python.yml"
+        content = workflow.read_text(encoding="utf-8")
+
+        assert "'.github/workflows/*.yml'" in content
+        assert "'.github/workflows/**/*.yml'" in content
+        assert "scripts/hooks/precommit/validate_workflow_uses_pinning.py" in content

--- a/scripts/hooks/tests/test_validate_workflow_uses_pinning.py
+++ b/scripts/hooks/tests/test_validate_workflow_uses_pinning.py
@@ -122,6 +122,8 @@ class TestFailingReferences:
         ("line", "expected"),
         [
             ("uses: actions/checkout@v6", "full 40-character commit SHA"),
+            ('"uses": actions/checkout@v6', "full 40-character commit SHA"),
+            ("'uses': actions/checkout@v6", "full 40-character commit SHA"),
             (f"uses: actions/checkout@{SHORT_SHA} # v6.0.2", "full 40-character commit SHA"),
             ("uses: actions/checkout", "full 40-character commit SHA"),
             (f"uses: actions/checkout@{FULL_SHA}", "missing required ` # vX.Y.Z`"),
@@ -151,6 +153,27 @@ jobs:
 
         assert len(violations) == 1
         assert expected in violations[0].message
+
+    def test_quoted_job_level_uses_key_fails(self, tmp_path):
+        """
+        Given: A job-level reusable workflow reference with a quoted `uses` key
+        When: validate_file scans the workflow
+        Then: It treats the quoted key as a real GitHub Actions `uses` field
+        """
+        workflow = _write_workflow(
+            tmp_path,
+            """
+name: quoted job key
+jobs:
+  reusable:
+    "uses": octo-org/example/.github/workflows/build.yml@main
+""".lstrip(),
+        )
+
+        violations = validate_file(workflow)
+
+        assert len(violations) == 1
+        assert "full 40-character commit SHA" in violations[0].message
 
     def test_docker_action_reference_fails_for_maintainer_review(self, tmp_path):
         """


### PR DESCRIPTION
## Summary

Closes #264.

This replaces draft PR #267 so the branch follows this repository's contributor guidelines (`feature/...` for non-content infrastructure work).

- Adds `validate_workflow_uses_pinning.py` to enforce ADR-024 for GitHub Actions `uses:` references.
- Wires the validator into the existing pre-commit framework and Python validation workflow so workflow-only PRs run the check in CI.
- Adds targeted tests for valid SHA pins, missing/short SHAs, missing or malformed semver comments, local `./...` exemptions, quoted `uses` keys, and `docker://` review failures.
- Updates scripts documentation with the hook behavior and manual validation commands.

## Validation

- `.venv/bin/pytest scripts/hooks/tests/test_validate_workflow_uses_pinning.py scripts/hooks/tests/test_precommit_hook_install.py`
- `.venv/bin/ruff check scripts/hooks/precommit/validate_workflow_uses_pinning.py scripts/hooks/tests/test_validate_workflow_uses_pinning.py scripts/hooks/tests/test_precommit_hook_install.py`
- `.venv/bin/python scripts/hooks/precommit/validate_workflow_uses_pinning.py`
- `pre-commit run validate-workflow-uses-pinning --all-files`

## Notes

The raw-line scanning false-positive risk for `uses:` text inside block scalars is accepted for this PR scope. A broader local hooks test run with the repo venv on `PATH` had one unrelated pre-existing failure in `test_install_deps.py::TestSkipChromiumWhenPresent::test_chromium_in_cache_emits_skip`; the new validator tests passed.
