### PR TITLE
Conformance sweep A7: builder updates (sentinel expansion)

### DIFF
--- a/scripts/build_persona_site_data.py
+++ b/scripts/build_persona_site_data.py
@@ -11,15 +11,28 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import sys
 from pathlib import Path
 
 import jsonschema
+import referencing
+import referencing.jsonschema
 import yaml
+from jsonschema import Draft7Validator
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Ensure REPO_ROOT is on sys.path so that "scripts.hooks._sentinel_expansion"
+# resolves when this file is invoked directly as a script (not just as a module).
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.hooks._sentinel_expansion import expand_sentinels_to_items  # noqa: E402
+
 DEFAULT_PERSONAS_PATH = REPO_ROOT / "risk-map" / "yaml" / "personas.yaml"
 DEFAULT_RISKS_PATH = REPO_ROOT / "risk-map" / "yaml" / "risks.yaml"
 DEFAULT_CONTROLS_PATH = REPO_ROOT / "risk-map" / "yaml" / "controls.yaml"
+DEFAULT_COMPONENTS_PATH = REPO_ROOT / "risk-map" / "yaml" / "components.yaml"
 DEFAULT_SITE_DIR = REPO_ROOT / "site"
 DEFAULT_OUTPUT_NAME = "persona-site-data.json"
 GUIDED_QUESTION_THRESHOLD = 5
@@ -28,13 +41,33 @@ SCHEMAS_DIR = REPO_ROOT / "risk-map" / "schemas"
 PERSONA_SITE_DATA_SCHEMA_PATH = SCHEMAS_DIR / "persona-site-data.schema.json"
 
 
-def _load_output_schema() -> dict:
-    """Load the persona site data output schema from disk."""
+def _make_schema_registry(schemas_dir: Path) -> referencing.Registry:
+    """Build a referencing.Registry that resolves bare-filename $refs against schemas_dir.
+
+    The persona-site-data schema $refs external-references.schema.json by
+    relative URI; this registry retrieves and registers it on demand.
+    """
+
+    def retrieve(uri: str) -> referencing.Resource:
+        # Extract the bare filename from the URI — all $refs in this repo are
+        # bare filenames (e.g. "external-references.schema.json"), not full paths.
+        name = uri.rsplit("/", 1)[-1]
+        with (schemas_dir / name).open("r", encoding="utf-8") as fh:
+            contents = json.load(fh)
+        return referencing.Resource.from_contents(contents, default_specification=referencing.jsonschema.DRAFT7)
+
+    return referencing.Registry(retrieve=retrieve)
+
+
+def _load_output_schema() -> tuple[dict, referencing.Registry]:
+    """Load the persona site data output schema and its $ref registry."""
     with PERSONA_SITE_DATA_SCHEMA_PATH.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
+        schema = json.load(handle)
+    registry = _make_schema_registry(SCHEMAS_DIR)
+    return schema, registry
 
 
-_OUTPUT_SCHEMA = _load_output_schema()
+_OUTPUT_SCHEMA, _OUTPUT_SCHEMA_REGISTRY = _load_output_schema()
 
 
 def load_yaml(path: Path) -> dict:
@@ -46,17 +79,36 @@ def load_yaml(path: Path) -> dict:
     return data
 
 
-def normalize_text_entries(value) -> list:
+def normalize_text_entries(value, *, intra_lookup=None, ref_lookup=None, field_path=None) -> list:
     """Normalize YAML text scalars/lists into a shape-preserving list.
 
-    Top-level string items are kept as stripped strings; top-level list items
-    are kept as lists of stripped strings (preserving YAML nested-group shape
-    so the frontend can render scoped subsection blocks).
+    When intra_lookup, ref_lookup, and field_path are all provided, string items
+    are expanded via expand_sentinels_to_items. Otherwise (legacy / no-sentinel
+    mode) the pre-A7 behavior is preserved: strip each string, drop empty strings.
+
+    Top-level list items (nested-group shape) are passed through unchanged without
+    sentinel expansion — the corpus has no sentinels in nested groups today.
 
     NIT-08: Empty / whitespace-only list entries are silently dropped — do
     not use ``- ""`` as a spacing hack. Nested sub-lists that are empty after
     stripping are likewise dropped from the output.
+
+    Args:
+        value: A string, list, or None from a YAML field.
+        intra_lookup: maps entity-id -> title (sentinel expansion mode).
+        ref_lookup: maps ref-id -> {"title": str, "url": str}.
+        field_path: caller-supplied location prefix for error messages.
+
+    Returns:
+        List of processed items (strings, nested lists, or mixed sentinel items).
+
+    Raises:
+        TypeError: for non-string, non-list leaf values.
+        UnresolvedSentinelError: when sentinel expansion mode is active and a
+            sentinel id cannot be resolved.
     """
+    sentinel_mode = intra_lookup is not None and ref_lookup is not None and field_path is not None
+
     if value is None:
         return []
 
@@ -66,8 +118,10 @@ def normalize_text_entries(value) -> list:
         items = [value]
 
     result: list = []
-    for item in items:
+    for item_idx, item in enumerate(items):
         if isinstance(item, list):
+            # Nested group: pass through with basic string validation and empty-drop.
+            # Sentinel expansion is not applied to nested groups (out-of-scope for A7).
             sub: list[str] = []
             for s in item:
                 if not isinstance(s, str):
@@ -77,12 +131,37 @@ def normalize_text_entries(value) -> list:
                     sub.append(stripped)
             if sub:
                 result.append(sub)
+
         elif isinstance(item, str):
-            stripped = item.strip()
-            if stripped:
-                result.append(stripped)
+            if sentinel_mode:
+                # Build a per-item field_path for error diagnostics.
+                item_field_path = f"{field_path}[{item_idx}]"
+                expanded = expand_sentinels_to_items(
+                    item.strip(),
+                    intra_lookup=intra_lookup,
+                    ref_lookup=ref_lookup,
+                    field_path=item_field_path,
+                )
+                if len(expanded) == 0:
+                    # Empty result — drop this item (NIT-08 parity).
+                    pass
+                elif len(expanded) == 1 and isinstance(expanded[0], str):
+                    # Single plain string — emit as-is (preserves pre-A7 shape).
+                    result.append(expanded[0])
+                else:
+                    # Mixed or structured items — wrap as nested array so the outer
+                    # prose array keeps a clean type: the inner array branch of the
+                    # schema already accepts ref/link items per ADR-016 D5.
+                    result.append(expanded)
+            else:
+                # Legacy mode: strip and drop empty.
+                stripped = item.strip()
+                if stripped:
+                    result.append(stripped)
+
         else:
             raise TypeError(f"Prose items must be string or list-of-strings, got {type(item).__name__}: {item!r}")
+
     return result
 
 
@@ -103,8 +182,78 @@ def normalize_control_risk_ids(raw_risks, all_risk_ids: list[str]) -> list[str]:
     return [risk_id for risk_id in raw_risks if risk_id in all_risk_ids]
 
 
-def build_site_data(personas_data: dict, risks_data: dict, controls_data: dict) -> dict:
-    """Build the JSON structure consumed by the static persona site."""
+def _build_intra_lookup(
+    personas_data: dict,
+    risks_data: dict,
+    controls_data: dict,
+    components_data: dict,
+) -> dict[str, str]:
+    """Build a unified id->title map across all four entity types.
+
+    Used for resolving intra-document sentinels like {{riskFoo}} or {{controlBar}}.
+
+    Args:
+        personas_data: parsed personas YAML dict.
+        risks_data: parsed risks YAML dict.
+        controls_data: parsed controls YAML dict.
+        components_data: parsed components YAML dict.
+
+    Returns:
+        Dict mapping every entity id to its title.
+    """
+    lookup: dict[str, str] = {}
+    for persona in personas_data.get("personas", []):
+        lookup[persona["id"]] = persona["title"]
+    for risk in risks_data.get("risks", []):
+        lookup[risk["id"]] = risk["title"]
+    for control in controls_data.get("controls", []):
+        lookup[control["id"]] = control["title"]
+    # components.yaml has a flat top-level "components" list alongside "categories".
+    for component in components_data.get("components", []):
+        lookup[component["id"]] = component["title"]
+    return lookup
+
+
+def _build_ref_lookup(entry: dict) -> dict[str, dict]:
+    """Build a ref-id->entry map from a single entity's externalReferences.
+
+    Per-entry scoping ensures {{ref:foo}} only resolves against the entry that
+    declares "foo" in its own externalReferences — not a corpus-wide pool.
+
+    Args:
+        entry: a single risk, control, or persona dict from YAML.
+
+    Returns:
+        Dict mapping ref-id -> {"title": str, "url": str}.
+    """
+    return {ref["id"]: {"title": ref["title"], "url": ref["url"]} for ref in entry.get("externalReferences", [])}
+
+
+def build_site_data(
+    personas_data: dict,
+    risks_data: dict,
+    controls_data: dict,
+    components_data: dict | None = None,
+) -> dict:
+    """Build the JSON structure consumed by the static persona site.
+
+    Args:
+        personas_data: parsed personas YAML dict.
+        risks_data: parsed risks YAML dict.
+        controls_data: parsed controls YAML dict.
+        components_data: parsed components YAML dict, or None to load from
+            DEFAULT_COMPONENTS_PATH. Providing it explicitly lets callers
+            supply synthetic data in tests without touching disk.
+
+    Returns:
+        Dict conforming to persona-site-data.schema.json.
+    """
+    if components_data is None:
+        components_data = load_yaml(DEFAULT_COMPONENTS_PATH)
+
+    # Build once; used for all intra-sentinel resolutions across every entity.
+    intra_lookup = _build_intra_lookup(personas_data, risks_data, controls_data, components_data)
+
     active_personas = [persona for persona in personas_data["personas"] if not persona.get("deprecated")]
     active_persona_ids = {persona["id"] for persona in active_personas}
 
@@ -112,45 +261,73 @@ def build_site_data(personas_data: dict, risks_data: dict, controls_data: dict) 
     seen_risk_categories = set()
     normalized_risks = []
 
-    for raw_risk in risks_data["risks"]:
+    for idx, raw_risk in enumerate(risks_data["risks"]):
         category_id = raw_risk["category"]
         if category_id not in seen_risk_categories:
             risk_categories.append({"id": category_id, "title": humanize_identifier(category_id, "risks")})
             seen_risk_categories.add(category_id)
 
-        normalized_risks.append(
-            {
-                "id": raw_risk["id"],
-                "title": raw_risk["title"],
-                "category": category_id,
-                "shortDescription": normalize_text_entries(raw_risk.get("shortDescription")),
-                "longDescription": normalize_text_entries(raw_risk.get("longDescription")),
-                "examples": normalize_text_entries(raw_risk.get("examples")),
-                "controlIds": list(raw_risk.get("controls", [])),
-                "personaIds": [
-                    persona_id for persona_id in raw_risk.get("personas", []) if persona_id in active_persona_ids
-                ],
-            }
-        )
+        ref_lookup = _build_ref_lookup(raw_risk)
+        risk_field = f"risks[{idx}]"
+
+        risk_record: dict = {
+            "id": raw_risk["id"],
+            "title": raw_risk["title"],
+            "category": category_id,
+            "shortDescription": normalize_text_entries(
+                raw_risk.get("shortDescription"),
+                intra_lookup=intra_lookup,
+                ref_lookup=ref_lookup,
+                field_path=f"{risk_field}.shortDescription",
+            ),
+            "longDescription": normalize_text_entries(
+                raw_risk.get("longDescription"),
+                intra_lookup=intra_lookup,
+                ref_lookup=ref_lookup,
+                field_path=f"{risk_field}.longDescription",
+            ),
+            "examples": normalize_text_entries(
+                raw_risk.get("examples"),
+                intra_lookup=intra_lookup,
+                ref_lookup=ref_lookup,
+                field_path=f"{risk_field}.examples",
+            ),
+            "controlIds": list(raw_risk.get("controls", [])),
+            "personaIds": [
+                persona_id for persona_id in raw_risk.get("personas", []) if persona_id in active_persona_ids
+            ],
+        }
+        if "externalReferences" in raw_risk:
+            risk_record["externalReferences"] = raw_risk["externalReferences"]
+
+        normalized_risks.append(risk_record)
 
     all_risk_ids = [risk["id"] for risk in normalized_risks]
     normalized_controls = []
 
-    for raw_control in controls_data["controls"]:
-        normalized_controls.append(
-            {
-                "id": raw_control["id"],
-                "title": raw_control["title"],
-                "category": raw_control["category"],
-                "description": normalize_text_entries(raw_control.get("description")),
-                "personaIds": [
-                    persona_id
-                    for persona_id in raw_control.get("personas", [])
-                    if persona_id in active_persona_ids
-                ],
-                "riskIds": normalize_control_risk_ids(raw_control.get("risks"), all_risk_ids),
-            }
-        )
+    for idx, raw_control in enumerate(controls_data["controls"]):
+        ref_lookup = _build_ref_lookup(raw_control)
+        control_field = f"controls[{idx}]"
+
+        control_record: dict = {
+            "id": raw_control["id"],
+            "title": raw_control["title"],
+            "category": raw_control["category"],
+            "description": normalize_text_entries(
+                raw_control.get("description"),
+                intra_lookup=intra_lookup,
+                ref_lookup=ref_lookup,
+                field_path=f"{control_field}.description",
+            ),
+            "personaIds": [
+                persona_id for persona_id in raw_control.get("personas", []) if persona_id in active_persona_ids
+            ],
+            "riskIds": normalize_control_risk_ids(raw_control.get("risks"), all_risk_ids),
+        }
+        if "externalReferences" in raw_control:
+            control_record["externalReferences"] = raw_control["externalReferences"]
+
+        normalized_controls.append(control_record)
 
     risk_ids_by_persona = {persona["id"]: [] for persona in active_personas}
     control_ids_by_persona = {persona["id"]: [] for persona in active_personas}
@@ -167,7 +344,8 @@ def build_site_data(personas_data: dict, risks_data: dict, controls_data: dict) 
     persona_records = []
     manual_fallback_persona_ids = []
 
-    for persona in active_personas:
+    for idx, persona in enumerate(active_personas):
+        # identificationQuestions are plain strings — no sentinel expansion (schema: string[]).
         question_prompts = normalize_text_entries(persona.get("identificationQuestions"))
         match_mode = "guided" if len(question_prompts) >= GUIDED_QUESTION_THRESHOLD else "manual"
 
@@ -187,22 +365,37 @@ def build_site_data(personas_data: dict, risks_data: dict, controls_data: dict) 
         if match_mode == "manual":
             manual_fallback_persona_ids.append(persona["id"])
 
-        persona_records.append(
-            {
-                "id": persona["id"],
-                "title": persona["title"],
-                "description": normalize_text_entries(persona.get("description")),
-                "responsibilities": normalize_text_entries(persona.get("responsibilities")),
-                "identificationQuestions": question_prompts,
-                "questionIds": question_ids,
-                "questionCount": len(question_ids),
-                "matchMode": match_mode,
-                "riskIds": risk_ids_by_persona[persona["id"]],
-                "controlIds": control_ids_by_persona[persona["id"]],
-                "riskCount": len(risk_ids_by_persona[persona["id"]]),
-                "controlCount": len(control_ids_by_persona[persona["id"]]),
-            }
-        )
+        ref_lookup = _build_ref_lookup(persona)
+        persona_field = f"personas[{idx}]"
+
+        persona_record: dict = {
+            "id": persona["id"],
+            "title": persona["title"],
+            "description": normalize_text_entries(
+                persona.get("description"),
+                intra_lookup=intra_lookup,
+                ref_lookup=ref_lookup,
+                field_path=f"{persona_field}.description",
+            ),
+            "responsibilities": normalize_text_entries(
+                persona.get("responsibilities"),
+                intra_lookup=intra_lookup,
+                ref_lookup=ref_lookup,
+                field_path=f"{persona_field}.responsibilities",
+            ),
+            "identificationQuestions": question_prompts,
+            "questionIds": question_ids,
+            "questionCount": len(question_ids),
+            "matchMode": match_mode,
+            "riskIds": risk_ids_by_persona[persona["id"]],
+            "controlIds": control_ids_by_persona[persona["id"]],
+            "riskCount": len(risk_ids_by_persona[persona["id"]]),
+            "controlCount": len(control_ids_by_persona[persona["id"]]),
+        }
+        if "externalReferences" in persona:
+            persona_record["externalReferences"] = persona["externalReferences"]
+
+        persona_records.append(persona_record)
 
     return {
         "personas": persona_records,
@@ -226,7 +419,9 @@ def resolve_output_path(site_dir: Path, output_path: Path | None) -> Path:
 def write_site_data(data: dict, output_path: Path) -> None:
     """Write site data JSON with stable formatting, validating against the output schema first."""
     try:
-        jsonschema.validate(data, _OUTPUT_SCHEMA)
+        # Use Draft7Validator with the registry so cross-schema $refs (e.g.
+        # external-references.schema.json) resolve from disk on demand.
+        Draft7Validator(_OUTPUT_SCHEMA, registry=_OUTPUT_SCHEMA_REGISTRY).validate(data)
     except jsonschema.ValidationError as exc:
         raise jsonschema.ValidationError(
             f"Persona site data failed schema validation at {list(exc.absolute_path)!r}: {exc.message}",

--- a/scripts/build_persona_site_data.py
+++ b/scripts/build_persona_site_data.py
@@ -86,8 +86,10 @@ def normalize_text_entries(value, *, intra_lookup=None, ref_lookup=None, field_p
     are expanded via expand_sentinels_to_items. Otherwise (legacy / no-sentinel
     mode) the pre-A7 behavior is preserved: strip each string, drop empty strings.
 
-    Top-level list items (nested-group shape) are passed through unchanged without
-    sentinel expansion — the corpus has no sentinels in nested groups today.
+    Top-level list items (nested-group shape) have their inner strings expanded
+    via expand_sentinels_to_items when sentinel_mode is active (field_path uses
+    [item_idx][inner_idx] notation for diagnostics). In legacy mode the pre-A7
+    behaviour is preserved: strip each inner string, drop empty.
 
     NIT-08: Empty / whitespace-only list entries are silently dropped — do
     not use ``- ""`` as a spacing hack. Nested sub-lists that are empty after
@@ -120,15 +122,34 @@ def normalize_text_entries(value, *, intra_lookup=None, ref_lookup=None, field_p
     result: list = []
     for item_idx, item in enumerate(items):
         if isinstance(item, list):
-            # Nested group: pass through with basic string validation and empty-drop.
-            # Sentinel expansion is not applied to nested groups (out-of-scope for A7).
-            sub: list[str] = []
-            for s in item:
+            # Nested group: mirrors the str-leaf branch — sentinel_mode expands
+            # each inner string; legacy mode strips and drops empties only.
+            sub: list[str | dict] = []
+            for inner_idx, s in enumerate(item):
                 if not isinstance(s, str):
                     raise TypeError(f"Nested prose items must be strings, got {type(s).__name__}: {s!r}")
-                stripped = s.strip()
-                if stripped:
-                    sub.append(stripped)
+                if sentinel_mode:
+                    inner_field_path = f"{field_path}[{item_idx}][{inner_idx}]"
+                    expanded = expand_sentinels_to_items(
+                        s.strip(),
+                        intra_lookup=intra_lookup,
+                        ref_lookup=ref_lookup,
+                        field_path=inner_field_path,
+                    )
+                    if len(expanded) == 0:
+                        # Empty result — drop this inner item (NIT-08 parity).
+                        pass
+                    elif len(expanded) == 1 and isinstance(expanded[0], str):
+                        # Single plain string — append as-is (no sentinels present).
+                        sub.append(expanded[0])
+                    else:
+                        # Mixed or structured items — extend so the inner list
+                        # carries text + ref/link + text per ADR-016 D5.
+                        sub.extend(expanded)
+                else:
+                    stripped = s.strip()
+                    if stripped:
+                        sub.append(stripped)
             if sub:
                 result.append(sub)
 

--- a/scripts/build_persona_site_data.py
+++ b/scripts/build_persona_site_data.py
@@ -27,7 +27,10 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.hooks._sentinel_expansion import expand_sentinels_to_items  # noqa: E402
+from scripts.hooks._sentinel_expansion import (  # noqa: E402
+    expand_sentinels_to_items,
+    expand_sentinels_to_text,
+)
 
 DEFAULT_PERSONAS_PATH = REPO_ROOT / "risk-map" / "yaml" / "personas.yaml"
 DEFAULT_RISKS_PATH = REPO_ROOT / "risk-map" / "yaml" / "risks.yaml"
@@ -366,8 +369,24 @@ def build_site_data(
     manual_fallback_persona_ids = []
 
     for idx, persona in enumerate(active_personas):
-        # identificationQuestions are plain strings — no sentinel expansion (schema: string[]).
-        question_prompts = normalize_text_entries(persona.get("identificationQuestions"))
+        # identificationQuestions schema is string[] (matchmaker prompts), so sentinels
+        # expand to plain text rather than structured ref/link items. Mirrors the
+        # markdown side (PersonaFullDetailTableGenerator); ADR-016 D5 hard-fail applies.
+        persona_ref_lookup = _build_ref_lookup(persona)
+        raw_questions = persona.get("identificationQuestions") or []
+        # Strip each question first to drop trailing newlines from PyYAML block
+        # scalars; the legacy normalize_text_entries path stripped at the same
+        # point, and the markdown side strips downstream in format_list.
+        question_prompts = [
+            expand_sentinels_to_text(
+                q.strip(),
+                intra_lookup=intra_lookup,
+                ref_lookup=persona_ref_lookup,
+                field_path=f"personas[{idx}].identificationQuestions[{q_idx}]",
+            )
+            for q_idx, q in enumerate(raw_questions)
+            if q.strip()
+        ]
         match_mode = "guided" if len(question_prompts) >= GUIDED_QUESTION_THRESHOLD else "manual"
 
         question_ids = []

--- a/scripts/hooks/_sentinel_expansion.py
+++ b/scripts/hooks/_sentinel_expansion.py
@@ -1,0 +1,195 @@
+"""Tokenizer-driven sentinel resolution shared by yaml_to_markdown.py and
+build_persona_site_data.py.
+
+Implements ADR-016 D5: both downstream generators expand intra-document
+sentinels ({{<entity-id>}}) and external-reference sentinels
+({{ref:<identifier>}}) into rendered output. An unresolved sentinel is a
+hard build failure — never silently passed through.
+
+Wire-format note: the tokenizer at scripts/hooks/precommit/_prose_tokens.py
+accepts the bare entity-prefix camelCase form ({{riskFoo}}, {{controlFoo}},
+{{componentFoo}}, {{personaFoo}}) — NOT the {{idXxx}} meta-notation that
+appears in ADR-016 D2 prose.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+
+from scripts.hooks.precommit._prose_tokens import TokenKind, tokenize
+
+
+class UnresolvedSentinelError(ValueError):
+    """Raised when a sentinel's id cannot be resolved during expansion.
+
+    Attributes:
+        sentinel: full sentinel span as it appeared in source (e.g.
+            "{{riskTypoFooBar}}" or "{{ref:cve-2024-99999}}").
+        field_path: caller-supplied path string identifying the prose field
+            that contained the unresolved sentinel (e.g.
+            "risks[3].longDescription[0]"). Lets the build error point an
+            author straight at the offending YAML location.
+    """
+
+    def __init__(self, sentinel: str, field_path: str, message: str = "") -> None:
+        self.sentinel = sentinel
+        self.field_path = field_path
+        # Build a message that always includes both sentinel and field_path so
+        # str(exc) satisfies the test contract regardless of whether message is empty.
+        full_message = message or f"Unresolved sentinel {sentinel!r} at {field_path!r}"
+        # Ensure sentinel and field_path appear in str(exc) even when message omits them.
+        if sentinel not in full_message:
+            full_message = f"{full_message} (sentinel: {sentinel})"
+        if field_path not in full_message:
+            full_message = f"{full_message} (field_path: {field_path})"
+        super().__init__(full_message)
+
+
+def expand_sentinels_to_text(
+    text: str,
+    *,
+    intra_lookup: Mapping[str, str],
+    ref_lookup: Mapping[str, dict],
+    field_path: str,
+    link_format: Callable[[str, str], str] = lambda title, url: f"[{title}]({url})",
+) -> str:
+    """Expand every sentinel in `text` to a rendered string.
+
+    For yaml_to_markdown.py. Intra-document sentinels resolve to the entity
+    title as plain text; external-reference sentinels resolve via
+    `link_format(title, url)` (defaults to standard markdown link syntax).
+    Non-sentinel tokens (TEXT, BOLD, ITALIC, INVALID_*) pass through verbatim
+    by their `.value`. No whitespace stripping — the substitution is purely
+    string replacement at sentinel positions.
+
+    Args:
+        text: prose string from a YAML field value.
+        intra_lookup: maps entity-id -> title.
+        ref_lookup: maps ref-id -> {"title": str, "url": str}.
+        field_path: caller-supplied location string for error messages.
+        link_format: callable that turns (title, url) into the rendered
+            external-reference string. Default produces "[title](url)".
+
+    Returns:
+        The text with sentinels replaced.
+
+    Raises:
+        UnresolvedSentinelError: any sentinel whose id is not in the
+            corresponding lookup. Surfaces the sentinel span and field_path.
+    """
+    tokens = tokenize(text)
+    parts: list[str] = []
+
+    for token in tokens:
+        if token.kind == TokenKind.SENTINEL_INTRA:
+            entity_id = token.value[2:-2]  # strip {{ and }}
+            if entity_id not in intra_lookup:
+                raise UnresolvedSentinelError(
+                    sentinel=token.value,
+                    field_path=field_path,
+                    message=f"Intra sentinel {token.value!r} not in intra_lookup at {field_path!r}",
+                )
+            parts.append(intra_lookup[entity_id])
+
+        elif token.kind == TokenKind.SENTINEL_REF:
+            # Strip {{ and }} to get "ref:<id>", then strip the "ref:" prefix.
+            inner = token.value[2:-2]
+            ref_id = inner[4:]  # strip "ref:"
+            if ref_id not in ref_lookup:
+                raise UnresolvedSentinelError(
+                    sentinel=token.value,
+                    field_path=field_path,
+                    message=f"Ref sentinel {token.value!r} not in ref_lookup at {field_path!r}",
+                )
+            entry = ref_lookup[ref_id]
+            parts.append(link_format(entry["title"], entry["url"]))
+
+        else:
+            # TEXT, BOLD, ITALIC, and all INVALID_* tokens pass through verbatim.
+            parts.append(token.value)
+
+    return "".join(parts)
+
+
+def expand_sentinels_to_items(
+    text: str,
+    *,
+    intra_lookup: Mapping[str, str],
+    ref_lookup: Mapping[str, dict],
+    field_path: str,
+) -> list:
+    """Expand every sentinel in `text` to a list of strings and structured items.
+
+    For build_persona_site_data.py. Intra-document sentinels become
+    {"type": "ref", "id": <entity-id>, "title": <entity-title>} dicts;
+    external-reference sentinels become
+    {"type": "link", "title": <ref-title>, "url": <ref-url>} dicts.
+    Adjacent non-sentinel tokens (TEXT, BOLD, ITALIC, INVALID_*) are
+    concatenated into a single string segment between sentinels.
+
+    Contract:
+      - For empty input: returns [] (the caller should drop the field).
+      - For any non-empty input: returns at least one item.
+      - Empty TEXT segments between adjacent sentinels are dropped — the
+        result never contains "" entries. Mirrors the NIT-08 semantics in
+        normalize_text_entries: empty/whitespace-only spans are not surfaced.
+
+    Args:
+        text: prose string from a YAML field value.
+        intra_lookup: maps entity-id -> title.
+        ref_lookup: maps ref-id -> {"title": str, "url": str}.
+        field_path: caller-supplied location string for error messages.
+
+    Returns:
+        A list whose elements are either strings (text segments) or
+        structured dicts ({"type": "ref", ...} or {"type": "link", ...}).
+
+    Raises:
+        UnresolvedSentinelError: any sentinel whose id is not in the
+            corresponding lookup.
+    """
+    tokens = tokenize(text)
+    items: list = []
+    # Buffer for accumulating adjacent non-sentinel token values.
+    pending_text: list[str] = []
+
+    def flush_pending() -> None:
+        """Emit the accumulated text buffer as a string item if non-whitespace."""
+        if pending_text:
+            segment = "".join(pending_text)
+            # Drop whitespace-only segments (NIT-08 parity).
+            if segment.strip():
+                items.append(segment)
+            pending_text.clear()
+
+    for token in tokens:
+        if token.kind == TokenKind.SENTINEL_INTRA:
+            flush_pending()
+            entity_id = token.value[2:-2]
+            if entity_id not in intra_lookup:
+                raise UnresolvedSentinelError(
+                    sentinel=token.value,
+                    field_path=field_path,
+                    message=f"Intra sentinel {token.value!r} not in intra_lookup at {field_path!r}",
+                )
+            items.append({"type": "ref", "id": entity_id, "title": intra_lookup[entity_id]})
+
+        elif token.kind == TokenKind.SENTINEL_REF:
+            flush_pending()
+            inner = token.value[2:-2]
+            ref_id = inner[4:]  # strip "ref:"
+            if ref_id not in ref_lookup:
+                raise UnresolvedSentinelError(
+                    sentinel=token.value,
+                    field_path=field_path,
+                    message=f"Ref sentinel {token.value!r} not in ref_lookup at {field_path!r}",
+                )
+            entry = ref_lookup[ref_id]
+            items.append({"type": "link", "title": entry["title"], "url": entry["url"]})
+
+        else:
+            # Accumulate TEXT, BOLD, ITALIC, and INVALID_* tokens into the text buffer.
+            pending_text.append(token.value)
+
+    flush_pending()
+    return items

--- a/scripts/hooks/tests/test_build_persona_site_data_sentinel_expansion.py
+++ b/scripts/hooks/tests/test_build_persona_site_data_sentinel_expansion.py
@@ -1,0 +1,1035 @@
+#!/usr/bin/env python3
+"""
+Tests for sentinel expansion integration in scripts/build_persona_site_data.py
+
+This module tests the A7 changes that wire sentinel resolution into the site
+data builder (ADR-016 D5, task 2.5.3 site-data side). All inputs are
+synthesized YAML dicts — the live corpus has no sentinels yet (Phase B B1+B2
+will migrate it). Tests use real schemas from risk-map/schemas/.
+
+Emit-shape decision (verified against persona-site-data.schema.json definitions/prose):
+  definitions/prose is an array whose items are oneOf:
+    - string
+    - {type: "ref", id, title}     (new ADR-016 D5 intra shape)
+    - {type: "link", title, url}   (new ADR-016 D5 ref shape)
+    - array of strings/ref/link    (existing nested-group bullet shape)
+
+  When a single prose string expands to exactly one string (no sentinels), the
+  builder emits it as a top-level string item — identical to pre-A7 behavior.
+
+  When a single prose string expands to multiple items (sentinels were present),
+  the builder emits the result as a NESTED ARRAY (the fourth branch of the
+  oneOf). This avoids top-level ref/link structured items being mixed directly
+  with strings in the outer prose array, which would make it harder for the
+  frontend to distinguish a "bullet group" from an "inline expansion group".
+  Both shapes are schema-valid; the nested-array choice is more semantically
+  distinct (inline expansion vs bullet group) at the cost of one extra array
+  nesting level for expanded entries.
+
+  Rationale: The schema's inner-array branch already accepts ref/link items
+  (per ADR-016 D5 PR #261 landing), so a mixed [string, {ref}, string] inner
+  array validates. The outer prose array's items minItems: 1 constraint is
+  satisfied because expand_sentinels_to_items drops empty strings before the
+  caller wraps the result.
+
+Key API changes under test (SWE must implement):
+  - build_site_data signature gains a required components_data: dict parameter
+  - build_site_data builds intra_lookup from personas + risks + controls + components
+  - build_site_data builds per-entry ref_lookup from each entry's externalReferences
+  - build_site_data calls normalize_text_entries (now sentinel-aware)
+  - externalReferences arrays are passed through to JSON output unchanged
+  - UnresolvedSentinelError propagates out of build_site_data on typo'd sentinels
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+# ---------------------------------------------------------------------------
+# Guarded import — RED phase: helper does not exist yet; builder signature
+# changes not yet applied.
+# ---------------------------------------------------------------------------
+_IMPORT_ERROR: ImportError | None = None
+try:
+    from scripts.hooks._sentinel_expansion import UnresolvedSentinelError  # noqa: E402
+except ImportError as _e:
+    _IMPORT_ERROR = _e
+    UnresolvedSentinelError = None  # type: ignore[assignment,misc]
+
+from scripts.build_persona_site_data import (  # noqa: E402
+    build_site_data,
+    write_site_data,
+)
+
+
+def _require_sentinel_module() -> None:
+    """Fail with a clear message if the sentinel helper is not importable."""
+    if _IMPORT_ERROR is not None:
+        pytest.fail(
+            f"scripts/hooks/_sentinel_expansion.py is not importable (expected in RED phase): {_IMPORT_ERROR}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Minimal synthetic YAML dicts used as test inputs.
+# None of these reference the live corpus.
+# ---------------------------------------------------------------------------
+
+_MINIMAL_PERSONA = {
+    "id": "personaTestSubject",
+    "title": "Test Subject",
+    "description": ["A plain description."],
+    "responsibilities": ["One responsibility."],
+    "identificationQuestions": ["Q1?", "Q2?", "Q3?", "Q4?", "Q5?"],
+}
+
+_MINIMAL_PERSONAS_DATA = {"personas": [_MINIMAL_PERSONA]}
+
+_MINIMAL_RISK = {
+    "id": "riskTestFoo",
+    "title": "Test Foo Risk",
+    "category": "risksTestCategory",
+    "shortDescription": ["Short description."],
+    "longDescription": ["Long description."],
+    "examples": ["An example."],
+    "personas": ["personaTestSubject"],
+    "controls": [],
+}
+
+_MINIMAL_RISKS_DATA = {"risks": [_MINIMAL_RISK]}
+
+_MINIMAL_CONTROL = {
+    "id": "controlTestBar",
+    "title": "Test Bar Control",
+    "category": "controlsTestCategory",
+    "description": ["Control description."],
+    "personas": ["personaTestSubject"],
+    "risks": [],
+}
+
+_MINIMAL_CONTROLS_DATA = {"controls": [_MINIMAL_CONTROL], "categories": []}
+
+_MINIMAL_COMPONENTS_DATA = {
+    "components": [
+        {
+            "id": "componentModelServing",
+            "title": "Model Serving Infrastructure",
+            "category": "componentsModel",
+        },
+        {
+            "id": "componentTestComponent",
+            "title": "Test Component",
+            "category": "componentsData",
+        },
+    ]
+}
+
+
+def _build(
+    personas_data=None,
+    risks_data=None,
+    controls_data=None,
+    components_data=None,
+) -> dict:
+    """Convenience wrapper calling build_site_data with defaults."""
+    return build_site_data(
+        personas_data or _MINIMAL_PERSONAS_DATA,
+        risks_data or _MINIMAL_RISKS_DATA,
+        controls_data or _MINIMAL_CONTROLS_DATA,
+        components_data or _MINIMAL_COMPONENTS_DATA,
+    )
+
+
+# ============================================================================
+# TestSentinelExpansionInPersonaProse
+# ============================================================================
+
+
+class TestSentinelExpansionInPersonaProse:
+    """Tests that sentinels in persona description/responsibilities are resolved."""
+
+    def test_persona_description_intra_sentinel_produces_ref_item(self):
+        """
+        Test that {{riskTestFoo}} in a persona description is resolved to a ref item.
+
+        Given: A persona whose description contains {{riskTestFoo}} and a risk with
+               id="riskTestFoo" and title="Test Foo Risk" in risks_data
+        When: build_site_data is called
+        Then: The persona's description in site data contains a nested array that
+              includes a {type: "ref", id: "riskTestFoo", title: "Test Foo Risk"} item
+        """
+        _require_sentinel_module()
+        persona = dict(_MINIMAL_PERSONA)
+        persona["description"] = ["See {{riskTestFoo}} for details."]
+
+        result = _build(personas_data={"personas": [persona]})
+
+        persona_out = next(p for p in result["personas"] if p["id"] == "personaTestSubject")
+        desc = persona_out["description"]
+        # At least one item should be a nested array (the expanded prose string)
+        nested_arrays = [item for item in desc if isinstance(item, list)]
+        assert nested_arrays, "When a prose string contains a sentinel, it should be emitted as a nested array"
+        ref_items = [
+            inner
+            for nested in nested_arrays
+            for inner in nested
+            if isinstance(inner, dict) and inner.get("type") == "ref"
+        ]
+        assert any(r["id"] == "riskTestFoo" and r["title"] == "Test Foo Risk" for r in ref_items), (
+            f"Expected ref item for riskTestFoo in description; got: {desc!r}"
+        )
+
+    def test_persona_description_ref_sentinel_produces_link_item(self):
+        """
+        Test that {{ref:cwe-89}} in a persona description is resolved to a link item.
+
+        Given: A persona whose description contains {{ref:cwe-89}} and an
+               externalReferences entry with id="cwe-89"
+        When: build_site_data is called
+        Then: The persona's description contains a nested array with a link item
+              having the correct title and url
+        """
+        _require_sentinel_module()
+        persona = dict(_MINIMAL_PERSONA)
+        persona["description"] = ["See {{ref:cwe-89}}."]
+        persona["externalReferences"] = [
+            {
+                "type": "cwe",
+                "id": "cwe-89",
+                "title": "CWE-89: SQL Injection",
+                "url": "https://cwe.mitre.org/data/definitions/89.html",
+            }
+        ]
+
+        result = _build(personas_data={"personas": [persona]})
+
+        persona_out = next(p for p in result["personas"] if p["id"] == "personaTestSubject")
+        desc = persona_out["description"]
+        nested_arrays = [item for item in desc if isinstance(item, list)]
+        assert nested_arrays
+        link_items = [
+            inner
+            for nested in nested_arrays
+            for inner in nested
+            if isinstance(inner, dict) and inner.get("type") == "link"
+        ]
+        assert any(li["title"] == "CWE-89: SQL Injection" for li in link_items), (
+            f"Expected link item for cwe-89 in description; got: {desc!r}"
+        )
+
+    def test_persona_responsibilities_intra_sentinel_resolved(self):
+        """
+        Test that a sentinel in persona responsibilities is resolved.
+
+        Given: A persona with {{controlTestBar}} in its responsibilities
+        When: build_site_data is called with a control id="controlTestBar"
+        Then: The responsibilities field in site data contains the resolved ref item
+        """
+        _require_sentinel_module()
+        persona = dict(_MINIMAL_PERSONA)
+        persona["responsibilities"] = ["Use {{controlTestBar}} as a mitigation."]
+
+        result = _build(personas_data={"personas": [persona]})
+
+        persona_out = next(p for p in result["personas"] if p["id"] == "personaTestSubject")
+        responsibilities = persona_out["responsibilities"]
+        nested_arrays = [item for item in responsibilities if isinstance(item, list)]
+        assert nested_arrays
+        ref_items = [
+            inner
+            for nested in nested_arrays
+            for inner in nested
+            if isinstance(inner, dict) and inner.get("type") == "ref"
+        ]
+        assert any(r["id"] == "controlTestBar" for r in ref_items), (
+            f"Expected ref item for controlTestBar in responsibilities; got: {responsibilities!r}"
+        )
+
+    def test_plain_persona_description_unchanged(self):
+        """
+        Test that a persona description without sentinels is emitted as plain strings.
+
+        Given: A persona with plain-text description containing no {{ }} markers
+        When: build_site_data is called
+        Then: The description field contains only strings, no nested arrays
+        """
+        _require_sentinel_module()
+        result = _build()
+        persona_out = next(p for p in result["personas"] if p["id"] == "personaTestSubject")
+        desc = persona_out["description"]
+        assert all(isinstance(item, str) for item in desc), (
+            f"Plain-text description should emit only strings; got: {desc!r}"
+        )
+
+
+# ============================================================================
+# TestSentinelExpansionInRiskProse
+# ============================================================================
+
+
+class TestSentinelExpansionInRiskProse:
+    """Tests that sentinels in risk shortDescription/longDescription/examples are resolved."""
+
+    def test_risk_short_description_intra_sentinel_resolved(self):
+        """
+        Test that {{controlTestBar}} in a risk's shortDescription is resolved.
+
+        Given: A risk with {{controlTestBar}} in shortDescription
+        When: build_site_data is called
+        Then: The shortDescription field contains a nested array with a ref item for controlTestBar
+        """
+        _require_sentinel_module()
+        risk = dict(_MINIMAL_RISK)
+        risk["shortDescription"] = ["See {{controlTestBar}}."]
+
+        result = _build(risks_data={"risks": [risk]})
+
+        risk_out = next(r for r in result["risks"] if r["id"] == "riskTestFoo")
+        short_desc = risk_out["shortDescription"]
+        nested = [item for item in short_desc if isinstance(item, list)]
+        assert nested
+        ref_items = [i for n in nested for i in n if isinstance(i, dict) and i.get("type") == "ref"]
+        assert any(r["id"] == "controlTestBar" for r in ref_items)
+
+    def test_risk_long_description_ref_sentinel_resolved(self):
+        """
+        Test that {{ref:zhou-2023-poisoning}} in a risk's longDescription is resolved.
+
+        Given: A risk with {{ref:zhou-2023-poisoning}} in longDescription and
+               an externalReferences entry with that id
+        When: build_site_data is called
+        Then: The longDescription contains a nested array with a link item
+        """
+        _require_sentinel_module()
+        risk = dict(_MINIMAL_RISK)
+        risk["longDescription"] = ["Based on {{ref:zhou-2023-poisoning}} research."]
+        risk["externalReferences"] = [
+            {
+                "type": "paper",
+                "id": "zhou-2023-poisoning",
+                "title": "Zhou et al. 2023 - Data Poisoning",
+                "url": "https://example.com/zhou-2023",
+            }
+        ]
+
+        result = _build(risks_data={"risks": [risk]})
+
+        risk_out = next(r for r in result["risks"] if r["id"] == "riskTestFoo")
+        long_desc = risk_out["longDescription"]
+        nested = [item for item in long_desc if isinstance(item, list)]
+        assert nested
+        link_items = [i for n in nested for i in n if isinstance(i, dict) and i.get("type") == "link"]
+        assert any(li["title"] == "Zhou et al. 2023 - Data Poisoning" for li in link_items)
+
+    def test_risk_examples_intra_sentinel_resolved(self):
+        """
+        Test that an intra sentinel in a risk's examples field is resolved.
+
+        Given: A risk with {{personaTestSubject}} in its examples
+        When: build_site_data is called
+        Then: The examples field contains a nested array with a ref item for personaTestSubject
+        """
+        _require_sentinel_module()
+        risk = dict(_MINIMAL_RISK)
+        risk["examples"] = ["A {{personaTestSubject}} might encounter this."]
+
+        result = _build(risks_data={"risks": [risk]})
+
+        risk_out = next(r for r in result["risks"] if r["id"] == "riskTestFoo")
+        examples = risk_out["examples"]
+        nested = [item for item in examples if isinstance(item, list)]
+        assert nested
+        ref_items = [i for n in nested for i in n if isinstance(i, dict) and i.get("type") == "ref"]
+        assert any(r["id"] == "personaTestSubject" for r in ref_items)
+
+    def test_plain_risk_prose_unchanged(self):
+        """
+        Test that risk prose without sentinels emits only plain strings.
+
+        Given: A risk with no sentinel spans in any prose field
+        When: build_site_data is called
+        Then: All prose fields contain only string items
+        """
+        _require_sentinel_module()
+        result = _build()
+        risk_out = next(r for r in result["risks"] if r["id"] == "riskTestFoo")
+        for field in ("shortDescription", "longDescription", "examples"):
+            prose = risk_out[field]
+            assert all(isinstance(item, str) for item in prose), (
+                f"Plain-text {field} must emit only strings; got: {prose!r}"
+            )
+
+
+# ============================================================================
+# TestSentinelExpansionInControlProse
+# ============================================================================
+
+
+class TestSentinelExpansionInControlProse:
+    """Tests that sentinels in control description are resolved."""
+
+    def test_control_description_intra_sentinel_resolved(self):
+        """
+        Test that {{riskTestFoo}} in a control's description is resolved.
+
+        Given: A control with {{riskTestFoo}} in its description
+        When: build_site_data is called with a risk id="riskTestFoo"
+        Then: The control's description contains a nested array with a ref item for riskTestFoo
+        """
+        _require_sentinel_module()
+        control = dict(_MINIMAL_CONTROL)
+        control["description"] = ["Mitigates {{riskTestFoo}} effectively."]
+
+        result = _build(controls_data={"controls": [control], "categories": []})
+
+        control_out = next(c for c in result["controls"] if c["id"] == "controlTestBar")
+        desc = control_out["description"]
+        nested = [item for item in desc if isinstance(item, list)]
+        assert nested
+        ref_items = [i for n in nested for i in n if isinstance(i, dict) and i.get("type") == "ref"]
+        assert any(r["id"] == "riskTestFoo" and r["title"] == "Test Foo Risk" for r in ref_items)
+
+    def test_control_description_ref_sentinel_resolved(self):
+        """
+        Test that {{ref:cwe-89}} in a control's description is resolved.
+
+        Given: A control with {{ref:cwe-89}} in description and externalReferences entry
+        When: build_site_data is called
+        Then: The control's description contains a nested array with a link item
+        """
+        _require_sentinel_module()
+        control = dict(_MINIMAL_CONTROL)
+        control["description"] = ["Addresses {{ref:cwe-89}}."]
+        control["externalReferences"] = [
+            {
+                "type": "cwe",
+                "id": "cwe-89",
+                "title": "CWE-89: SQL Injection",
+                "url": "https://cwe.mitre.org/data/definitions/89.html",
+            }
+        ]
+
+        result = _build(controls_data={"controls": [control], "categories": []})
+
+        control_out = next(c for c in result["controls"] if c["id"] == "controlTestBar")
+        desc = control_out["description"]
+        nested = [item for item in desc if isinstance(item, list)]
+        assert nested
+        link_items = [i for n in nested for i in n if isinstance(i, dict) and i.get("type") == "link"]
+        assert any(li["title"] == "CWE-89: SQL Injection" for li in link_items)
+
+    def test_plain_control_prose_unchanged(self):
+        """
+        Test that control prose without sentinels emits only plain strings.
+
+        Given: A control with no sentinel spans in description
+        When: build_site_data is called
+        Then: The description field contains only string items
+        """
+        _require_sentinel_module()
+        result = _build()
+        control_out = next(c for c in result["controls"] if c["id"] == "controlTestBar")
+        desc = control_out["description"]
+        assert all(isinstance(item, str) for item in desc), (
+            f"Plain-text description must emit only strings; got: {desc!r}"
+        )
+
+
+# ============================================================================
+# TestExternalReferencesPassthrough
+# ============================================================================
+
+
+class TestExternalReferencesPassthrough:
+    """Tests that externalReferences arrays are included verbatim in JSON output."""
+
+    def test_persona_external_references_passed_through(self):
+        """
+        Test that a persona's externalReferences appear unchanged in site data output.
+
+        Given: A persona with an externalReferences array
+        When: build_site_data is called
+        Then: The persona in site data has the same externalReferences array
+
+        Passthrough is required because the schema declares externalReferences as
+        optional on each item with additionalProperties: false.
+        """
+        _require_sentinel_module()
+        ext_refs = [
+            {
+                "type": "paper",
+                "id": "smith-2024",
+                "title": "Smith 2024",
+                "url": "https://example.com/smith-2024",
+            }
+        ]
+        persona = dict(_MINIMAL_PERSONA)
+        persona["externalReferences"] = ext_refs
+
+        result = _build(personas_data={"personas": [persona]})
+
+        persona_out = next(p for p in result["personas"] if p["id"] == "personaTestSubject")
+        assert "externalReferences" in persona_out, "externalReferences must be passed through to site data output"
+        assert persona_out["externalReferences"] == ext_refs
+
+    def test_risk_external_references_passed_through(self):
+        """
+        Test that a risk's externalReferences appear unchanged in site data output.
+
+        Given: A risk with an externalReferences array
+        When: build_site_data is called
+        Then: The risk in site data has the same externalReferences array
+        """
+        _require_sentinel_module()
+        ext_refs = [
+            {
+                "type": "cwe",
+                "id": "cwe-89",
+                "title": "CWE-89",
+                "url": "https://cwe.mitre.org/data/definitions/89.html",
+            }
+        ]
+        risk = dict(_MINIMAL_RISK)
+        risk["externalReferences"] = ext_refs
+
+        result = _build(risks_data={"risks": [risk]})
+
+        risk_out = next(r for r in result["risks"] if r["id"] == "riskTestFoo")
+        assert "externalReferences" in risk_out
+        assert risk_out["externalReferences"] == ext_refs
+
+    def test_control_external_references_passed_through(self):
+        """
+        Test that a control's externalReferences appear unchanged in site data output.
+
+        Given: A control with an externalReferences array
+        When: build_site_data is called
+        Then: The control in site data has the same externalReferences array
+        """
+        _require_sentinel_module()
+        ext_refs = [
+            {
+                "type": "atlas",
+                "id": "aml-t0020",
+                "title": "MITRE ATLAS AML.T0020",
+                "url": "https://atlas.mitre.org/techniques/AML.T0020",
+            }
+        ]
+        control = dict(_MINIMAL_CONTROL)
+        control["externalReferences"] = ext_refs
+
+        result = _build(controls_data={"controls": [control], "categories": []})
+
+        control_out = next(c for c in result["controls"] if c["id"] == "controlTestBar")
+        assert "externalReferences" in control_out
+        assert control_out["externalReferences"] == ext_refs
+
+    def test_no_external_references_key_absent_in_output(self):
+        """
+        Test that entities without externalReferences do not emit the key.
+
+        Given: A persona/risk/control with no externalReferences field
+        When: build_site_data is called
+        Then: The output for that entity does not have an externalReferences key
+              (passthrough is conditional on source having the field)
+        """
+        _require_sentinel_module()
+        result = _build()
+
+        persona_out = next(p for p in result["personas"] if p["id"] == "personaTestSubject")
+        risk_out = next(r for r in result["risks"] if r["id"] == "riskTestFoo")
+        control_out = next(c for c in result["controls"] if c["id"] == "controlTestBar")
+
+        assert "externalReferences" not in persona_out
+        assert "externalReferences" not in risk_out
+        assert "externalReferences" not in control_out
+
+
+# ============================================================================
+# TestUnresolvedSentinelRaises
+# ============================================================================
+
+
+class TestUnresolvedSentinelRaises:
+    """Tests that unresolved sentinels raise UnresolvedSentinelError from build_site_data."""
+
+    def test_intra_typo_in_persona_description_raises(self):
+        """
+        Test that a typo'd intra sentinel in a persona description raises UnresolvedSentinelError.
+
+        Given: A persona with {{riskTypoFooBar}} (no such id in the corpus)
+        When: build_site_data is called
+        Then: UnresolvedSentinelError is raised and propagates out of build_site_data;
+              the error's .sentinel is "{{riskTypoFooBar}}" and .field_path references
+              the persona's description
+        """
+        _require_sentinel_module()
+        persona = dict(_MINIMAL_PERSONA)
+        persona["description"] = ["See {{riskTypoFooBar}} for context."]
+
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            _build(personas_data={"personas": [persona]})
+
+        exc = exc_info.value
+        assert exc.sentinel == "{{riskTypoFooBar}}"
+        assert "persona" in exc.field_path.lower() or "description" in exc.field_path.lower(), (
+            f"field_path should reference the persona's description; got: {exc.field_path!r}"
+        )
+
+    def test_ref_typo_in_risk_long_description_raises(self):
+        """
+        Test that an unknown ref id in a risk's longDescription raises UnresolvedSentinelError.
+
+        Given: A risk with {{ref:cve-2024-99999}} in longDescription and no matching
+               externalReferences entry
+        When: build_site_data is called
+        Then: UnresolvedSentinelError is raised with .sentinel == "{{ref:cve-2024-99999}}"
+              and .field_path references the risk's longDescription
+        """
+        _require_sentinel_module()
+        risk = dict(_MINIMAL_RISK)
+        risk["longDescription"] = ["See {{ref:cve-2024-99999}}."]
+        # No externalReferences provided => ref_lookup is empty for this entry
+
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            _build(risks_data={"risks": [risk]})
+
+        exc = exc_info.value
+        assert exc.sentinel == "{{ref:cve-2024-99999}}"
+        # field_path should identify which field triggered the error
+        assert exc.field_path, "field_path must be non-empty"
+
+    def test_intra_typo_in_control_description_raises(self):
+        """
+        Test that a typo'd intra sentinel in a control description raises UnresolvedSentinelError.
+
+        Given: A control with {{riskNonExistentXyz}} in its description
+        When: build_site_data is called (no risk with that id exists)
+        Then: UnresolvedSentinelError is raised with .sentinel == "{{riskNonExistentXyz}}"
+        """
+        _require_sentinel_module()
+        control = dict(_MINIMAL_CONTROL)
+        control["description"] = ["Mitigates {{riskNonExistentXyz}}."]
+
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            _build(controls_data={"controls": [control], "categories": []})
+
+        exc = exc_info.value
+        assert exc.sentinel == "{{riskNonExistentXyz}}"
+
+    def test_ref_typo_in_persona_responsibilities_raises(self):
+        """
+        Test that an unknown ref id in persona responsibilities raises UnresolvedSentinelError.
+
+        Given: A persona with {{ref:unknown-ref-xyz}} in responsibilities and no
+               externalReferences for that entry
+        When: build_site_data is called
+        Then: UnresolvedSentinelError is raised with the correct sentinel span
+        """
+        _require_sentinel_module()
+        persona = dict(_MINIMAL_PERSONA)
+        persona["responsibilities"] = ["Per {{ref:unknown-ref-xyz}}."]
+
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            _build(personas_data={"personas": [persona]})
+
+        exc = exc_info.value
+        assert exc.sentinel == "{{ref:unknown-ref-xyz}}"
+
+    def test_field_path_in_error_is_informative(self):
+        """
+        Test that the field_path in UnresolvedSentinelError identifies the entry and field.
+
+        Given: A risk with index 0 and a typo'd intra sentinel in longDescription index 0
+        When: build_site_data is called
+        Then: The field_path in the raised error contains enough context to identify
+              the entry (e.g. "risks[0].longDescription[0]" or similar)
+        """
+        _require_sentinel_module()
+        risk = dict(_MINIMAL_RISK)
+        risk["longDescription"] = ["Contains {{riskTypoForPath}}."]
+
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            _build(risks_data={"risks": [risk]})
+
+        exc = exc_info.value
+        assert exc.field_path, "field_path must be non-empty for diagnostics"
+        # The field_path should reference the risk's longDescription in some form
+        assert (
+            "long" in exc.field_path.lower()
+            or "description" in exc.field_path.lower()
+            or "risks" in exc.field_path.lower()
+        ), f"field_path should help locate the error; got: {exc.field_path!r}"
+
+
+# ============================================================================
+# TestSchemaValidationStillPasses
+# ============================================================================
+
+
+class TestSchemaValidationStillPasses:
+    """Tests that write_site_data schema validation still passes with new shapes.
+
+    Note: write_site_data loads its schema via a module-level _OUTPUT_SCHEMA
+    constant at import time (build_persona_site_data.py:37), so no schemas-dir
+    fixture is needed in these tests — the on-disk schema is already cached by
+    the time any test method runs.
+    """
+
+    def test_write_site_data_accepts_output_with_ref_items(self, tmp_path: Path):
+        """
+        Test that write_site_data accepts site data containing ref-type prose items.
+
+        Given: Synthesized site data where a persona's description contains
+               a nested array with a ref item (the new expanded shape)
+        When: write_site_data is called with a tmp_path output
+        Then: No jsonschema.ValidationError is raised and the file is written
+
+        This validates that the ADR-016 D5 schema extension (PR #261) is in place
+        and the new shape passes through write_site_data's validate-before-write gate.
+        """
+        _require_sentinel_module()
+        # Build using synthesized data with a sentinel that will be resolved
+        persona = dict(_MINIMAL_PERSONA)
+        persona["description"] = ["See {{riskTestFoo}} for context."]
+
+        result = _build(personas_data={"personas": [persona]})
+
+        output_path = tmp_path / "site-data.json"
+        # Should not raise
+        write_site_data(result, output_path)
+        assert output_path.exists()
+
+    def test_write_site_data_accepts_output_with_link_items(self, tmp_path: Path):
+        """
+        Test that write_site_data accepts site data containing link-type prose items.
+
+        Given: Synthesized site data where a risk's shortDescription contains
+               a nested array with a link item
+        When: write_site_data is called
+        Then: No jsonschema.ValidationError is raised
+        """
+        _require_sentinel_module()
+        risk = dict(_MINIMAL_RISK)
+        risk["shortDescription"] = ["Based on {{ref:cwe-89}}."]
+        risk["externalReferences"] = [
+            {
+                "type": "cwe",
+                "id": "cwe-89",
+                "title": "CWE-89: SQL Injection",
+                "url": "https://cwe.mitre.org/data/definitions/89.html",
+            }
+        ]
+
+        result = _build(risks_data={"risks": [risk]})
+
+        output_path = tmp_path / "site-data-links.json"
+        write_site_data(result, output_path)
+        assert output_path.exists()
+
+    def test_write_site_data_accepts_external_references_passthrough(self, tmp_path: Path):
+        """
+        Test that externalReferences passthrough does not break schema validation.
+
+        Given: Synthesized data with externalReferences on a risk
+        When: build_site_data → write_site_data pipeline runs
+        Then: No jsonschema.ValidationError is raised and the file is written
+        """
+        _require_sentinel_module()
+        risk = dict(_MINIMAL_RISK)
+        risk["externalReferences"] = [
+            {
+                "type": "paper",
+                "id": "smith-2024",
+                "title": "Smith 2024",
+                "url": "https://example.com/smith-2024",
+            }
+        ]
+
+        result = _build(risks_data={"risks": [risk]})
+
+        output_path = tmp_path / "site-data-ext-refs.json"
+        write_site_data(result, output_path)
+        assert output_path.exists()
+
+        # Round-trip check: the output JSON parses and contains externalReferences
+        data = json.loads(output_path.read_text(encoding="utf-8"))
+        risk_out = next(r for r in data["risks"] if r["id"] == "riskTestFoo")
+        assert "externalReferences" in risk_out
+
+    def test_write_site_data_accepts_mixed_plain_and_expanded_prose(self, tmp_path: Path):
+        """
+        Test that a mix of plain strings and sentinel-expanded entries validates.
+
+        Given: A risk where some prose entries are plain strings and one contains
+               a sentinel, producing a mix of string and nested-array items
+        When: build_site_data → write_site_data pipeline runs
+        Then: No jsonschema.ValidationError is raised
+        """
+        _require_sentinel_module()
+        risk = dict(_MINIMAL_RISK)
+        risk["longDescription"] = [
+            "Plain first paragraph.",
+            "See {{riskTestFoo}} for details.",
+            "Plain third paragraph.",
+        ]
+
+        result = _build(risks_data={"risks": [risk]})
+
+        output_path = tmp_path / "site-data-mixed.json"
+        write_site_data(result, output_path)
+        assert output_path.exists()
+
+
+# ============================================================================
+# TestComponentsLookupSeeded
+# ============================================================================
+
+
+class TestComponentsLookupSeeded:
+    """Tests that components.yaml is loaded and its IDs are in intra_lookup."""
+
+    def test_component_sentinel_resolves_correctly(self):
+        """
+        Test that {{componentModelServing}} resolves to the component's title.
+
+        Given: A risk's shortDescription containing {{componentModelServing}} and
+               components_data containing an entry with id="componentModelServing"
+               and title="Model Serving Infrastructure"
+        When: build_site_data is called
+        Then: The resolved item has id="componentModelServing" and
+              title="Model Serving Infrastructure"
+
+        This proves that components_data is loaded and its entries are included
+        in the intra_lookup union — a new A7 requirement (the current pre-A7 builder
+        does not load components.yaml at all).
+        """
+        _require_sentinel_module()
+        risk = dict(_MINIMAL_RISK)
+        risk["shortDescription"] = ["Affects {{componentModelServing}}."]
+
+        result = _build(risks_data={"risks": [risk]})
+
+        risk_out = next(r for r in result["risks"] if r["id"] == "riskTestFoo")
+        short_desc = risk_out["shortDescription"]
+        nested = [item for item in short_desc if isinstance(item, list)]
+        assert nested, "componentModelServing sentinel should produce a nested array in shortDescription"
+        ref_items = [
+            inner for n in nested for inner in n if isinstance(inner, dict) and inner.get("type") == "ref"
+        ]
+        assert any(
+            r["id"] == "componentModelServing" and r["title"] == "Model Serving Infrastructure" for r in ref_items
+        ), f"Expected ref for componentModelServing with correct title; got ref_items: {ref_items!r}"
+
+    def test_unknown_component_sentinel_raises(self):
+        """
+        Test that {{componentBogusNonExistent}} raises UnresolvedSentinelError.
+
+        Given: A risk with a component-prefix sentinel that matches no entry in
+               components_data
+        When: build_site_data is called
+        Then: UnresolvedSentinelError is raised, proving components_data is checked
+              (not silently skipped)
+        """
+        _require_sentinel_module()
+        risk = dict(_MINIMAL_RISK)
+        risk["shortDescription"] = ["Affects {{componentBogusNonExistent}}."]
+
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            _build(risks_data={"risks": [risk]})
+
+        exc = exc_info.value
+        assert exc.sentinel == "{{componentBogusNonExistent}}"
+
+    def test_build_site_data_accepts_components_data_argument(self):
+        """
+        Test that build_site_data accepts a components_data argument without error.
+
+        Given: A minimal valid call to build_site_data with all four arguments
+        When: build_site_data is called with components_data=_MINIMAL_COMPONENTS_DATA
+        Then: No TypeError or AttributeError is raised; the result is a dict with
+              the expected top-level keys
+
+        This is the minimal smoke test confirming the new components_data parameter
+        was added to the function signature.
+        """
+        _require_sentinel_module()
+        result = _build()
+        assert isinstance(result, dict)
+        assert "personas" in result
+        assert "risks" in result
+        assert "controls" in result
+
+
+# ============================================================================
+# TestIntraLookupConstruction
+# ============================================================================
+
+
+class TestIntraLookupConstruction:
+    """Tests that the intra_lookup is constructed correctly from all entity sources."""
+
+    def test_persona_ids_in_intra_lookup(self):
+        """
+        Test that persona ids from personas_data are resolvable as intra sentinels.
+
+        Given: A risk whose shortDescription references {{personaTestSubject}}
+               and a persona with id="personaTestSubject" and title="Test Subject"
+        When: build_site_data is called
+        Then: The sentinel is resolved to a ref item with title="Test Subject"
+        """
+        _require_sentinel_module()
+        risk = dict(_MINIMAL_RISK)
+        risk["shortDescription"] = ["For {{personaTestSubject}} role."]
+
+        result = _build(risks_data={"risks": [risk]})
+
+        risk_out = next(r for r in result["risks"] if r["id"] == "riskTestFoo")
+        short_desc = risk_out["shortDescription"]
+        nested = [item for item in short_desc if isinstance(item, list)]
+        assert nested
+        ref_items = [i for n in nested for i in n if isinstance(i, dict) and i.get("type") == "ref"]
+        assert any(r["id"] == "personaTestSubject" and r["title"] == "Test Subject" for r in ref_items)
+
+    def test_risk_ids_in_intra_lookup(self):
+        """
+        Test that risk ids from risks_data are resolvable as intra sentinels.
+
+        Given: A control whose description references {{riskTestFoo}}
+               and a risk with id="riskTestFoo" and title="Test Foo Risk"
+        When: build_site_data is called
+        Then: The sentinel is resolved to a ref item with title="Test Foo Risk"
+        """
+        _require_sentinel_module()
+        control = dict(_MINIMAL_CONTROL)
+        control["description"] = ["Mitigates {{riskTestFoo}}."]
+
+        result = _build(controls_data={"controls": [control], "categories": []})
+
+        control_out = next(c for c in result["controls"] if c["id"] == "controlTestBar")
+        desc = control_out["description"]
+        nested = [item for item in desc if isinstance(item, list)]
+        assert nested
+        ref_items = [i for n in nested for i in n if isinstance(i, dict) and i.get("type") == "ref"]
+        assert any(r["id"] == "riskTestFoo" and r["title"] == "Test Foo Risk" for r in ref_items)
+
+    def test_control_ids_in_intra_lookup(self):
+        """
+        Test that control ids from controls_data are resolvable as intra sentinels.
+
+        Given: A persona whose description references {{controlTestBar}}
+               and a control with id="controlTestBar" and title="Test Bar Control"
+        When: build_site_data is called
+        Then: The sentinel is resolved to a ref item with title="Test Bar Control"
+        """
+        _require_sentinel_module()
+        persona = dict(_MINIMAL_PERSONA)
+        persona["description"] = ["Apply {{controlTestBar}}."]
+
+        result = _build(personas_data={"personas": [persona]})
+
+        persona_out = next(p for p in result["personas"] if p["id"] == "personaTestSubject")
+        desc = persona_out["description"]
+        nested = [item for item in desc if isinstance(item, list)]
+        assert nested
+        ref_items = [i for n in nested for i in n if isinstance(i, dict) and i.get("type") == "ref"]
+        assert any(r["id"] == "controlTestBar" and r["title"] == "Test Bar Control" for r in ref_items)
+
+
+# ============================================================================
+# TestRefLookupPerEntry
+# ============================================================================
+
+
+class TestRefLookupPerEntry:
+    """Tests that ref_lookup is scoped per-entry from each entry's externalReferences."""
+
+    def test_ref_lookup_scoped_to_entry_not_shared(self):
+        """
+        Test that ref sentinels are resolved only from the entry's own externalReferences.
+
+        Given: Two risks — risk A has {{ref:cwe-89}} in its prose with a matching
+               externalReferences entry; risk B has {{ref:cwe-89}} with NO externalReferences
+        When: build_site_data is called
+        Then: Risk A resolves the sentinel successfully; risk B raises UnresolvedSentinelError
+
+        This proves ref_lookup is per-entry, not shared across the corpus.
+        """
+        _require_sentinel_module()
+        risk_a = {
+            "id": "riskWithRef",
+            "title": "Risk With Ref",
+            "category": "risksTestCategory",
+            "shortDescription": ["See {{ref:cwe-89}}."],
+            "longDescription": ["Details."],
+            "examples": [],
+            "personas": [],
+            "controls": [],
+            "externalReferences": [
+                {
+                    "type": "cwe",
+                    "id": "cwe-89",
+                    "title": "CWE-89: SQL Injection",
+                    "url": "https://cwe.mitre.org/data/definitions/89.html",
+                }
+            ],
+        }
+        risk_b = {
+            "id": "riskWithoutRef",
+            "title": "Risk Without Ref",
+            "category": "risksTestCategory",
+            "shortDescription": ["See {{ref:cwe-89}}."],  # same sentinel, no externalReferences
+            "longDescription": [],
+            "examples": [],
+            "personas": [],
+            "controls": [],
+            # No externalReferences — ref_lookup for this entry is empty
+        }
+
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            _build(risks_data={"risks": [risk_a, risk_b]})
+
+        exc = exc_info.value
+        assert exc.sentinel == "{{ref:cwe-89}}"
+
+
+# ============================================================================
+# Test summary
+# ============================================================================
+"""
+Test Summary
+============
+Total test classes: 9
+Total tests: ~35
+
+- TestSentinelExpansionInPersonaProse (4):  intra ref in description, ref link in description,
+                                             intra in responsibilities, plain prose unchanged
+- TestSentinelExpansionInRiskProse (4):     intra in shortDescription, ref in longDescription,
+                                             intra in examples, plain prose unchanged
+- TestSentinelExpansionInControlProse (3):  intra in description, ref in description,
+                                             plain prose unchanged
+- TestExternalReferencesPassthrough (4):    persona, risk, control passthrough; absent key omitted
+- TestUnresolvedSentinelRaises (5):         intra typo in persona, ref typo in risk,
+                                             intra typo in control, ref typo in responsibilities,
+                                             field_path is informative
+- TestSchemaValidationStillPasses (4):      ref items, link items, ext-refs, mixed plain+expanded
+- TestComponentsLookupSeeded (3):           component sentinel resolves, unknown raises, sig accepted
+- TestIntraLookupConstruction (3):          persona/risk/control ids all in lookup
+- TestRefLookupPerEntry (1):                ref_lookup is per-entry scoped
+
+Coverage areas:
+- Sentinel resolution in all three entity prose fields (persona, risk, control)
+- All four sentinel kinds: intra (risk/control/component/persona) and ref
+- externalReferences passthrough contract
+- build_site_data accepts components_data parameter (new A7 requirement)
+- UnresolvedSentinelError propagation with informative field_path
+- Schema validation of expanded output via write_site_data
+- Per-entry ref_lookup scoping (not shared across corpus entries)
+"""

--- a/scripts/hooks/tests/test_build_persona_site_data_sentinel_expansion.py
+++ b/scripts/hooks/tests/test_build_persona_site_data_sentinel_expansion.py
@@ -53,8 +53,9 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT))
 
 # ---------------------------------------------------------------------------
-# Guarded import — RED phase: helper does not exist yet; builder signature
-# changes not yet applied.
+# Decoupled import for the helper: if it fails to import (e.g. dependency
+# drift), tests fail individually with a clear message rather than at
+# collection time. Mirrors the A3 pattern in test_prose_tokens.py.
 # ---------------------------------------------------------------------------
 _IMPORT_ERROR: ImportError | None = None
 try:
@@ -72,9 +73,7 @@ from scripts.build_persona_site_data import (  # noqa: E402
 def _require_sentinel_module() -> None:
     """Fail with a clear message if the sentinel helper is not importable."""
     if _IMPORT_ERROR is not None:
-        pytest.fail(
-            f"scripts/hooks/_sentinel_expansion.py is not importable (expected in RED phase): {_IMPORT_ERROR}"
-        )
+        pytest.fail(f"scripts/hooks/_sentinel_expansion.py is not importable: {_IMPORT_ERROR}")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/hooks/tests/test_build_persona_site_data_sentinel_expansion.py
+++ b/scripts/hooks/tests/test_build_persona_site_data_sentinel_expansion.py
@@ -1000,13 +1000,171 @@ class TestRefLookupPerEntry:
 
 
 # ============================================================================
+# TestNestedGroupSentinelExpansion
+# ============================================================================
+
+
+class TestNestedGroupSentinelExpansion:
+    """Tests that sentinels inside nested-group items are expanded.
+
+    The nested-list branch of normalize_text_entries (lines 122-133 of
+    build_persona_site_data.py) currently strips inner strings but never calls
+    expand_sentinels_to_items. ADR-016 D5 requires every prose-field leaf to
+    be expanded with hard-fail on unresolved IDs — the nested-group shape is
+    not exempt. These RED-phase tests document the missing behavior.
+    """
+
+    def test_nested_group_intra_sentinel_expands_to_ref_item(self):
+        """
+        Test that an intra sentinel inside a nested group is expanded to a ref item.
+
+        Given: A risk longDescription containing a nested group
+               [["See {{controlInputValidation}} for context."]] where
+               controlInputValidation resolves to "Input Validation" via a
+               synthetic control in controls_data
+        When: normalize_text_entries is called in sentinel_mode (all three of
+              intra_lookup, ref_lookup, field_path are provided)
+        Then:
+          - Outer result is a list with one element (the nested group).
+          - That element is itself a list (nested-group shape preserved, not flattened).
+          - Inside the inner list there is a
+            {"type": "ref", "id": "controlInputValidation", "title": "Input Validation"}
+            dict from expand_sentinels_to_items.
+          - Surrounding text fragments ("See " and " for context.") are also present
+            per expand_sentinels_to_items contract (text-before, ref-dict, text-after).
+        """
+        _require_sentinel_module()
+        from scripts.build_persona_site_data import normalize_text_entries
+
+        intra_lookup = {"controlInputValidation": "Input Validation"}
+        ref_lookup: dict = {}
+        value = [["See {{controlInputValidation}} for context."]]
+
+        result = normalize_text_entries(
+            value,
+            intra_lookup=intra_lookup,
+            ref_lookup=ref_lookup,
+            field_path="risks[0].longDescription",
+        )
+
+        # Outer shape: one element, which is itself a list (nested group preserved).
+        assert len(result) == 1, f"Expected one nested group; got {result!r}"
+        inner = result[0]
+        assert isinstance(inner, list), (
+            f"Nested group shape must be preserved as a list, not collapsed; got type {type(inner).__name__!r}"
+        )
+
+        # Inner shape: ref dict must be present (sentinel was expanded).
+        ref_items = [i for i in inner if isinstance(i, dict) and i.get("type") == "ref"]
+        assert ref_items, f"Expected at least one ref dict in the expanded inner list; inner={inner!r}"
+        assert ref_items[0]["id"] == "controlInputValidation", f"ref item id mismatch; got {ref_items[0]!r}"
+        assert ref_items[0]["title"] == "Input Validation", f"ref item title mismatch; got {ref_items[0]!r}"
+
+        # Surrounding text fragments must also be present (expand_sentinels_to_items contract).
+        text_items = [i for i in inner if isinstance(i, str)]
+        assert any("See" in t for t in text_items), f"Text fragment before sentinel missing; inner={inner!r}"
+        assert any("for context" in t for t in text_items), (
+            f"Text fragment after sentinel missing; inner={inner!r}"
+        )
+
+    def test_nested_group_ref_sentinel_expands_to_link_item(self):
+        """
+        Test that a {{ref:...}} sentinel inside a nested group is expanded to a link item.
+
+        Given: A risk longDescription containing [["See {{ref:cwe-89}} for the CWE entry."]]
+               with ref_lookup={"cwe-89": {"title": "SQL Injection",
+               "url": "https://cwe.mitre.org/data/definitions/89.html"}}
+        When: normalize_text_entries is called in sentinel_mode
+        Then:
+          - Outer result has one element which is itself a list (shape preserved).
+          - The inner list contains a
+            {"type": "link", "title": "SQL Injection",
+             "url": "https://cwe.mitre.org/data/definitions/89.html"} dict.
+        """
+        _require_sentinel_module()
+        from scripts.build_persona_site_data import normalize_text_entries
+
+        intra_lookup: dict = {}
+        ref_lookup = {
+            "cwe-89": {
+                "title": "SQL Injection",
+                "url": "https://cwe.mitre.org/data/definitions/89.html",
+            }
+        }
+        value = [["See {{ref:cwe-89}} for the CWE entry."]]
+
+        result = normalize_text_entries(
+            value,
+            intra_lookup=intra_lookup,
+            ref_lookup=ref_lookup,
+            field_path="risks[0].longDescription",
+        )
+
+        # Outer shape preserved.
+        assert len(result) == 1, f"Expected one nested group; got {result!r}"
+        inner = result[0]
+        assert isinstance(inner, list), f"Nested group shape must be a list; got type {type(inner).__name__!r}"
+
+        # Link item must be present in the inner list.
+        link_items = [i for i in inner if isinstance(i, dict) and i.get("type") == "link"]
+        assert link_items, f"Expected at least one link dict in the expanded inner list; inner={inner!r}"
+        assert link_items[0]["title"] == "SQL Injection", f"link item title mismatch; got {link_items[0]!r}"
+        assert link_items[0]["url"] == "https://cwe.mitre.org/data/definitions/89.html", (
+            f"link item url mismatch; got {link_items[0]!r}"
+        )
+
+    def test_nested_group_unresolved_sentinel_raises_with_nested_field_path(self):
+        """
+        Test that an unresolved sentinel inside a nested group raises UnresolvedSentinelError
+        with a field_path that encodes the nested indices.
+
+        Given: A risk longDescription [["See {{controlNonexistent}}."]] with
+               empty intra_lookup={} and empty ref_lookup={}
+        When: normalize_text_entries(..., field_path="risks[0].longDescription") runs
+              in sentinel_mode
+        Then:
+          - UnresolvedSentinelError is raised (never silently swallowed).
+          - exc.sentinel == "{{controlNonexistent}}".
+          - exc.field_path encodes both the outer item index and the inner item
+            index, e.g. "risks[0].longDescription[0][0]" (outer item_idx=0,
+            inner inner_idx=0). The exact form must reference the nested location
+            so an author can pinpoint the offending YAML entry.
+        """
+        _require_sentinel_module()
+        from scripts.build_persona_site_data import normalize_text_entries
+
+        intra_lookup: dict = {}
+        ref_lookup: dict = {}
+        value = [["See {{controlNonexistent}}."]]
+
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            normalize_text_entries(
+                value,
+                intra_lookup=intra_lookup,
+                ref_lookup=ref_lookup,
+                field_path="risks[0].longDescription",
+            )
+
+        exc = exc_info.value
+        assert exc.sentinel == "{{controlNonexistent}}", f"sentinel attribute mismatch; got {exc.sentinel!r}"
+        # field_path must encode the nested location: both outer (item_idx=0) and
+        # inner (inner_idx=0) indices, e.g. "risks[0].longDescription[0][0]".
+        assert "[0][0]" in exc.field_path, (
+            f"field_path must reference nested indices [outer_idx][inner_idx]; got field_path={exc.field_path!r}"
+        )
+        assert "risks[0].longDescription" in exc.field_path, (
+            f"field_path must include the caller-supplied base path; got field_path={exc.field_path!r}"
+        )
+
+
+# ============================================================================
 # Test summary
 # ============================================================================
 """
 Test Summary
 ============
-Total test classes: 9
-Total tests: ~35
+Total test classes: 10
+Total tests: ~38
 
 - TestSentinelExpansionInPersonaProse (4):  intra ref in description, ref link in description,
                                              intra in responsibilities, plain prose unchanged
@@ -1022,6 +1180,10 @@ Total tests: ~35
 - TestComponentsLookupSeeded (3):           component sentinel resolves, unknown raises, sig accepted
 - TestIntraLookupConstruction (3):          persona/risk/control ids all in lookup
 - TestRefLookupPerEntry (1):                ref_lookup is per-entry scoped
+- TestNestedGroupSentinelExpansion (3):     intra sentinel in nested group expands to ref item,
+                                             ref sentinel in nested group expands to link item,
+                                             unresolved sentinel in nested group raises with
+                                             nested field_path encoding [outer_idx][inner_idx]
 
 Coverage areas:
 - Sentinel resolution in all three entity prose fields (persona, risk, control)
@@ -1031,4 +1193,5 @@ Coverage areas:
 - UnresolvedSentinelError propagation with informative field_path
 - Schema validation of expanded output via write_site_data
 - Per-entry ref_lookup scoping (not shared across corpus entries)
+- Nested-group sentinel expansion (new: ADR-016 D5 coverage for list-of-list items)
 """

--- a/scripts/hooks/tests/test_build_persona_site_data_sentinel_expansion.py
+++ b/scripts/hooks/tests/test_build_persona_site_data_sentinel_expansion.py
@@ -1158,6 +1158,140 @@ class TestNestedGroupSentinelExpansion:
 
 
 # ============================================================================
+# TestIdentificationQuestionsSentinelExpansion
+# ============================================================================
+
+
+class TestIdentificationQuestionsSentinelExpansion:
+    """Sentinel expansion in persona identificationQuestions (plain-text shape).
+
+    The persona-site-data schema declares identificationQuestions as `string[]`,
+    not the rich prose shape used for description/responsibilities. Sentinels
+    must therefore expand to plain text (not to structured ref/link items),
+    matching the markdown side (PersonaFullDetailTableGenerator at
+    yaml_to_markdown.py:566-573 already does this via expand_sentinels_to_text).
+
+    Pre-fix builder skipped expansion entirely, leaving sentinel text literally
+    in question_prompts and the question_records[].prompt — divergent from the
+    markdown side and a fail-open against ADR-016 D5 (every prose-field leaf
+    walked, hard-fail on unresolved). This test class pins the contract.
+    """
+
+    def test_identification_questions_intra_sentinel_resolves_to_plain_text(self):
+        """
+        Test that {{controlFoo}} in identificationQuestions expands to the title text.
+
+        Given: A persona with identificationQuestions containing
+               "Does {{controlTestBar}} apply to your team?" and a synthetic
+               control with id=controlTestBar, title="Test Bar Control"
+        When: build_site_data is called
+        Then:
+          - The persona record's identificationQuestions list contains the
+            expanded plain-text question (title substituted, no literal
+            sentinel)
+          - The matching question_records entry's `prompt` is the expanded text
+        """
+        _require_sentinel_module()
+        persona = dict(_MINIMAL_PERSONA)
+        persona["identificationQuestions"] = [
+            "Does {{controlTestBar}} apply to your team?",
+            "Q2?",
+            "Q3?",
+            "Q4?",
+            "Q5?",
+        ]
+
+        result = _build(personas_data={"personas": [persona]})
+
+        persona_out = next(p for p in result["personas"] if p["id"] == "personaTestSubject")
+        first_q = persona_out["identificationQuestions"][0]
+        assert "{{" not in first_q, f"Sentinel must be expanded; got: {first_q!r}"
+        assert "Test Bar Control" in first_q, f"Expected title 'Test Bar Control' substituted; got: {first_q!r}"
+
+        # The corresponding question_records entry must carry the same expanded text.
+        q_record = next(q for q in result["questions"] if q["personaId"] == "personaTestSubject")
+        assert q_record["prompt"] == first_q, (
+            f"question_records prompt must match expanded persona idQuestion; "
+            f"persona[0]={first_q!r}, record={q_record['prompt']!r}"
+        )
+
+    def test_identification_questions_ref_sentinel_resolves_to_plain_text(self):
+        """
+        Test that {{ref:foo}} in identificationQuestions expands to plain link text.
+
+        Given: A persona declaring externalReferences[{id: "src-1", title:
+               "Spec X", url: "https://example.com/x"}] and an
+               identificationQuestion containing "{{ref:src-1}}"
+        When: build_site_data is called
+        Then:
+          - The persona record's identificationQuestions[0] no longer contains
+            the literal sentinel; the link title appears in the rendered text
+          - Schema (string[]) is preserved — the question is a single string
+        """
+        _require_sentinel_module()
+        persona = dict(_MINIMAL_PERSONA)
+        persona["identificationQuestions"] = [
+            "Have you read {{ref:src-1}}?",
+            "Q2?",
+            "Q3?",
+            "Q4?",
+            "Q5?",
+        ]
+        persona["externalReferences"] = [
+            {
+                "id": "src-1",
+                "type": "paper",
+                "title": "Spec X",
+                "url": "https://example.com/x",
+            }
+        ]
+
+        result = _build(personas_data={"personas": [persona]})
+
+        persona_out = next(p for p in result["personas"] if p["id"] == "personaTestSubject")
+        first_q = persona_out["identificationQuestions"][0]
+        assert isinstance(first_q, str), (
+            f"identificationQuestions item must be a string; got {type(first_q).__name__}"
+        )
+        assert "{{ref:" not in first_q, f"Ref sentinel must be expanded; got: {first_q!r}"
+        assert "Spec X" in first_q, f"Expected link title 'Spec X' present in expanded text; got: {first_q!r}"
+
+    def test_identification_questions_unresolved_sentinel_raises(self):
+        """
+        Test that an unresolved sentinel in identificationQuestions raises hard-fail.
+
+        Given: A persona whose identificationQuestion contains
+               {{controlNonexistent}}, and no entity with id=controlNonexistent
+               exists in any of the four corpus dicts
+        When: build_site_data is called
+        Then: UnresolvedSentinelError is raised with field_path encoding the
+              persona index and the question index, e.g.
+              "personas[0].identificationQuestions[0]"
+        """
+        _require_sentinel_module()
+        persona = dict(_MINIMAL_PERSONA)
+        persona["identificationQuestions"] = [
+            "Does {{controlNonexistent}} apply?",
+            "Q2?",
+            "Q3?",
+            "Q4?",
+            "Q5?",
+        ]
+
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            _build(personas_data={"personas": [persona]})
+
+        exc = exc_info.value
+        assert exc.sentinel == "{{controlNonexistent}}", f"sentinel attribute mismatch; got {exc.sentinel!r}"
+        assert "identificationQuestions" in exc.field_path, (
+            f"field_path must reference the field; got field_path={exc.field_path!r}"
+        )
+        assert "[0]" in exc.field_path, (
+            f"field_path must encode the question index; got field_path={exc.field_path!r}"
+        )
+
+
+# ============================================================================
 # Test summary
 # ============================================================================
 """

--- a/scripts/hooks/tests/test_sentinel_expansion.py
+++ b/scripts/hooks/tests/test_sentinel_expansion.py
@@ -1,0 +1,891 @@
+#!/usr/bin/env python3
+"""
+Tests for scripts/hooks/_sentinel_expansion.py
+
+This module tests the shared sentinel-expansion helper (ADR-016 D5). The helper
+is the single source of truth for tokenizer-driven sentinel resolution used by
+both downstream generators:
+  - scripts/build_persona_site_data.py  (via expand_sentinels_to_items)
+  - scripts/yaml_to_markdown.py         (via expand_sentinels_to_text)
+
+Public API under test:
+  UnresolvedSentinelError(sentinel, field_path, message="")
+  expand_sentinels_to_text(text, *, intra_lookup, ref_lookup, field_path,
+                            link_format=lambda title, url: f"[{title}]({url})")
+  expand_sentinels_to_items(text, *, intra_lookup, ref_lookup, field_path)
+
+Wire-format sentinel examples used in fixtures (real tokenizer forms):
+  {{riskPromptInjection}}                    intra; id = "riskPromptInjection"
+  {{controlInputValidationAndSanitization}}  intra; id = "controlInputValidationAndSanitization"
+  {{componentModelServing}}                  intra; id = "componentModelServing"
+  {{personaModelCreator}}                    intra; id = "personaModelCreator"
+  {{ref:cwe-89}}                             ref;  ref-id = "cwe-89"
+  {{ref:zhou-2023-poisoning}}                ref;  ref-id = "zhou-2023-poisoning"
+
+Do NOT use {{idRiskPromptInjection}} -- that is ADR meta-notation, not real wire format.
+
+Design choices locked in by these tests:
+  - expand_sentinels_to_text: TEXT spans are passed through verbatim (no strip).
+  - expand_sentinels_to_items: empty TEXT spans (after .strip()) are NOT emitted.
+  - expand_sentinels_to_items on a single-item TEXT-only result returns ["text"].
+  - INVALID_* tokens and BOLD/ITALIC tokens pass through by .value in both funcs.
+  - UnresolvedSentinelError carries .sentinel and .field_path attributes.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+# ---------------------------------------------------------------------------
+# Guarded import — RED-phase: helper does not exist yet.
+# Tests fail with ImportError until SWE creates the module.
+# ---------------------------------------------------------------------------
+_IMPORT_ERROR: ImportError | None = None
+try:
+    from scripts.hooks._sentinel_expansion import (  # noqa: E402
+        UnresolvedSentinelError,
+        expand_sentinels_to_items,
+        expand_sentinels_to_text,
+    )
+except ImportError as _e:
+    _IMPORT_ERROR = _e
+    UnresolvedSentinelError = None  # type: ignore[assignment,misc]
+    expand_sentinels_to_text = None  # type: ignore[assignment]
+    expand_sentinels_to_items = None  # type: ignore[assignment]
+
+
+def _require_module() -> None:
+    """Skip-with-fail if the module is missing; produces clear RED failure."""
+    if _IMPORT_ERROR is not None:
+        pytest.fail(
+            f"scripts/hooks/_sentinel_expansion.py is not importable (expected in RED phase): {_IMPORT_ERROR}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+INTRA_LOOKUP = {
+    "riskPromptInjection": "Prompt Injection",
+    "controlInputValidationAndSanitization": "Input Validation And Sanitization",
+    "componentModelServing": "Model Serving Infrastructure",
+    "personaModelCreator": "Model Creator",
+}
+
+REF_LOOKUP = {
+    "cwe-89": {
+        "title": "CWE-89: Improper Neutralization of SQL Commands",
+        "url": "https://cwe.mitre.org/data/definitions/89.html",
+    },
+    "zhou-2023-poisoning": {"title": "Zhou et al. 2023 - Data Poisoning", "url": "https://example.com/zhou-2023"},
+}
+
+
+# ============================================================================
+# TestExpandSentinelsToText
+# ============================================================================
+
+
+class TestExpandSentinelsToText:
+    """Tests for expand_sentinels_to_text (markdown-side output)."""
+
+    def test_plain_text_passthrough(self):
+        """
+        Test that text with no sentinels is returned unchanged.
+
+        Given: A plain prose string with no {{ }} markers
+        When: expand_sentinels_to_text is called
+        Then: The exact input string is returned
+        """
+        _require_module()
+        result = expand_sentinels_to_text(
+            "Just plain text with no sentinels.",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].shortDescription[0]",
+        )
+        assert result == "Just plain text with no sentinels."
+
+    def test_intra_sentinel_replaced_with_title(self):
+        """
+        Test that an intra-doc sentinel is replaced by its entity title.
+
+        Given: Text containing {{riskPromptInjection}} and a matching intra_lookup entry
+        When: expand_sentinels_to_text is called
+        Then: The sentinel span is replaced by the entity title (bare text, no link)
+        """
+        _require_module()
+        result = expand_sentinels_to_text(
+            "See {{riskPromptInjection}} for details.",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].longDescription[0]",
+        )
+        assert result == "See Prompt Injection for details."
+
+    def test_ref_sentinel_replaced_with_link_format(self):
+        """
+        Test that a ref sentinel is replaced using the link_format callable.
+
+        Given: Text containing {{ref:cwe-89}} and a matching ref_lookup entry
+        When: expand_sentinels_to_text is called with the default link_format
+        Then: The sentinel span is replaced by [title](url) markdown
+        """
+        _require_module()
+        result = expand_sentinels_to_text(
+            "Relates to {{ref:cwe-89}} vulnerability class.",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[1].longDescription[0]",
+        )
+        expected_link = (
+            "[CWE-89: Improper Neutralization of SQL Commands](https://cwe.mitre.org/data/definitions/89.html)"
+        )
+        assert result == f"Relates to {expected_link} vulnerability class."
+
+    def test_ref_sentinel_custom_link_format(self):
+        """
+        Test that a custom link_format callable is used for ref sentinels.
+
+        Given: Text with {{ref:cwe-89}} and a custom link_format returning HTML <a>
+        When: expand_sentinels_to_text is called with that custom link_format
+        Then: The output uses the custom format rather than the default markdown
+        """
+        _require_module()
+
+        def html_link(title: str, url: str) -> str:
+            return f'<a href="{url}">{title}</a>'
+
+        result = expand_sentinels_to_text(
+            "See {{ref:cwe-89}}.",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="controls[0].description[0]",
+            link_format=html_link,
+        )
+        assert 'href="https://cwe.mitre.org/data/definitions/89.html"' in result
+        assert "CWE-89" in result
+
+    def test_multiple_sentinels_in_one_string(self):
+        """
+        Test that multiple sentinels in one string are all replaced.
+
+        Given: A string containing both {{riskPromptInjection}} and {{ref:cwe-89}}
+        When: expand_sentinels_to_text is called
+        Then: Both sentinels are replaced in a single pass
+        """
+        _require_module()
+        result = expand_sentinels_to_text(
+            "{{riskPromptInjection}} is related to {{ref:cwe-89}}.",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].longDescription[1]",
+        )
+        assert "Prompt Injection" in result
+        assert "{{riskPromptInjection}}" not in result
+        assert "{{ref:cwe-89}}" not in result
+        assert "[CWE-89" in result
+
+    def test_whitespace_preserved_verbatim_around_sentinels(self):
+        """
+        Test that internal whitespace is preserved verbatim; no stripping on TEXT spans.
+
+        Given: A string with leading spaces, trailing spaces, and spaces around a sentinel
+        When: expand_sentinels_to_text is called
+        Then: All whitespace is preserved exactly; only the sentinel span is substituted
+
+        This is the critical no-strip regression test: expand_sentinels_to_text must
+        not call .strip() on TEXT spans. Sentinel substitution is a string replacement,
+        not a normalization step.
+        """
+        _require_module()
+        result = expand_sentinels_to_text(
+            "  spaces  {{riskPromptInjection}}  more  ",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].shortDescription[0]",
+        )
+        assert result == "  spaces  Prompt Injection  more  "
+
+    def test_bold_token_passthrough(self):
+        """
+        Test that bold markup passes through unchanged.
+
+        Given: A string containing **bold text** alongside a sentinel
+        When: expand_sentinels_to_text is called
+        Then: The bold markup is preserved verbatim; only the sentinel is substituted
+        """
+        _require_module()
+        result = expand_sentinels_to_text(
+            "**Important**: see {{riskPromptInjection}}.",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].shortDescription[0]",
+        )
+        assert result == "**Important**: see Prompt Injection."
+
+    def test_italic_token_passthrough(self):
+        """
+        Test that italic markup passes through unchanged.
+
+        Given: A string containing *italic text* alongside a sentinel
+        When: expand_sentinels_to_text is called
+        Then: The italic markup is preserved verbatim
+        """
+        _require_module()
+        result = expand_sentinels_to_text(
+            "*Note:* {{controlInputValidationAndSanitization}} applies.",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="controls[0].description[0]",
+        )
+        assert result == "*Note:* Input Validation And Sanitization applies."
+
+    def test_empty_string_input(self):
+        """
+        Test that an empty string input returns an empty string.
+
+        Given: An empty string
+        When: expand_sentinels_to_text is called
+        Then: An empty string is returned with no error
+        """
+        _require_module()
+        result = expand_sentinels_to_text(
+            "",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].shortDescription[0]",
+        )
+        assert result == ""
+
+    def test_component_sentinel_replaced(self):
+        """
+        Test that a component-prefix intra sentinel is resolved.
+
+        Given: Text containing {{componentModelServing}} with a matching intra_lookup
+        When: expand_sentinels_to_text is called
+        Then: The sentinel is replaced by the component's title text
+        """
+        _require_module()
+        result = expand_sentinels_to_text(
+            "Affects {{componentModelServing}} directly.",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].longDescription[0]",
+        )
+        assert result == "Affects Model Serving Infrastructure directly."
+
+    def test_persona_sentinel_replaced(self):
+        """
+        Test that a persona-prefix intra sentinel is resolved.
+
+        Given: Text containing {{personaModelCreator}} with a matching intra_lookup
+        When: expand_sentinels_to_text is called
+        Then: The sentinel is replaced by the persona's title text
+        """
+        _require_module()
+        result = expand_sentinels_to_text(
+            "Relevant to {{personaModelCreator}} role.",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="controls[0].description[0]",
+        )
+        assert result == "Relevant to Model Creator role."
+
+
+# ============================================================================
+# TestExpandSentinelsToItems
+# ============================================================================
+
+
+class TestExpandSentinelsToItems:
+    """Tests for expand_sentinels_to_items (builder-side structured output)."""
+
+    def test_plain_text_returns_single_string(self):
+        """
+        Test that text with no sentinels returns a list with one string element.
+
+        Given: A plain prose string with no sentinel spans
+        When: expand_sentinels_to_items is called
+        Then: Returns a list containing exactly one string equal to the input
+        """
+        _require_module()
+        result = expand_sentinels_to_items(
+            "Plain prose text.",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].shortDescription[0]",
+        )
+        assert result == ["Plain prose text."]
+
+    def test_intra_sentinel_returns_ref_item(self):
+        """
+        Test that an intra-doc sentinel is represented as a ref structured item.
+
+        Given: Text containing only {{riskPromptInjection}}
+        When: expand_sentinels_to_items is called
+        Then: Returns a list with one dict: {type: "ref", id: "riskPromptInjection", title: "Prompt Injection"}
+        """
+        _require_module()
+        result = expand_sentinels_to_items(
+            "{{riskPromptInjection}}",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].shortDescription[0]",
+        )
+        assert result == [{"type": "ref", "id": "riskPromptInjection", "title": "Prompt Injection"}]
+
+    def test_ref_sentinel_returns_link_item(self):
+        """
+        Test that a ref sentinel is represented as a link structured item.
+
+        Given: Text containing only {{ref:cwe-89}}
+        When: expand_sentinels_to_items is called
+        Then: Returns a list with one dict: {type: "link", title: ..., url: ...}
+        """
+        _require_module()
+        result = expand_sentinels_to_items(
+            "{{ref:cwe-89}}",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[1].longDescription[0]",
+        )
+        assert result == [
+            {
+                "type": "link",
+                "title": "CWE-89: Improper Neutralization of SQL Commands",
+                "url": "https://cwe.mitre.org/data/definitions/89.html",
+            }
+        ]
+
+    def test_sentinel_surrounded_by_text_produces_three_items(self):
+        """
+        Test that a sentinel surrounded by text produces [str, structured, str].
+
+        Given: Text of the form "prefix {{sentinel}} suffix"
+        When: expand_sentinels_to_items is called
+        Then: Returns [prefix_str, sentinel_item, suffix_str] — three elements
+        """
+        _require_module()
+        result = expand_sentinels_to_items(
+            "See {{riskPromptInjection}} for details.",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].longDescription[0]",
+        )
+        assert len(result) == 3
+        assert result[0] == "See "
+        assert result[1] == {"type": "ref", "id": "riskPromptInjection", "title": "Prompt Injection"}
+        assert result[2] == " for details."
+
+    def test_two_adjacent_sentinels_no_whitespace_between(self):
+        """
+        Test that two adjacent sentinels with no text between them produce two items.
+
+        Given: Text "{{riskPromptInjection}}{{ref:cwe-89}}" with no TEXT between
+        When: expand_sentinels_to_items is called
+        Then: Returns [ref_item, link_item] — exactly two elements, no empty string between
+        """
+        _require_module()
+        result = expand_sentinels_to_items(
+            "{{riskPromptInjection}}{{ref:cwe-89}}",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].longDescription[0]",
+        )
+        assert len(result) == 2
+        assert result[0]["type"] == "ref"
+        assert result[1]["type"] == "link"
+        # No empty string between them
+        assert not any(item == "" for item in result)
+
+    def test_empty_text_between_sentinels_is_not_emitted(self):
+        """
+        Test that empty/whitespace-only TEXT spans between sentinels are dropped.
+
+        Given: Two sentinels with only whitespace between them
+        When: expand_sentinels_to_items is called
+        Then: No empty or whitespace-only string element appears in the result
+
+        This is the NIT-08 regression test: matches normalize_text_entries behavior
+        that drops empty / whitespace-only items.
+        """
+        _require_module()
+        result = expand_sentinels_to_items(
+            "{{riskPromptInjection}} {{ref:cwe-89}}",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].examples[0]",
+        )
+        # The single space between sentinels is whitespace-only; after .strip() it is ""
+        # It must NOT appear in the output.
+        string_items = [item for item in result if isinstance(item, str)]
+        assert not any(s.strip() == "" for s in string_items), (
+            "Whitespace-only TEXT spans must be dropped from expand_sentinels_to_items output"
+        )
+
+    def test_empty_string_input(self):
+        """
+        Test that an empty string input returns an empty list.
+
+        Given: An empty string
+        When: expand_sentinels_to_items is called
+        Then: Returns an empty list (no items, including no empty string)
+        """
+        _require_module()
+        result = expand_sentinels_to_items(
+            "",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].shortDescription[0]",
+        )
+        assert result == []
+
+    def test_multiple_intra_sentinels_all_resolved(self):
+        """
+        Test that multiple intra-doc sentinels in one string are all resolved.
+
+        Given: A string with two intra sentinels separated by text
+        When: expand_sentinels_to_items is called
+        Then: Both sentinels produce ref items in source order; TEXT segments preserved
+        """
+        _require_module()
+        result = expand_sentinels_to_items(
+            "Both {{riskPromptInjection}} and {{controlInputValidationAndSanitization}} matter.",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].longDescription[2]",
+        )
+        types = [item.get("type") if isinstance(item, dict) else "text" for item in result]
+        assert "ref" in types
+        assert types.count("ref") == 2
+        # First ref is the risk, second is the control
+        ref_items = [item for item in result if isinstance(item, dict) and item["type"] == "ref"]
+        assert ref_items[0]["id"] == "riskPromptInjection"
+        assert ref_items[1]["id"] == "controlInputValidationAndSanitization"
+
+    def test_bold_and_italic_tokens_concatenated_into_text(self):
+        """
+        Test that BOLD and ITALIC tokens are concatenated into TEXT segments.
+
+        Given: A string with **bold** and *italic* content adjacent to a sentinel
+        When: expand_sentinels_to_items is called
+        Then: Bold/italic tokens are concatenated with adjacent TEXT into string segments;
+              sentinels produce structured items
+        """
+        _require_module()
+        result = expand_sentinels_to_items(
+            "**Critical**: {{riskPromptInjection}}.",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].shortDescription[0]",
+        )
+        # Expect: ["**Critical**: ", {ref item}, "."]
+        assert any(isinstance(item, dict) and item["type"] == "ref" for item in result)
+        string_parts = [item for item in result if isinstance(item, str)]
+        combined = "".join(string_parts)
+        assert "**Critical**" in combined
+
+    def test_invalid_sentinel_token_treated_as_text(self):
+        """
+        Test that INVALID_SENTINEL tokens are treated as text (passed through by .value).
+
+        Given: A malformed sentinel like {{notValidPrefix}} that produces INVALID_SENTINEL
+        When: expand_sentinels_to_items is called
+        Then: The invalid sentinel span appears in the output as a text segment,
+              not as a structured item, and no error is raised
+        """
+        _require_module()
+        result = expand_sentinels_to_items(
+            "Has {{notValidPrefix}} in it.",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].longDescription[0]",
+        )
+        combined = "".join(item if isinstance(item, str) else "" for item in result)
+        assert "{{notValidPrefix}}" in combined
+
+    def test_component_intra_sentinel_resolves_to_ref_item(self):
+        """
+        Test that a component-prefix sentinel is resolved as a ref item.
+
+        Given: Text containing {{componentModelServing}}
+        When: expand_sentinels_to_items is called with intra_lookup containing that id
+        Then: Returns a ref item with id="componentModelServing" and the correct title
+        """
+        _require_module()
+        result = expand_sentinels_to_items(
+            "{{componentModelServing}}",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].longDescription[0]",
+        )
+        assert result == [{"type": "ref", "id": "componentModelServing", "title": "Model Serving Infrastructure"}]
+
+    def test_ref_sentinel_with_dotted_id(self):
+        """
+        Test that a ref sentinel with a hyphenated/compound id is resolved.
+
+        Given: Text containing {{ref:zhou-2023-poisoning}}
+        When: expand_sentinels_to_items is called with matching ref_lookup
+        Then: Returns a link item with the correct title and url
+        """
+        _require_module()
+        result = expand_sentinels_to_items(
+            "See {{ref:zhou-2023-poisoning}} for the attack description.",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].longDescription[0]",
+        )
+        link_items = [item for item in result if isinstance(item, dict) and item["type"] == "link"]
+        assert len(link_items) == 1
+        assert link_items[0]["title"] == "Zhou et al. 2023 - Data Poisoning"
+        assert link_items[0]["url"] == "https://example.com/zhou-2023"
+
+
+# ============================================================================
+# TestUnresolvedSentinelError
+# ============================================================================
+
+
+class TestUnresolvedSentinelError:
+    """Tests for UnresolvedSentinelError exception class and raise behavior."""
+
+    def test_exception_is_subclass_of_value_error(self):
+        """
+        Test that UnresolvedSentinelError is a ValueError subclass.
+
+        Given: The UnresolvedSentinelError class
+        When: Checked with issubclass
+        Then: It is a subclass of ValueError
+        """
+        _require_module()
+        assert issubclass(UnresolvedSentinelError, ValueError)
+
+    def test_exception_carries_sentinel_attribute(self):
+        """
+        Test that UnresolvedSentinelError stores the full sentinel span.
+
+        Given: An UnresolvedSentinelError constructed with a sentinel and field_path
+        When: The .sentinel attribute is accessed
+        Then: It equals the sentinel span as it appeared in source
+        """
+        _require_module()
+        exc = UnresolvedSentinelError(
+            sentinel="{{riskTypoFooBar}}",
+            field_path="risks[3].longDescription[0]",
+        )
+        assert exc.sentinel == "{{riskTypoFooBar}}"
+
+    def test_exception_carries_field_path_attribute(self):
+        """
+        Test that UnresolvedSentinelError stores the field_path string.
+
+        Given: An UnresolvedSentinelError constructed with a field_path
+        When: The .field_path attribute is accessed
+        Then: It equals the caller-supplied field_path string
+        """
+        _require_module()
+        exc = UnresolvedSentinelError(
+            sentinel="{{riskTypoFooBar}}",
+            field_path="risks[3].longDescription[0]",
+        )
+        assert exc.field_path == "risks[3].longDescription[0]"
+
+    def test_exception_message_includes_sentinel_and_field_path(self):
+        """
+        Test that str(UnresolvedSentinelError) includes both sentinel and field_path.
+
+        Given: An UnresolvedSentinelError with a custom message
+        When: str(exc) is evaluated
+        Then: The string contains both the sentinel span and the field_path
+        """
+        _require_module()
+        exc = UnresolvedSentinelError(
+            sentinel="{{ref:cve-2024-99999}}",
+            field_path="controls[2].description[0]",
+            message="No matching externalReferences entry",
+        )
+        msg = str(exc)
+        assert exc.sentinel in msg
+        assert exc.field_path in msg
+        assert exc.field_path == "controls[2].description[0]"
+
+    def test_expand_to_text_raises_on_unknown_intra_id(self):
+        """
+        Test that expand_sentinels_to_text raises UnresolvedSentinelError for unknown intra id.
+
+        Given: Text containing {{riskTypoFooBar}} and an intra_lookup with no such id
+        When: expand_sentinels_to_text is called
+        Then: UnresolvedSentinelError is raised with .sentinel == "{{riskTypoFooBar}}"
+              and .field_path matching the caller's field_path argument
+        """
+        _require_module()
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            expand_sentinels_to_text(
+                "Contains {{riskTypoFooBar}} which is wrong.",
+                intra_lookup={"riskOther": "Other Risk"},
+                ref_lookup={},
+                field_path="risks[3].longDescription[0]",
+            )
+        exc = exc_info.value
+        assert exc.sentinel == "{{riskTypoFooBar}}"
+        assert exc.field_path == "risks[3].longDescription[0]"
+
+    def test_expand_to_text_raises_on_unknown_ref_id(self):
+        """
+        Test that expand_sentinels_to_text raises UnresolvedSentinelError for unknown ref id.
+
+        Given: Text containing {{ref:cve-2024-99999}} and a ref_lookup with no such entry
+        When: expand_sentinels_to_text is called
+        Then: UnresolvedSentinelError is raised with .sentinel == "{{ref:cve-2024-99999}}"
+        """
+        _require_module()
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            expand_sentinels_to_text(
+                "See {{ref:cve-2024-99999}} for the vulnerability.",
+                intra_lookup=INTRA_LOOKUP,
+                ref_lookup={},  # empty — no entry matches
+                field_path="risks[1].longDescription[2]",
+            )
+        exc = exc_info.value
+        assert exc.sentinel == "{{ref:cve-2024-99999}}"
+        assert exc.field_path == "risks[1].longDescription[2]"
+
+    def test_expand_to_items_raises_on_unknown_intra_id(self):
+        """
+        Test that expand_sentinels_to_items raises UnresolvedSentinelError for unknown intra id.
+
+        Given: Text containing {{riskTypoFooBar}} and an intra_lookup with no such id
+        When: expand_sentinels_to_items is called
+        Then: UnresolvedSentinelError is raised with .sentinel == "{{riskTypoFooBar}}"
+        """
+        _require_module()
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            expand_sentinels_to_items(
+                "Contains {{riskTypoFooBar}} which is wrong.",
+                intra_lookup={},
+                ref_lookup={},
+                field_path="risks[3].longDescription[0]",
+            )
+        exc = exc_info.value
+        assert exc.sentinel == "{{riskTypoFooBar}}"
+        assert exc.field_path == "risks[3].longDescription[0]"
+
+    def test_expand_to_items_raises_on_unknown_ref_id(self):
+        """
+        Test that expand_sentinels_to_items raises UnresolvedSentinelError for unknown ref id.
+
+        Given: Text containing {{ref:cve-2024-99999}} and an empty ref_lookup
+        When: expand_sentinels_to_items is called
+        Then: UnresolvedSentinelError is raised with the correct sentinel span and field_path
+        """
+        _require_module()
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            expand_sentinels_to_items(
+                "See {{ref:cve-2024-99999}}.",
+                intra_lookup=INTRA_LOOKUP,
+                ref_lookup={},
+                field_path="controls[0].description[1]",
+            )
+        exc = exc_info.value
+        assert exc.sentinel == "{{ref:cve-2024-99999}}"
+        assert exc.field_path == "controls[0].description[1]"
+
+    @pytest.mark.parametrize(
+        "bad_sentinel,field_path",
+        [
+            ("{{riskTypoFooBar}}", "risks[0].longDescription[0]"),
+            ("{{controlNonExistent}}", "controls[1].description[0]"),
+            ("{{componentBogus}}", "risks[2].examples[0]"),
+            ("{{personaMissing}}", "controls[0].description[2]"),
+        ],
+    )
+    def test_expand_to_text_raises_for_various_unknown_intra_ids(self, bad_sentinel, field_path):
+        """
+        Test that expand_sentinels_to_text raises for various unknown intra-doc ids.
+
+        Given: A sentinel that looks syntactically valid but has no entry in intra_lookup
+        When: expand_sentinels_to_text is called
+        Then: UnresolvedSentinelError is raised with the right sentinel and field_path
+        """
+        _require_module()
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            expand_sentinels_to_text(
+                f"Text with {bad_sentinel} sentinel.",
+                intra_lookup={},
+                ref_lookup={},
+                field_path=field_path,
+            )
+        exc = exc_info.value
+        assert exc.sentinel == bad_sentinel
+        assert exc.field_path == field_path
+
+
+# ============================================================================
+# TestPartitionInvariant
+# ============================================================================
+
+
+class TestPartitionInvariant:
+    """Sanity tests: every input character is accounted for in the output."""
+
+    def test_to_text_reconstructs_input_modulo_sentinel_substitution(self):
+        """
+        Test that expand_sentinels_to_text accounts for every input character.
+
+        Given: A string with text and sentinels
+        When: expand_sentinels_to_text is called
+        Then: The result equals what you would get by substituting the sentinel spans
+              in the original string; no characters are lost or duplicated
+
+        The invariant: result == input.replace(sentinel_span, title_substitution)
+        for each sentinel, applied in source order.
+        """
+        _require_module()
+        input_text = "Before {{riskPromptInjection}} middle {{ref:cwe-89}} after."
+        result = expand_sentinels_to_text(
+            input_text,
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].longDescription[0]",
+        )
+        expected = (
+            "Before Prompt Injection middle "
+            "[CWE-89: Improper Neutralization of SQL Commands](https://cwe.mitre.org/data/definitions/89.html)"
+            " after."
+        )
+        assert result == expected
+
+    def test_to_items_string_reconstruction_matches_input(self):
+        """
+        Test that concatenating all string segments from expand_sentinels_to_items
+        (with sentinel spans replaced by sentinel id/title) reconstructs the input.
+
+        Given: A string with text and one intra sentinel
+        When: expand_sentinels_to_items is called
+        Then: Joining the text parts and substituting sentinel spans reconstructs the input
+
+        This is the partition invariant for the items output: no characters are lost,
+        dropped, or duplicated by the tokenization + expansion process.
+        """
+        _require_module()
+        input_text = "Before {{riskPromptInjection}} after."
+        result = expand_sentinels_to_items(
+            input_text,
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].longDescription[0]",
+        )
+        # Reconstruct: strings pass through, sentinels contribute their span (for comparison)
+        reconstructed_parts = []
+        for item in result:
+            if isinstance(item, str):
+                reconstructed_parts.append(item)
+            elif isinstance(item, dict) and item["type"] == "ref":
+                # The sentinel span is {{<id>}}, so the reconstruction substitutes back
+                reconstructed_parts.append(f"{{{{{item['id']}}}}}")
+            elif isinstance(item, dict) and item["type"] == "link":
+                # Ref sentinels are {{ref:<id>}} in source; find the ref_lookup key
+                for ref_id, ref_data in REF_LOOKUP.items():
+                    if ref_data == {"title": item["title"], "url": item["url"]}:
+                        reconstructed_parts.append(f"{{{{ref:{ref_id}}}}}")
+                        break
+        assert "".join(reconstructed_parts) == input_text
+
+    def test_to_items_no_empty_strings_dropped_from_between_sentinels(self):
+        """
+        Test the drop-empty invariant: no empty strings appear in items output.
+
+        Given: Adjacent sentinels with empty/whitespace TEXT between them
+        When: expand_sentinels_to_items is called
+        Then: No empty string ('') appears in the result list
+
+        This is a critical invariant: empty-string items would cause schema validation
+        issues since string items in the prose schema allow empty strings at the
+        item level (the schema has no minLength on string items), but we want to
+        keep the output clean and consistent with normalize_text_entries NIT-08.
+        """
+        _require_module()
+        # Adjacent sentinels, no whitespace
+        result = expand_sentinels_to_items(
+            "{{riskPromptInjection}}{{ref:cwe-89}}",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].examples[0]",
+        )
+        assert "" not in result
+
+    def test_to_text_no_op_on_whitespace_only_string(self):
+        """
+        Test that a whitespace-only string is returned unchanged by expand_sentinels_to_text.
+
+        Given: A whitespace-only string (no sentinels)
+        When: expand_sentinels_to_text is called
+        Then: The exact whitespace string is returned (no stripping)
+        """
+        _require_module()
+        result = expand_sentinels_to_text(
+            "   \t  ",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="risks[0].shortDescription[0]",
+        )
+        assert result == "   \t  "
+
+    def test_to_items_on_text_only_string_returns_exact_input(self):
+        """
+        Test that a string with no sentinels is returned unchanged as a single item.
+
+        Given: A plain text string "Hello, world."
+        When: expand_sentinels_to_items is called
+        Then: Returns exactly ["Hello, world."] — the input is not stripped or modified
+        """
+        _require_module()
+        result = expand_sentinels_to_items(
+            "Hello, world.",
+            intra_lookup=INTRA_LOOKUP,
+            ref_lookup=REF_LOOKUP,
+            field_path="controls[0].description[0]",
+        )
+        assert result == ["Hello, world."]
+
+
+# ============================================================================
+# Test summary
+# ============================================================================
+"""
+Test Summary
+============
+Total tests: ~40 (across 4 test classes)
+- TestExpandSentinelsToText (11):       plain passthrough, intra/ref substitution,
+                                         custom link_format, multiple sentinels,
+                                         whitespace preservation (critical regression),
+                                         bold/italic passthrough, empty string, component, persona
+- TestExpandSentinelsToItems (11):      plain → single string, intra → ref item,
+                                         ref → link item, surrounding text, adjacent sentinels,
+                                         empty-between-sentinels dropped, empty input,
+                                         multiple sentinels, bold/italic concatenated,
+                                         INVALID_SENTINEL passthrough, component sentinel
+- TestUnresolvedSentinelError (9+4par): ValueError subclass, .sentinel/.field_path attrs,
+                                         message includes both, raises from _to_text (intra+ref),
+                                         raises from _to_items (intra+ref), parametrized intra miss
+- TestPartitionInvariant (5):            _to_text reconstructs modulo substitution,
+                                         _to_items reconstruction, no empty strings,
+                                         whitespace-only passthrough, text-only unchanged
+
+Coverage target: 90%+ on scripts/hooks/_sentinel_expansion.py
+
+Key design constraints pinned by these tests:
+  - expand_sentinels_to_text: TEXT spans passed through verbatim (no .strip())
+  - expand_sentinels_to_items: empty/whitespace TEXT spans dropped (NIT-08 parity)
+  - INVALID_* tokens pass through by .value in both functions
+  - UnresolvedSentinelError is a ValueError with .sentinel and .field_path attributes
+"""

--- a/scripts/hooks/tests/test_sentinel_expansion.py
+++ b/scripts/hooks/tests/test_sentinel_expansion.py
@@ -43,8 +43,9 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT))
 
 # ---------------------------------------------------------------------------
-# Guarded import — RED-phase: helper does not exist yet.
-# Tests fail with ImportError until SWE creates the module.
+# Decoupled import: if the helper module fails to import (e.g. dependency
+# drift), tests fail individually with a clear message instead of a
+# collection-time error. Mirrors the A3 pattern in test_prose_tokens.py.
 # ---------------------------------------------------------------------------
 _IMPORT_ERROR: ImportError | None = None
 try:
@@ -61,11 +62,9 @@ except ImportError as _e:
 
 
 def _require_module() -> None:
-    """Skip-with-fail if the module is missing; produces clear RED failure."""
+    """Fail clearly if the helper module is missing (decoupled-import pattern)."""
     if _IMPORT_ERROR is not None:
-        pytest.fail(
-            f"scripts/hooks/_sentinel_expansion.py is not importable (expected in RED phase): {_IMPORT_ERROR}"
-        )
+        pytest.fail(f"scripts/hooks/_sentinel_expansion.py is not importable: {_IMPORT_ERROR}")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/hooks/tests/test_yaml_to_markdown_persona_sentinel_expansion.py
+++ b/scripts/hooks/tests/test_yaml_to_markdown_persona_sentinel_expansion.py
@@ -1,0 +1,804 @@
+#!/usr/bin/env python3
+"""
+Tests for A7 sentinel expansion in PersonaSummaryTableGenerator and
+PersonaFullDetailTableGenerator (scripts/hooks/yaml_to_markdown.py).
+
+This file closes the same-file consistency gap identified in the A8 lesson:
+commit 2 wired FullDetailTableGenerator and SummaryTableGenerator but left both
+persona-specific generators unwired. This test suite pins the missing contracts
+before the SWE wires them.
+
+Contracts pinned by this test suite:
+
+PersonaSummaryTableGenerator.generate wiring (tasks 2.5.1 + 2.5.3):
+  - Passes self.intra_lookup and a per-row ref_lookup to collapse_column when
+    expanding description.  field_path uses "personas[N].description" form.
+  - When lookups are None (default), sentinels pass through unchanged —
+    backward-compat baseline.
+  - An unresolved sentinel raises UnresolvedSentinelError; it is never swallowed.
+  - Emits "## References for {persona-id}" sub-section after the main table
+    for any persona with a non-empty externalReferences array.
+
+PersonaFullDetailTableGenerator.generate wiring (tasks 2.5.1 + 2.5.3):
+  - Same collapse_column wiring for description.
+  - Per-item expand_sentinels_to_text applied to each string in responsibilities
+    and identificationQuestions before passing to format_list.
+    field_path per item: "personas[N].responsibilities[M]" or
+    "personas[N].identificationQuestions[M]".
+  - None lookups preserve pre-A7 passthrough for all three field paths.
+  - UnresolvedSentinelError propagates from responsibilities and questions paths
+    (the critical task 2.5.3 gap for non-description fields).
+  - Same ## References for {persona-id} sub-section contract.
+
+field_path format contract:
+  - description: "personas[N].description"
+  - responsibilities item M: "personas[N].responsibilities[M]"
+  - identificationQuestions item M: "personas[N].identificationQuestions[M]"
+  N and M are zero-based row/item indices (positional; entry id not required).
+
+Wire-format sentinels used in fixtures (real tokenizer form):
+  - {{controlInputValidationAndSanitization}}   intra, control
+  - {{riskPromptInjection}}                     intra, risk
+  - {{componentModelServing}}                   intra, component
+  - {{ref:cwe-89}}                              external
+  - {{ref:zhou-2023-poisoning}}                 external
+
+Do NOT use {{idXxx}} meta-notation — that is ADR-016 meta, not wire format.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+# ---------------------------------------------------------------------------
+# Decoupled imports: mirrors the A3 pattern in test_prose_tokens.py and the
+# A7 commit-2 pattern in test_yaml_to_markdown_sentinel_expansion.py.
+# If the sentinel helper fails to import, individual tests fail with a clear
+# message rather than aborting the whole collection.
+# ---------------------------------------------------------------------------
+
+_SENTINEL_MODULE_ERROR: ImportError | None = None
+try:
+    from scripts.hooks._sentinel_expansion import UnresolvedSentinelError  # noqa: E402
+except ImportError as _e:
+    _SENTINEL_MODULE_ERROR = _e
+    UnresolvedSentinelError = None  # type: ignore[assignment,misc]
+
+# yaml_to_markdown exists pre-A7; the symbol lookups below fail at test-call
+# time (not at collection time) if the persona generators are missing.
+import scripts.hooks.yaml_to_markdown as _ytm  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helper utilities
+# ---------------------------------------------------------------------------
+
+
+def _require_sentinel_module() -> None:
+    """Fail clearly if the sentinel helper module is not importable."""
+    if _SENTINEL_MODULE_ERROR is not None:
+        pytest.fail(f"scripts/hooks/_sentinel_expansion.py is not importable: {_SENTINEL_MODULE_ERROR}")
+
+
+def _get_persona_summary_generator():
+    """Return PersonaSummaryTableGenerator class; fails if not present."""
+    cls = getattr(_ytm, "PersonaSummaryTableGenerator", None)
+    if cls is None:
+        pytest.fail("yaml_to_markdown.PersonaSummaryTableGenerator is not defined")
+    return cls
+
+
+def _get_persona_full_detail_generator():
+    """Return PersonaFullDetailTableGenerator class; fails if not present."""
+    cls = getattr(_ytm, "PersonaFullDetailTableGenerator", None)
+    if cls is None:
+        pytest.fail("yaml_to_markdown.PersonaFullDetailTableGenerator is not defined")
+    return cls
+
+
+# ---------------------------------------------------------------------------
+# Shared lookup fixtures used across test classes
+# ---------------------------------------------------------------------------
+
+_INTRA_LOOKUP = {
+    "controlInputValidationAndSanitization": "Input Validation And Sanitization",
+    "riskPromptInjection": "Prompt Injection",
+    "componentModelServing": "Model Serving Infrastructure",
+}
+
+_REF_LOOKUP = {
+    "cwe-89": {
+        "title": "CWE-89: Improper Neutralization of SQL Commands",
+        "url": "https://cwe.mitre.org/data/definitions/89.html",
+    },
+    "zhou-2023-poisoning": {
+        "title": "Zhou et al. 2023 - Data Poisoning",
+        "url": "https://example.com/zhou-2023",
+    },
+}
+
+
+def _make_persona(
+    pid: str = "personaTestAlpha",
+    title: str = "Test Alpha Persona",
+    description: str = "A plain description with no sentinels.",
+    responsibilities: list[str] | None = None,
+    identification_questions: list[str] | None = None,
+    external_references: list[dict] | None = None,
+    deprecated: bool = False,
+) -> dict:
+    """Return a minimal persona dict suitable for both persona generators."""
+    p: dict = {
+        "id": pid,
+        "title": title,
+        "description": description,
+        "deprecated": deprecated,
+        "responsibilities": responsibilities if responsibilities is not None else [],
+        "identificationQuestions": (identification_questions if identification_questions is not None else []),
+        "mappings": {},
+    }
+    if external_references is not None:
+        p["externalReferences"] = external_references
+    return p
+
+
+def _make_personas_yaml(*personas) -> dict:
+    """Wrap one or more persona dicts in the top-level YAML structure."""
+    return {"personas": list(personas)}
+
+
+# ============================================================================
+# TestPersonaSummarySentinelExpansion
+# ============================================================================
+
+
+class TestPersonaSummarySentinelExpansion:
+    """
+    Tests for sentinel expansion in PersonaSummaryTableGenerator.generate().
+
+    The generator reads description via collapse_column.  When lookups are None
+    (the default), sentinels pass through unchanged.  When intra_lookup and
+    ref_lookup are set on the instance, sentinels are expanded and unresolved
+    ones raise UnresolvedSentinelError.  A ## References for {id} sub-section
+    is appended for personas with a non-empty externalReferences array.
+    """
+
+    def test_no_lookups_preserves_legacy_passthrough(self):
+        """
+        Baseline: no-kwargs construction passes description sentinels through verbatim.
+
+        Given: PersonaSummaryTableGenerator() with no lookup kwargs; persona description
+               containing {{controlFoo}} (arbitrary sentinel placeholder)
+        When: generate() is called
+        Then: The sentinel text appears verbatim in the output (not resolved, no error)
+
+        This is the backward-compat contract: pre-A7 call sites omit lookups
+        and must keep working without change.
+        """
+        gen_cls = _get_persona_summary_generator()
+        yaml_data = _make_personas_yaml(
+            _make_persona(description="See {{controlInputValidationAndSanitization}} for details.")
+        )
+        gen = gen_cls()
+        output = gen.generate(yaml_data, "personas")
+        assert "{{controlInputValidationAndSanitization}}" in output
+
+    def test_intra_sentinel_in_description_resolves(self):
+        """
+        Intra sentinel in description expands to plain title when lookups are supplied.
+
+        Given: PersonaSummaryTableGenerator(intra_lookup=..., ref_lookup={})
+               persona description "See {{controlInputValidationAndSanitization}} for details."
+        When: generate() is called
+        Then: Output contains "Input Validation And Sanitization" (the resolved title)
+              and does NOT contain the raw sentinel span
+        """
+        _require_sentinel_module()
+        gen_cls = _get_persona_summary_generator()
+        yaml_data = _make_personas_yaml(
+            _make_persona(description="See {{controlInputValidationAndSanitization}} for details.")
+        )
+        gen = gen_cls(intra_lookup=_INTRA_LOOKUP, ref_lookup={})
+        output = gen.generate(yaml_data, "personas")
+        assert "Input Validation And Sanitization" in output
+        assert "{{controlInputValidationAndSanitization}}" not in output
+
+    def test_ref_sentinel_in_description_resolves(self):
+        """
+        External-reference sentinel in description expands to a markdown link.
+
+        Given: PersonaSummaryTableGenerator(intra_lookup={}, ref_lookup=...)
+               persona description "See {{ref:cwe-89}}."
+        When: generate() is called
+        Then: Output contains the linked title and url, not the raw sentinel span
+        """
+        _require_sentinel_module()
+        gen_cls = _get_persona_summary_generator()
+        yaml_data = _make_personas_yaml(_make_persona(description="See {{ref:cwe-89}}."))
+        gen = gen_cls(intra_lookup={}, ref_lookup=_REF_LOOKUP)
+        output = gen.generate(yaml_data, "personas")
+        assert "[CWE-89: Improper Neutralization of SQL Commands]" in output
+        assert "https://cwe.mitre.org/data/definitions/89.html" in output
+        assert "{{ref:cwe-89}}" not in output
+
+    def test_unresolved_intra_sentinel_raises(self):
+        """
+        UnresolvedSentinelError propagates from description when the intra id is missing.
+
+        Given: PersonaSummaryTableGenerator(intra_lookup={}, ref_lookup={})
+               persona description "Mentions {{controlBogus}}."
+        When: generate() is called
+        Then: UnresolvedSentinelError is raised with .sentinel == "{{controlBogus}}"
+        """
+        _require_sentinel_module()
+        gen_cls = _get_persona_summary_generator()
+        yaml_data = _make_personas_yaml(_make_persona(description="Mentions {{controlBogus}}."))
+        gen = gen_cls(intra_lookup={}, ref_lookup={})
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            gen.generate(yaml_data, "personas")
+        assert exc_info.value.sentinel == "{{controlBogus}}"
+
+    def test_unresolved_ref_sentinel_raises(self):
+        """
+        UnresolvedSentinelError propagates from description when ref id is missing.
+
+        Given: PersonaSummaryTableGenerator(intra_lookup={}, ref_lookup={})
+               persona description "See {{ref:cve-2024-99999}}."
+        When: generate() is called
+        Then: UnresolvedSentinelError is raised with .sentinel == "{{ref:cve-2024-99999}}"
+        """
+        _require_sentinel_module()
+        gen_cls = _get_persona_summary_generator()
+        yaml_data = _make_personas_yaml(_make_persona(description="See {{ref:cve-2024-99999}}."))
+        gen = gen_cls(intra_lookup={}, ref_lookup={})
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            gen.generate(yaml_data, "personas")
+        assert exc_info.value.sentinel == "{{ref:cve-2024-99999}}"
+
+    def test_external_references_sub_section_emitted(self):
+        """
+        ## References for {persona-id} sub-section appears after the table when
+        externalReferences is non-empty.
+
+        Given: PersonaSummaryTableGenerator(); persona "personaWithRefs" having
+               externalReferences=[{type: "cwe", id: "cwe-89", title: "CWE-89",
+               url: "https://example.com/cwe-89"}]
+        When: generate() is called
+        Then: Output contains "## References for personaWithRefs" AFTER the table
+              followed by a bullet "- [CWE-89](https://example.com/cwe-89) (cwe)"
+        """
+        gen_cls = _get_persona_summary_generator()
+        refs = [{"type": "cwe", "id": "cwe-89", "title": "CWE-89", "url": "https://example.com/cwe-89"}]
+        yaml_data = _make_personas_yaml(_make_persona(pid="personaWithRefs", external_references=refs))
+        gen = gen_cls()
+        output = gen.generate(yaml_data, "personas")
+
+        assert "## References for personaWithRefs" in output
+        # Sub-section is after the table (after the last "|" in the markdown table)
+        table_end_idx = output.rfind("|")
+        refs_idx = output.index("## References for personaWithRefs")
+        assert refs_idx > table_end_idx, (
+            f"## References section (pos {refs_idx}) must appear after the last table pipe (pos {table_end_idx})"
+        )
+        # Bullet contains title as link and type in parens
+        assert "- [CWE-89](https://example.com/cwe-89) (cwe)" in output
+
+    def test_no_external_references_no_sub_section(self):
+        """
+        No ## References for header when persona has no externalReferences field.
+
+        Given: PersonaSummaryTableGenerator(); persona with no externalReferences key
+        When: generate() is called
+        Then: "## References for" does NOT appear anywhere in the output
+        """
+        gen_cls = _get_persona_summary_generator()
+        yaml_data = _make_personas_yaml(_make_persona(pid="personaNoRefs"))
+        gen = gen_cls()
+        output = gen.generate(yaml_data, "personas")
+        assert "## References for" not in output
+
+    def test_multiple_personas_each_get_their_own_section(self):
+        """
+        Two personas with externalReferences each get a distinct ## References for section.
+
+        Given: PersonaSummaryTableGenerator(); two personas "personaAlpha" and "personaBeta",
+               each with one externalReferences entry
+        When: generate() is called
+        Then: Output contains both "## References for personaAlpha" and
+              "## References for personaBeta"
+        """
+        gen_cls = _get_persona_summary_generator()
+        refs_alpha = [{"type": "cwe", "id": "cwe-1", "title": "CWE-1", "url": "https://example.com/1"}]
+        refs_beta = [{"type": "paper", "id": "paper-2", "title": "Paper 2", "url": "https://example.com/2"}]
+        yaml_data = _make_personas_yaml(
+            _make_persona(pid="personaAlpha", external_references=refs_alpha),
+            _make_persona(pid="personaBeta", external_references=refs_beta),
+        )
+        gen = gen_cls()
+        output = gen.generate(yaml_data, "personas")
+        assert "## References for personaAlpha" in output
+        assert "## References for personaBeta" in output
+
+
+# ============================================================================
+# TestPersonaFullDetailSentinelExpansion
+# ============================================================================
+
+
+class TestPersonaFullDetailSentinelExpansion:
+    """
+    Tests for sentinel expansion in PersonaFullDetailTableGenerator.generate().
+
+    Beyond description (same contract as PersonaSummaryTableGenerator), the full
+    detail generator also reads responsibilities[] and identificationQuestions[].
+    Both are arrays of strings; each element must be expanded via
+    expand_sentinels_to_text before being passed to format_list.
+
+    The task 2.5.3 hard-fail gate requires UnresolvedSentinelError to propagate
+    from responsibilities and identificationQuestions paths — currently they use
+    bare format_list with no sentinel awareness, so the raises tests are RED.
+    """
+
+    def test_no_lookups_preserves_legacy_passthrough(self):
+        """
+        Baseline: no-kwargs construction passes sentinels through verbatim in all fields.
+
+        Given: PersonaFullDetailTableGenerator() with no lookup kwargs;
+               description, responsibilities, and identificationQuestions each
+               containing sentinel-like text
+        When: generate() is called
+        Then: None of the fields cause an error; sentinel text passes through
+        """
+        gen_cls = _get_persona_full_detail_generator()
+        yaml_data = _make_personas_yaml(
+            _make_persona(
+                description="See {{controlInputValidationAndSanitization}}.",
+                responsibilities=["Use {{controlInputValidationAndSanitization}} on inputs."],
+                identification_questions=["Does {{riskPromptInjection}} apply?"],
+            )
+        )
+        gen = gen_cls()
+        # Should not raise; sentinels pass through verbatim
+        output = gen.generate(yaml_data, "personas")
+        assert "{{controlInputValidationAndSanitization}}" in output
+
+    def test_intra_sentinel_in_description_resolves(self):
+        """
+        Intra sentinel in description expands to plain title for full-detail generator.
+
+        This tests a different code path from PersonaSummaryTableGenerator; both
+        must be wired independently.
+
+        Given: PersonaFullDetailTableGenerator(intra_lookup=..., ref_lookup={})
+               persona description "Use {{controlInputValidationAndSanitization}} here."
+        When: generate() is called
+        Then: Output contains "Input Validation And Sanitization"; sentinel absent
+        """
+        _require_sentinel_module()
+        gen_cls = _get_persona_full_detail_generator()
+        yaml_data = _make_personas_yaml(
+            _make_persona(description="Use {{controlInputValidationAndSanitization}} here.")
+        )
+        gen = gen_cls(intra_lookup=_INTRA_LOOKUP, ref_lookup={})
+        output = gen.generate(yaml_data, "personas")
+        assert "Input Validation And Sanitization" in output
+        assert "{{controlInputValidationAndSanitization}}" not in output
+
+    def test_ref_sentinel_in_description_resolves(self):
+        """
+        External-reference sentinel in description expands to markdown link.
+
+        Given: PersonaFullDetailTableGenerator(intra_lookup={}, ref_lookup=...)
+               persona description "See {{ref:cwe-89}}."
+        When: generate() is called
+        Then: Output contains [CWE-89: ...](url) and NOT the raw sentinel
+        """
+        _require_sentinel_module()
+        gen_cls = _get_persona_full_detail_generator()
+        yaml_data = _make_personas_yaml(_make_persona(description="See {{ref:cwe-89}}."))
+        gen = gen_cls(intra_lookup={}, ref_lookup=_REF_LOOKUP)
+        output = gen.generate(yaml_data, "personas")
+        assert "[CWE-89: Improper Neutralization of SQL Commands]" in output
+        assert "https://cwe.mitre.org/data/definitions/89.html" in output
+        assert "{{ref:cwe-89}}" not in output
+
+    def test_intra_sentinel_in_responsibilities_resolves(self):
+        """
+        Intra sentinel inside a responsibilities[] string expands to plain title.
+
+        Given: PersonaFullDetailTableGenerator(intra_lookup=..., ref_lookup={})
+               responsibilities=["Use {{controlInputValidationAndSanitization}} on all inputs."]
+        When: generate() is called
+        Then: The Responsibilities column cell in the table output contains
+              "Input Validation And Sanitization" and NOT the raw sentinel
+        """
+        _require_sentinel_module()
+        gen_cls = _get_persona_full_detail_generator()
+        yaml_data = _make_personas_yaml(
+            _make_persona(responsibilities=["Use {{controlInputValidationAndSanitization}} on all inputs."])
+        )
+        gen = gen_cls(intra_lookup=_INTRA_LOOKUP, ref_lookup={})
+        output = gen.generate(yaml_data, "personas")
+        assert "Input Validation And Sanitization" in output
+        assert "{{controlInputValidationAndSanitization}}" not in output
+
+    def test_ref_sentinel_in_responsibilities_resolves(self):
+        """
+        External-reference sentinel inside a responsibilities[] string expands to link.
+
+        Given: PersonaFullDetailTableGenerator(intra_lookup={}, ref_lookup=...)
+               responsibilities=["Comply with {{ref:cwe-89}} classification."]
+        When: generate() is called
+        Then: Output's Responsibilities cell contains the markdown link text
+        """
+        _require_sentinel_module()
+        gen_cls = _get_persona_full_detail_generator()
+        yaml_data = _make_personas_yaml(
+            _make_persona(responsibilities=["Comply with {{ref:cwe-89}} classification."])
+        )
+        gen = gen_cls(intra_lookup={}, ref_lookup=_REF_LOOKUP)
+        output = gen.generate(yaml_data, "personas")
+        assert "[CWE-89: Improper Neutralization of SQL Commands]" in output
+        assert "{{ref:cwe-89}}" not in output
+
+    def test_intra_sentinel_in_identification_questions_resolves(self):
+        """
+        Intra sentinel inside an identificationQuestions[] entry resolves to title.
+
+        Given: PersonaFullDetailTableGenerator(intra_lookup=..., ref_lookup={})
+               identificationQuestions=["Does {{riskPromptInjection}} affect this role?"]
+        When: generate() is called
+        Then: Output contains "Prompt Injection"; raw sentinel absent
+        """
+        _require_sentinel_module()
+        gen_cls = _get_persona_full_detail_generator()
+        yaml_data = _make_personas_yaml(
+            _make_persona(identification_questions=["Does {{riskPromptInjection}} affect this role?"])
+        )
+        gen = gen_cls(intra_lookup=_INTRA_LOOKUP, ref_lookup={})
+        output = gen.generate(yaml_data, "personas")
+        assert "Prompt Injection" in output
+        assert "{{riskPromptInjection}}" not in output
+
+    def test_unresolved_sentinel_in_responsibilities_raises(self):
+        """
+        CRITICAL task 2.5.3 gate: UnresolvedSentinelError propagates from
+        the responsibilities path (currently uses bare format_list — no expansion).
+
+        Given: PersonaFullDetailTableGenerator(intra_lookup={}, ref_lookup={})
+               responsibilities=["Apply {{controlBogusTypo}} everywhere."]
+               (no matching id in intra_lookup)
+        When: generate() is called
+        Then: UnresolvedSentinelError is raised with .sentinel == "{{controlBogusTypo}}"
+
+        Currently FAILS because the responsibilities path uses bare format_list
+        with no sentinel expansion.
+        """
+        _require_sentinel_module()
+        gen_cls = _get_persona_full_detail_generator()
+        yaml_data = _make_personas_yaml(_make_persona(responsibilities=["Apply {{controlBogusTypo}} everywhere."]))
+        gen = gen_cls(intra_lookup={}, ref_lookup={})
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            gen.generate(yaml_data, "personas")
+        assert exc_info.value.sentinel == "{{controlBogusTypo}}"
+
+    def test_unresolved_sentinel_in_identification_questions_raises(self):
+        """
+        CRITICAL task 2.5.3 gate: UnresolvedSentinelError propagates from
+        the identificationQuestions path (currently uses bare format_list — no expansion).
+
+        Given: PersonaFullDetailTableGenerator(intra_lookup={}, ref_lookup={})
+               identificationQuestions=["Does {{riskBadTypo}} apply here?"]
+               (no matching id in intra_lookup)
+        When: generate() is called
+        Then: UnresolvedSentinelError is raised with .sentinel == "{{riskBadTypo}}"
+
+        Currently FAILS because the identificationQuestions path uses bare format_list
+        with no sentinel expansion.
+        """
+        _require_sentinel_module()
+        gen_cls = _get_persona_full_detail_generator()
+        yaml_data = _make_personas_yaml(
+            _make_persona(identification_questions=["Does {{riskBadTypo}} apply here?"])
+        )
+        gen = gen_cls(intra_lookup={}, ref_lookup={})
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            gen.generate(yaml_data, "personas")
+        assert exc_info.value.sentinel == "{{riskBadTypo}}"
+
+    def test_external_references_sub_section_emitted(self):
+        """
+        ## References for {persona-id} sub-section appears after the table.
+
+        Given: PersonaFullDetailTableGenerator(); persona "personaFullWithRefs"
+               with externalReferences=[{cwe entry}]
+        When: generate() is called
+        Then: Output contains "## References for personaFullWithRefs" after the table
+        """
+        gen_cls = _get_persona_full_detail_generator()
+        refs = [{"type": "cwe", "id": "cwe-89", "title": "CWE-89", "url": "https://example.com/cwe-89"}]
+        yaml_data = _make_personas_yaml(_make_persona(pid="personaFullWithRefs", external_references=refs))
+        gen = gen_cls()
+        output = gen.generate(yaml_data, "personas")
+
+        assert "## References for personaFullWithRefs" in output
+        table_end_idx = output.rfind("|")
+        refs_idx = output.index("## References for personaFullWithRefs")
+        assert refs_idx > table_end_idx, (
+            f"## References section (pos {refs_idx}) must appear after the last table pipe (pos {table_end_idx})"
+        )
+
+    def test_no_external_references_no_sub_section(self):
+        """
+        No ## References for header when persona has no externalReferences field.
+
+        Given: PersonaFullDetailTableGenerator(); persona with no externalReferences key
+        When: generate() is called
+        Then: "## References for" does NOT appear anywhere in the output
+        """
+        gen_cls = _get_persona_full_detail_generator()
+        yaml_data = _make_personas_yaml(_make_persona(pid="personaFullNoRefs"))
+        gen = gen_cls()
+        output = gen.generate(yaml_data, "personas")
+        assert "## References for" not in output
+
+    def test_field_path_in_unresolved_error_is_informative(self):
+        """
+        field_path in UnresolvedSentinelError identifies the offending location.
+
+        Three sub-cases:
+        A. Typo in description → field_path contains "personas" and "description"
+        B. Typo in responsibilities[1] → field_path contains "personas" and
+           "responsibilities" with a positional index
+        C. Typo in identificationQuestions[0] → field_path contains "personas" and
+           "identificationQuestions" with a positional index
+
+        Given: PersonaFullDetailTableGenerator(intra_lookup={}, ref_lookup={})
+        When: generate() raises UnresolvedSentinelError
+        Then: exc.field_path is non-empty and contains the field name for all three paths
+        """
+        _require_sentinel_module()
+        gen_cls = _get_persona_full_detail_generator()
+
+        # Sub-case A: description
+        yaml_data_a = _make_personas_yaml(_make_persona(description="Bad {{controlTypoInDesc}} here."))
+        gen_a = gen_cls(intra_lookup={}, ref_lookup={})
+        with pytest.raises(UnresolvedSentinelError) as exc_a:
+            gen_a.generate(yaml_data_a, "personas")
+        assert exc_a.value.field_path, "field_path must be non-empty for description error"
+        assert "personas" in exc_a.value.field_path
+        assert "description" in exc_a.value.field_path
+
+        # Sub-case B: responsibilities (second item, index 1)
+        yaml_data_b = _make_personas_yaml(
+            _make_persona(
+                responsibilities=[
+                    "First responsibility (clean).",
+                    "Second has {{controlTypoInResp}} typo.",
+                ]
+            )
+        )
+        gen_b = gen_cls(intra_lookup={}, ref_lookup={})
+        with pytest.raises(UnresolvedSentinelError) as exc_b:
+            gen_b.generate(yaml_data_b, "personas")
+        assert exc_b.value.field_path, "field_path must be non-empty for responsibilities error"
+        assert "personas" in exc_b.value.field_path
+        assert "responsibilities" in exc_b.value.field_path
+
+        # Sub-case C: identificationQuestions (first item, index 0)
+        yaml_data_c = _make_personas_yaml(
+            _make_persona(identification_questions=["Does {{riskTypoInIdQ}} apply?"])
+        )
+        gen_c = gen_cls(intra_lookup={}, ref_lookup={})
+        with pytest.raises(UnresolvedSentinelError) as exc_c:
+            gen_c.generate(yaml_data_c, "personas")
+        assert exc_c.value.field_path, "field_path must be non-empty for identificationQuestions error"
+        assert "personas" in exc_c.value.field_path
+        assert "identificationQuestions" in exc_c.value.field_path
+
+
+# ============================================================================
+# TestPersonaFieldPathFormat
+# ============================================================================
+
+
+class TestPersonaFieldPathFormat:
+    """
+    Contracts on the exact shape of field_path strings emitted by both persona
+    generators.
+
+    These tests assert that:
+    - description errors reference "personas[N]" and "description" where N is
+      the zero-based row index.
+    - responsibilities errors reference "personas[N]" and "responsibilities[M]"
+      where M is the zero-based item index.
+    """
+
+    def test_field_path_for_description_uses_personas_index(self):
+        """
+        Typo in persona[2]'s description → field_path contains "personas[2]" and "description".
+
+        Given: PersonaFullDetailTableGenerator(intra_lookup={}, ref_lookup={})
+               three personas; the third (index 2) has {{controlTypoDesc}} in description
+        When: generate() raises UnresolvedSentinelError
+        Then: exc.field_path contains "personas[2]" and "description"
+
+        Note: A7's commit-2 generators emit field_path against the input
+        (insertion-order) index, not the sorted-by-id index. This fixture's
+        ids are pre-sorted so the assertion is robust to either contract,
+        but the SWE should match the established insertion-order convention.
+        """
+        _require_sentinel_module()
+        gen_cls = _get_persona_full_detail_generator()
+
+        # Use alphabetically ordered ids so sorted position is predictable:
+        # personaA → index 0, personaB → index 1, personaC → index 2
+        yaml_data = _make_personas_yaml(
+            _make_persona(pid="personaA", description="Clean description for A."),
+            _make_persona(pid="personaB", description="Clean description for B."),
+            _make_persona(pid="personaC", description="Has {{controlTypoDesc}} at index 2."),
+        )
+        gen = gen_cls(intra_lookup={}, ref_lookup={})
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            gen.generate(yaml_data, "personas")
+        exc = exc_info.value
+        assert exc.field_path, "field_path must be non-empty"
+        assert "personas[2]" in exc.field_path, (
+            f"Expected 'personas[2]' in field_path for third persona's description; got: {exc.field_path!r}"
+        )
+        assert "description" in exc.field_path
+
+    def test_field_path_for_responsibilities_includes_item_index(self):
+        """
+        Typo in persona[0].responsibilities[3] → field_path contains "personas[0]"
+        and "responsibilities[3]".
+
+        Given: PersonaFullDetailTableGenerator(intra_lookup={}, ref_lookup={})
+               single persona (index 0) with 4 responsibilities; only the fourth
+               (index 3) contains {{controlTypoResp}}
+        When: generate() raises UnresolvedSentinelError
+        Then: exc.field_path contains "personas[0]" and "responsibilities[3]"
+        """
+        _require_sentinel_module()
+        gen_cls = _get_persona_full_detail_generator()
+        yaml_data = _make_personas_yaml(
+            _make_persona(
+                pid="personaOnlyOne",
+                responsibilities=[
+                    "First clean responsibility.",
+                    "Second clean responsibility.",
+                    "Third clean responsibility.",
+                    "Fourth has {{controlTypoResp}} typo.",
+                ],
+            )
+        )
+        gen = gen_cls(intra_lookup={}, ref_lookup={})
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            gen.generate(yaml_data, "personas")
+        exc = exc_info.value
+        assert exc.field_path, "field_path must be non-empty"
+        assert "personas[0]" in exc.field_path, f"Expected 'personas[0]' in field_path; got: {exc.field_path!r}"
+        assert "responsibilities[3]" in exc.field_path, (
+            f"Expected 'responsibilities[3]' in field_path; got: {exc.field_path!r}"
+        )
+
+
+# ============================================================================
+# TestPersonaSentinelBackwardCompat
+# ============================================================================
+
+
+class TestPersonaSentinelBackwardCompat:
+    """
+    Backward-compatibility guard using the live corpus.
+
+    The current personas.yaml contains no sentinel spans (zero {{...}} markers
+    in prose fields). Both persona generators must produce identical output
+    whether or not lookups are supplied — the no-kwargs path must not regress
+    when the same data flows through the post-A7 code.
+
+    This test proves that Phase B B2 (corpus migration) has nothing to flip
+    until actual sentinels are added to the live YAML.
+    """
+
+    def test_existing_persona_yaml_unchanged(self):
+        """
+        Live personas.yaml produces identical output with and without lookup kwargs.
+
+        Given: The live risk-map/yaml/personas.yaml loaded from disk (has zero sentinels)
+        When: Both PersonaSummaryTableGenerator and PersonaFullDetailTableGenerator
+              are called once with no kwargs and once with non-None lookups
+        Then: The no-kwargs output and the with-lookup output are identical for each
+              generator — no regression from A7 wiring
+
+        Path is relative to REPO_ROOT; the test skips if the file does not exist
+        (CI running outside the full repo checkout).
+        """
+        import yaml as _yaml
+
+        personas_path = REPO_ROOT / "risk-map" / "yaml" / "personas.yaml"
+        if not personas_path.exists():
+            pytest.skip(f"Live personas.yaml not found at {personas_path}; skipping corpus test")
+
+        with open(personas_path, encoding="utf-8") as fh:
+            yaml_data = _yaml.safe_load(fh)
+
+        # PersonaSummaryTableGenerator
+        sum_cls = _get_persona_summary_generator()
+        gen_sum_no_lookup = sum_cls()
+        gen_sum_with_lookup = sum_cls(intra_lookup=_INTRA_LOOKUP, ref_lookup=_REF_LOOKUP)
+
+        out_sum_no = gen_sum_no_lookup.generate(yaml_data, "personas")
+        out_sum_with = gen_sum_with_lookup.generate(yaml_data, "personas")
+        assert out_sum_no == out_sum_with, (
+            "PersonaSummaryTableGenerator output must be identical for no-lookup vs lookup "
+            "when the corpus contains no sentinels"
+        )
+
+        # PersonaFullDetailTableGenerator
+        full_cls = _get_persona_full_detail_generator()
+        gen_full_no_lookup = full_cls()
+        gen_full_with_lookup = full_cls(intra_lookup=_INTRA_LOOKUP, ref_lookup=_REF_LOOKUP)
+
+        out_full_no = gen_full_no_lookup.generate(yaml_data, "personas")
+        out_full_with = gen_full_with_lookup.generate(yaml_data, "personas")
+        assert out_full_no == out_full_with, (
+            "PersonaFullDetailTableGenerator output must be identical for no-lookup vs lookup "
+            "when the corpus contains no sentinels"
+        )
+
+
+# ============================================================================
+# Test Summary
+# ============================================================================
+"""
+Test Summary
+============
+Total tests: 26
+
+TestPersonaSummarySentinelExpansion (8):
+  test_no_lookups_preserves_legacy_passthrough
+  test_intra_sentinel_in_description_resolves
+  test_ref_sentinel_in_description_resolves
+  test_unresolved_intra_sentinel_raises
+  test_unresolved_ref_sentinel_raises
+  test_external_references_sub_section_emitted
+  test_no_external_references_no_sub_section
+  test_multiple_personas_each_get_their_own_section
+
+TestPersonaFullDetailSentinelExpansion (11):
+  test_no_lookups_preserves_legacy_passthrough
+  test_intra_sentinel_in_description_resolves
+  test_ref_sentinel_in_description_resolves
+  test_intra_sentinel_in_responsibilities_resolves
+  test_ref_sentinel_in_responsibilities_resolves
+  test_intra_sentinel_in_identification_questions_resolves
+  test_unresolved_sentinel_in_responsibilities_raises           ← task 2.5.3 RED
+  test_unresolved_sentinel_in_identification_questions_raises   ← task 2.5.3 RED
+  test_external_references_sub_section_emitted
+  test_no_external_references_no_sub_section
+  test_field_path_in_unresolved_error_is_informative
+
+TestPersonaFieldPathFormat (2):
+  test_field_path_for_description_uses_personas_index
+  test_field_path_for_responsibilities_includes_item_index
+
+TestPersonaSentinelBackwardCompat (1):
+  test_existing_persona_yaml_unchanged
+
+Coverage target: 90%+ on the A7 persona wiring in yaml_to_markdown.py
+
+Key contracts pinned:
+  - PersonaSummaryTableGenerator: collapse_column called with intra_lookup/ref_lookup for description
+  - PersonaFullDetailTableGenerator: collapse_column for description; per-item
+    expand_sentinels_to_text for responsibilities[] and identificationQuestions[]
+  - Both generators emit ## References for {persona-id} sub-sections
+  - field_path format: personas[N].description, personas[N].responsibilities[M],
+    personas[N].identificationQuestions[M]
+  - UnresolvedSentinelError propagates from all three field paths (never swallowed)
+"""

--- a/scripts/hooks/tests/test_yaml_to_markdown_persona_sentinel_expansion.py
+++ b/scripts/hooks/tests/test_yaml_to_markdown_persona_sentinel_expansion.py
@@ -340,8 +340,8 @@ class TestPersonaFullDetailSentinelExpansion:
     expand_sentinels_to_text before being passed to format_list.
 
     The task 2.5.3 hard-fail gate requires UnresolvedSentinelError to propagate
-    from responsibilities and identificationQuestions paths — currently they use
-    bare format_list with no sentinel awareness, so the raises tests are RED.
+    from the responsibilities and identificationQuestions paths; this suite
+    pins that propagation contract.
     """
 
     def test_no_lookups_preserves_legacy_passthrough(self):
@@ -467,17 +467,14 @@ class TestPersonaFullDetailSentinelExpansion:
 
     def test_unresolved_sentinel_in_responsibilities_raises(self):
         """
-        CRITICAL task 2.5.3 gate: UnresolvedSentinelError propagates from
-        the responsibilities path (currently uses bare format_list — no expansion).
+        Task 2.5.3 gate: UnresolvedSentinelError propagates from the
+        responsibilities per-item expansion path.
 
         Given: PersonaFullDetailTableGenerator(intra_lookup={}, ref_lookup={})
                responsibilities=["Apply {{controlBogusTypo}} everywhere."]
                (no matching id in intra_lookup)
         When: generate() is called
         Then: UnresolvedSentinelError is raised with .sentinel == "{{controlBogusTypo}}"
-
-        Currently FAILS because the responsibilities path uses bare format_list
-        with no sentinel expansion.
         """
         _require_sentinel_module()
         gen_cls = _get_persona_full_detail_generator()
@@ -489,17 +486,14 @@ class TestPersonaFullDetailSentinelExpansion:
 
     def test_unresolved_sentinel_in_identification_questions_raises(self):
         """
-        CRITICAL task 2.5.3 gate: UnresolvedSentinelError propagates from
-        the identificationQuestions path (currently uses bare format_list — no expansion).
+        Task 2.5.3 gate: UnresolvedSentinelError propagates from the
+        identificationQuestions per-item expansion path.
 
         Given: PersonaFullDetailTableGenerator(intra_lookup={}, ref_lookup={})
                identificationQuestions=["Does {{riskBadTypo}} apply here?"]
                (no matching id in intra_lookup)
         When: generate() is called
         Then: UnresolvedSentinelError is raised with .sentinel == "{{riskBadTypo}}"
-
-        Currently FAILS because the identificationQuestions path uses bare format_list
-        with no sentinel expansion.
         """
         _require_sentinel_module()
         gen_cls = _get_persona_full_detail_generator()
@@ -759,7 +753,7 @@ class TestPersonaSentinelBackwardCompat:
 """
 Test Summary
 ============
-Total tests: 26
+Total tests: 22
 
 TestPersonaSummarySentinelExpansion (8):
   test_no_lookups_preserves_legacy_passthrough
@@ -778,8 +772,8 @@ TestPersonaFullDetailSentinelExpansion (11):
   test_intra_sentinel_in_responsibilities_resolves
   test_ref_sentinel_in_responsibilities_resolves
   test_intra_sentinel_in_identification_questions_resolves
-  test_unresolved_sentinel_in_responsibilities_raises           ← task 2.5.3 RED
-  test_unresolved_sentinel_in_identification_questions_raises   ← task 2.5.3 RED
+  test_unresolved_sentinel_in_responsibilities_raises           (task 2.5.3 gate)
+  test_unresolved_sentinel_in_identification_questions_raises   (task 2.5.3 gate)
   test_external_references_sub_section_emitted
   test_no_external_references_no_sub_section
   test_field_path_in_unresolved_error_is_informative

--- a/scripts/hooks/tests/test_yaml_to_markdown_persona_sentinel_expansion.py
+++ b/scripts/hooks/tests/test_yaml_to_markdown_persona_sentinel_expansion.py
@@ -748,6 +748,321 @@ class TestPersonaSentinelBackwardCompat:
 
 
 # ============================================================================
+# TestPersonaPerEntryRefLookupCollision  (RED — ADR-016 D6 per-entry scope)
+# ============================================================================
+
+
+def _write_sibling_yamls_for_personas(directory: Path) -> None:
+    """Write minimal sibling YAML files so yaml_to_markdown_table's intra_lookup build succeeds.
+
+    yaml_to_markdown_table scans all four corpus files to populate intra_lookup.
+    The persona collision tests use a synthesised personas.yaml; the others are stubs.
+    """
+    import yaml as _yaml
+
+    (directory / "risks.yaml").write_text(_yaml.dump({"risks": []}), encoding="utf-8")
+    (directory / "controls.yaml").write_text(_yaml.dump({"controls": []}), encoding="utf-8")
+    (directory / "components.yaml").write_text(_yaml.dump({"components": []}), encoding="utf-8")
+
+
+class TestPersonaPerEntryRefLookupCollision:
+    """
+    RED-phase tests for ADR-016 D6 rule 3 on the persona path.
+
+    The same flat last-write-wins ref_lookup bug that affects risks/controls also
+    affects PersonaSummaryTableGenerator and PersonaFullDetailTableGenerator because
+    yaml_to_markdown_table builds ONE ref_lookup for the whole file at lines 1051-1063
+    and passes it to every generator.
+
+    A3 — PersonaSummaryTableGenerator collision:
+      Two personas share externalReferences[].id = "shared" with different
+      titles/urls.  Post-fix: each persona's {{ref:shared}} resolves to its own
+      ref.  RED: both resolve to the last-loaded title.
+
+    A4 — PersonaFullDetailTableGenerator collision (all three expansion sites):
+      Same two personas.  Post-fix: description, responsibilities[], AND
+      identificationQuestions[] each resolve {{ref:shared}} to the persona's own
+      ref, not the sibling's.  RED: all three fields of both personas collapse to
+      the last-loaded title.
+
+    B2 — cross-entry unresolved (persona path):
+      persona-A's description contains {{ref:cve-2024-99999}}; only persona-B
+      declares that id.  Post-fix: UnresolvedSentinelError raised for persona-A.
+      RED: flat lookup provides the ref from persona-B → no exception.
+    """
+
+    # Minimal but realistic identificationQuestions — 2 entries to keep fixtures small.
+    _IQ_CLEAN = ["Does this role manage model training?", "Do they define data pipelines?"]
+
+    def test_a3_persona_summary_collision_each_entry_resolves_own_ref(self, tmp_path: Path):
+        """
+        A3: PersonaSummaryTableGenerator via yaml_to_markdown_table resolves
+        {{ref:shared}} to each persona's own ref metadata (summary format).
+
+        Given: personas.yaml with two personas:
+               - personaAlpha: externalReferences [{id:"shared", title:"REF-A Title", url:".../A"}]
+                               description: "Alpha uses {{ref:shared}} standard."
+               - personaBeta:  externalReferences [{id:"shared", title:"REF-B Title", url:".../B"}]
+                               description: "Beta follows {{ref:shared}} guidance."
+        When: yaml_to_markdown_table(personas_yaml, "personas", table_format="summary")
+        Then: (post-fix contract)
+              - personaAlpha's row contains "REF-A Title" and does NOT contain "REF-B Title"
+              - personaBeta's row contains "REF-B Title" and does NOT contain "REF-A Title"
+
+        RED failure (HEAD ebe4504):
+              The flat lookup resolves both to "REF-B Title" (last loaded).
+              The assertion "personaAlpha region contains REF-A Title" fails.
+        """
+        _require_sentinel_module()
+        import yaml as _yaml
+
+        personas_data = {
+            "personas": [
+                {
+                    "id": "personaAlpha",
+                    "title": "Alpha Persona",
+                    "description": "Alpha uses {{ref:shared}} standard.",
+                    "deprecated": False,
+                    "responsibilities": [],
+                    "identificationQuestions": self._IQ_CLEAN,
+                    "mappings": {},
+                    "externalReferences": [
+                        {
+                            "id": "shared",
+                            "type": "spec",
+                            "title": "REF-A Title",
+                            "url": "https://example.com/A",
+                        }
+                    ],
+                },
+                {
+                    "id": "personaBeta",
+                    "title": "Beta Persona",
+                    "description": "Beta follows {{ref:shared}} guidance.",
+                    "deprecated": False,
+                    "responsibilities": [],
+                    "identificationQuestions": self._IQ_CLEAN,
+                    "mappings": {},
+                    "externalReferences": [
+                        {
+                            "id": "shared",
+                            "type": "spec",
+                            "title": "REF-B Title",
+                            "url": "https://example.com/B",
+                        }
+                    ],
+                },
+            ]
+        }
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text(_yaml.dump(personas_data), encoding="utf-8")
+        _write_sibling_yamls_for_personas(tmp_path)
+
+        output = _ytm.yaml_to_markdown_table(personas_file, "personas", table_format="summary")
+
+        # Bound row isolation to the table portion only (References sections
+        # come after the table and would sweep both entries' titles).
+        table_end = output.find("## References for")
+        table = output if table_end == -1 else output[:table_end]
+        alpha_idx = table.find("personaAlpha")
+        beta_idx = table.find("personaBeta")
+        assert alpha_idx != -1, "personaAlpha not found in table"
+        assert beta_idx != -1, "personaBeta not found in table"
+
+        # personaAlpha sorts before personaBeta alphabetically.
+        alpha_region = table[alpha_idx:beta_idx]
+        beta_region = table[beta_idx:]
+
+        assert "REF-A Title" in alpha_region, (
+            f"personaAlpha must resolve {{{{ref:shared}}}} to its own 'REF-A Title'; "
+            f"alpha_region:\n{alpha_region!r}"
+        )
+        assert "REF-B Title" not in alpha_region, (
+            "personaAlpha must NOT contain 'REF-B Title' (cross-entry collision)"
+        )
+        assert "REF-B Title" in beta_region, (
+            f"personaBeta must resolve {{{{ref:shared}}}} to its own 'REF-B Title'; beta_region:\n{beta_region!r}"
+        )
+        assert "REF-A Title" not in beta_region, (
+            "personaBeta must NOT contain 'REF-A Title' (cross-entry collision)"
+        )
+
+    def test_a4_persona_full_detail_collision_all_three_fields(self, tmp_path: Path):
+        """
+        A4: PersonaFullDetailTableGenerator via yaml_to_markdown_table resolves
+        {{ref:shared}} correctly in description, responsibilities[], AND
+        identificationQuestions[] for each persona.
+
+        Given: personas.yaml with two personas, each declaring externalReferences
+               [{id:"shared", title:"REF-A Title"|"REF-B Title", url:".../A"|".../B"}].
+               personaAlpha:
+                 - description: "Alpha description cites {{ref:shared}}."
+                 - responsibilities: ["Alpha must apply {{ref:shared}} controls."]
+                 - identificationQuestions: ["Does {{ref:shared}} apply to alpha?", "Q2"]
+               personaBeta:
+                 - description: "Beta description cites {{ref:shared}}."
+                 - responsibilities: ["Beta should follow {{ref:shared}} guidance."]
+                 - identificationQuestions: ["Is {{ref:shared}} relevant to beta?", "Q2"]
+        When: yaml_to_markdown_table(personas_yaml, "personas", table_format="full")
+        Then: (post-fix contract) For every sentinel site in both personas:
+              - personaAlpha's expanded output contains "REF-A Title" (its own ref)
+              - personaBeta's expanded output contains "REF-B Title" (its own ref)
+              Neither persona's region contains the OTHER persona's ref title.
+
+        RED failure (HEAD ebe4504):
+              All six sentinel sites (3 per persona × 2 personas) resolve to the
+              last-loaded title.  The per-entry assertion fails.
+        """
+        _require_sentinel_module()
+        import yaml as _yaml
+
+        personas_data = {
+            "personas": [
+                {
+                    "id": "personaAlpha",
+                    "title": "Alpha Persona",
+                    "description": "Alpha description cites {{ref:shared}}.",
+                    "deprecated": False,
+                    "responsibilities": ["Alpha must apply {{ref:shared}} controls."],
+                    "identificationQuestions": [
+                        "Does {{ref:shared}} apply to alpha?",
+                        "Second plain question for alpha.",
+                    ],
+                    "mappings": {},
+                    "externalReferences": [
+                        {
+                            "id": "shared",
+                            "type": "spec",
+                            "title": "REF-A Title",
+                            "url": "https://example.com/A",
+                        }
+                    ],
+                },
+                {
+                    "id": "personaBeta",
+                    "title": "Beta Persona",
+                    "description": "Beta description cites {{ref:shared}}.",
+                    "deprecated": False,
+                    "responsibilities": ["Beta should follow {{ref:shared}} guidance."],
+                    "identificationQuestions": [
+                        "Is {{ref:shared}} relevant to beta?",
+                        "Second plain question for beta.",
+                    ],
+                    "mappings": {},
+                    "externalReferences": [
+                        {
+                            "id": "shared",
+                            "type": "spec",
+                            "title": "REF-B Title",
+                            "url": "https://example.com/B",
+                        }
+                    ],
+                },
+            ]
+        }
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text(_yaml.dump(personas_data), encoding="utf-8")
+        _write_sibling_yamls_for_personas(tmp_path)
+
+        output = _ytm.yaml_to_markdown_table(personas_file, "personas", table_format="full")
+
+        # Bound row isolation to the table portion only (References sections
+        # come after the table and would sweep both entries' titles).
+        table_end = output.find("## References for")
+        table = output if table_end == -1 else output[:table_end]
+        alpha_idx = table.find("personaAlpha")
+        beta_idx = table.find("personaBeta")
+        assert alpha_idx != -1, "personaAlpha not found in table"
+        assert beta_idx != -1, "personaBeta not found in table"
+
+        # personaAlpha sorts before personaBeta alphabetically.
+        alpha_region = table[alpha_idx:beta_idx]
+        beta_region = table[beta_idx:]
+
+        # All three expansion sites for personaAlpha must use REF-A Title.
+        assert "REF-A Title" in alpha_region, (
+            f"personaAlpha (all fields) must resolve to 'REF-A Title'; alpha_region:\n{alpha_region!r}"
+        )
+        assert "REF-B Title" not in alpha_region, (
+            "personaAlpha region must NOT contain 'REF-B Title' (cross-entry collision in any field)"
+        )
+        # All three expansion sites for personaBeta must use REF-B Title.
+        assert "REF-B Title" in beta_region, (
+            f"personaBeta (all fields) must resolve to 'REF-B Title'; beta_region:\n{beta_region!r}"
+        )
+        assert "REF-A Title" not in beta_region, (
+            "personaBeta region must NOT contain 'REF-A Title' (cross-entry collision in any field)"
+        )
+
+    def test_b2_persona_cross_entry_ref_id_raises_unresolved_error(self, tmp_path: Path):
+        """
+        B2: A {{ref:id}} in persona-A's description that is declared only in persona-B's
+        externalReferences must raise UnresolvedSentinelError after the fix (persona path).
+
+        Given: personas.yaml with two personas:
+               - personaAlpha: externalReferences=[]  (declares NO refs)
+                               description: "Alpha needs {{ref:cve-2024-99999}} context."
+               - personaBeta:  externalReferences=[{id:"cve-2024-99999", ...}]
+                               description: (no sentinel)
+        When: yaml_to_markdown_table(personas_yaml, "personas", table_format="full")
+        Then: (post-fix contract)
+              UnresolvedSentinelError is raised for personaAlpha's sentinel because
+              "cve-2024-99999" is not in personaAlpha's own externalReferences.
+
+        RED failure (HEAD ebe4504):
+              The flat lookup contains "cve-2024-99999" from personaBeta, so the
+              sentinel resolves and no exception is raised.
+        """
+        _require_sentinel_module()
+        import yaml as _yaml
+
+        personas_data = {
+            "personas": [
+                {
+                    "id": "personaAlpha",
+                    "title": "Alpha Persona",
+                    "description": "Alpha needs {{ref:cve-2024-99999}} context.",
+                    "deprecated": False,
+                    "responsibilities": [],
+                    "identificationQuestions": self._IQ_CLEAN,
+                    "mappings": {},
+                    "externalReferences": [],  # personaAlpha owns no refs
+                },
+                {
+                    "id": "personaBeta",
+                    "title": "Beta Persona",
+                    "description": "Beta plain description.",
+                    "deprecated": False,
+                    "responsibilities": [],
+                    "identificationQuestions": self._IQ_CLEAN,
+                    "mappings": {},
+                    "externalReferences": [
+                        {
+                            "id": "cve-2024-99999",
+                            "type": "cve",
+                            "title": "CVE-2024-99999 Title",
+                            "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-99999",
+                        }
+                    ],
+                },
+            ]
+        }
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text(_yaml.dump(personas_data), encoding="utf-8")
+        _write_sibling_yamls_for_personas(tmp_path)
+
+        # Post-fix: personaAlpha's {{ref:cve-2024-99999}} must raise because
+        # that id is not declared in personaAlpha's own externalReferences.
+        # RED: flat lookup resolves it via personaBeta → no exception raised.
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            _ytm.yaml_to_markdown_table(personas_file, "personas", table_format="full")
+
+        assert "cve-2024-99999" in str(exc_info.value), (
+            f"Error must identify the unresolved ref id; got: {exc_info.value!r}"
+        )
+
+
+# ============================================================================
 # Test Summary
 # ============================================================================
 """

--- a/scripts/hooks/tests/test_yaml_to_markdown_sentinel_expansion.py
+++ b/scripts/hooks/tests/test_yaml_to_markdown_sentinel_expansion.py
@@ -65,9 +65,10 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT))
 
 # ---------------------------------------------------------------------------
-# Guarded imports — RED phase: wiring and new helpers do not exist yet.
-# Both import blocks use guarded patterns so individual tests fail with
-# informative messages rather than a module-level collection error.
+# Decoupled imports: if the sentinel helper or new yaml_to_markdown symbols
+# fail to import (e.g. dependency drift), tests fail individually with clear
+# messages rather than producing a collection-time error. Mirrors the A3
+# pattern in test_prose_tokens.py.
 # ---------------------------------------------------------------------------
 
 _SENTINEL_MODULE_ERROR: ImportError | None = None

--- a/scripts/hooks/tests/test_yaml_to_markdown_sentinel_expansion.py
+++ b/scripts/hooks/tests/test_yaml_to_markdown_sentinel_expansion.py
@@ -1,0 +1,1519 @@
+#!/usr/bin/env python3
+"""
+Tests for A7 sentinel expansion in scripts/hooks/yaml_to_markdown.py
+
+Covers task 2.5.1 (collapse_column sentinel wiring) and task 2.5.3
+(hard-fail on unresolved sentinel) for the markdown-generator side.
+
+Contracts pinned by this test suite:
+
+collapse_column wiring:
+  - Gains keyword-only arguments `intra_lookup=None` and `ref_lookup=None`.
+    When both are None (the default), sentinels pass through unchanged so
+    pre-A7 call sites keep working until the table generators are wired up.
+  - When lookups are supplied, sentinels are expanded via
+    expand_sentinels_to_text: intra → plain title, ref → [title](url) link.
+  - An unresolved sentinel raises UnresolvedSentinelError (never swallowed).
+
+format_external_references helper:
+  - New public function on yaml_to_markdown module.
+  - Accepts a list of dicts (the externalReferences array from YAML) or None.
+  - Returns a markdown sub-section string:
+      ## References\n- [title](url) (type)\n...
+    or "" when refs are empty/None.
+
+## References emission in table generators:
+  - FullDetailTableGenerator.generate() and SummaryTableGenerator.generate()
+    each accept optional `intra_lookup` and `ref_lookup` constructor parameters
+    (or keyword arguments); these are forwarded to collapse_column.
+  - After the main markdown table, each entry that has a non-empty
+    externalReferences list gets a sub-section header:
+      ## References for {entry-id}
+    followed by one bullet per reference in source order.
+  - XRef generators (RiskXRefTableGenerator, ComponentXRefTableGenerator,
+    FlatRiskXRefTableGenerator, FlatComponentXRefTableGenerator) do NOT emit
+    References sub-sections — they operate on structural mapping fields only.
+
+intra_lookup / ref_lookup constructor plumbing:
+  - FullDetailTableGenerator and SummaryTableGenerator each accept an
+    `intra_lookup` and `ref_lookup` keyword argument in their constructors.
+    Both default to None (backward-compatible: no expansion when not supplied).
+  - The table generator does NOT auto-load the corpus files internally;
+    callers (yaml_to_markdown_table / convert_type) are responsible for
+    supplying lookups. This keeps the generator classes unit-testable with
+    pure synthesized data.
+
+Wire-format sentinels used in fixtures (real tokenizer form, NOT ADR meta):
+  - {{riskPromptInjection}}                          intra
+  - {{controlInputValidationAndSanitization}}        intra
+  - {{componentModelServing}}                        intra
+  - {{personaModelCreator}}                          intra
+  - {{ref:cwe-89}}                                   external
+  - {{ref:zhou-2023-poisoning}}                      external
+
+Do NOT use {{idRiskFoo}} — that is ADR-016 meta-notation, not wire format.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+# ---------------------------------------------------------------------------
+# Guarded imports — RED phase: wiring and new helpers do not exist yet.
+# Both import blocks use guarded patterns so individual tests fail with
+# informative messages rather than a module-level collection error.
+# ---------------------------------------------------------------------------
+
+_SENTINEL_MODULE_ERROR: ImportError | None = None
+try:
+    from scripts.hooks._sentinel_expansion import UnresolvedSentinelError  # noqa: E402
+except ImportError as _e:
+    _SENTINEL_MODULE_ERROR = _e
+    UnresolvedSentinelError = None  # type: ignore[assignment,misc]
+
+# yaml_to_markdown itself exists pre-A7, so this import should succeed now;
+# the individual symbol lookups below fail at test-call time, not at collection.
+import scripts.hooks.yaml_to_markdown as _ytm  # noqa: E402
+
+
+def _require_sentinel_module() -> None:
+    """Fail clearly if the sentinel helper is not importable."""
+    if _SENTINEL_MODULE_ERROR is not None:
+        pytest.fail(f"scripts/hooks/_sentinel_expansion.py is not importable: {_SENTINEL_MODULE_ERROR}")
+
+
+def _get_collapse_column():
+    """Return collapse_column; fails if the A7 keyword args are not present."""
+    fn = getattr(_ytm, "collapse_column", None)
+    if fn is None:
+        pytest.fail("yaml_to_markdown.collapse_column is not defined")
+    return fn
+
+
+def _get_format_external_references():
+    """Return format_external_references; fails if function does not exist yet."""
+    fn = getattr(_ytm, "format_external_references", None)
+    if fn is None:
+        pytest.fail(
+            "yaml_to_markdown.format_external_references does not exist — "
+            "SWE must add this public helper (task 2.5.1)"
+        )
+    return fn
+
+
+def _get_full_detail_generator():
+    return getattr(_ytm, "FullDetailTableGenerator")
+
+
+def _get_summary_generator():
+    return getattr(_ytm, "SummaryTableGenerator")
+
+
+# ---------------------------------------------------------------------------
+# Shared test fixtures / inline data
+# ---------------------------------------------------------------------------
+
+# Synthetic lookups used by direct collapse_column / helper tests.
+_INTRA_LOOKUP = {
+    "riskPromptInjection": "Prompt Injection",
+    "controlInputValidationAndSanitization": "Input Validation And Sanitization",
+    "componentModelServing": "Model Serving Infrastructure",
+    "personaModelCreator": "Model Creator",
+}
+
+_REF_LOOKUP = {
+    "cwe-89": {
+        "title": "CWE-89: Improper Neutralization of SQL Commands",
+        "url": "https://cwe.mitre.org/data/definitions/89.html",
+    },
+    "zhou-2023-poisoning": {
+        "title": "Zhou et al. 2023 - Data Poisoning",
+        "url": "https://example.com/zhou-2023",
+    },
+}
+
+
+def _make_risks_yaml_data(**overrides):
+    """Return minimal risks YAML dict suitable for FullDetailTableGenerator."""
+    base = {
+        "risks": [
+            {
+                "id": "riskTestAlpha",
+                "title": "Alpha Risk",
+                "category": "riskCatTest",
+                "shortDescription": ["Short description of alpha risk."],
+                "longDescription": ["Long description of alpha risk."],
+                "examples": ["Example of alpha risk."],
+                "personas": [],
+                "controls": [],
+            }
+        ]
+    }
+    base.update(overrides)
+    return base
+
+
+# ============================================================================
+# TestCollapseColumnSentinelExpansion
+# ============================================================================
+
+
+class TestCollapseColumnSentinelExpansion:
+    """
+    Direct tests of collapse_column after A7 wiring.
+
+    Contract: collapse_column gains keyword-only `intra_lookup` and `ref_lookup`
+    parameters (both default to None). When None (or not supplied), sentinels are
+    passed through unchanged — preserving backward compat with all pre-A7 call
+    sites. When dicts are supplied, sentinel spans are expanded via
+    expand_sentinels_to_text before the usual newline/dash normalisation.
+    """
+
+    def test_plain_text_passthrough_no_kwargs(self):
+        """
+        Test pre-A7 behavior: plain string returns unchanged when no lookups given.
+
+        Given: A plain prose string with no {{ }} markers and no lookup kwargs
+        When: collapse_column is called with only the entry argument
+        Then: The result contains the original text (newlines become <br>, "- >" stripped)
+        """
+        fn = _get_collapse_column()
+        result = fn("Plain description text.")
+        assert "Plain description text" in result
+        # No crashes, no sentinel artifacts
+        assert "{{" not in result
+
+    def test_string_with_newlines_no_kwargs(self):
+        """
+        Test that newlines are still normalised to <br> with no lookup kwargs.
+
+        Given: A string with embedded newlines and no lookup kwargs
+        When: collapse_column is called
+        Then: Newlines are replaced with <br>; pre-A7 behavior unchanged
+        """
+        fn = _get_collapse_column()
+        result = fn("Line 1\nLine 2")
+        assert "<br>" in result
+        assert "Line 1" in result
+        assert "Line 2" in result
+
+    def test_plain_text_passthrough_with_lookups(self):
+        """
+        Test that plain text (no sentinels) is unaffected even when lookups are provided.
+
+        Given: A plain string with no {{ }} markers and non-None lookup dicts
+        When: collapse_column is called with intra_lookup and ref_lookup
+        Then: The result equals the pre-A7 result for the same input
+        """
+        fn = _get_collapse_column()
+        result = fn("No sentinels here.", intra_lookup=_INTRA_LOOKUP, ref_lookup=_REF_LOOKUP)
+        assert "No sentinels here" in result
+        assert "{{" not in result
+
+    def test_intra_sentinel_resolves_to_plain_title(self):
+        """
+        Test that {{riskPromptInjection}} expands to the entity title as plain text.
+
+        Given: An entry string containing {{riskPromptInjection}} and a matching intra_lookup
+        When: collapse_column is called with intra_lookup and ref_lookup
+        Then: The sentinel span is replaced by "Prompt Injection" (no link markup)
+              and the original sentinel span does not appear in the output
+        """
+        _require_sentinel_module()
+        fn = _get_collapse_column()
+        result = fn(
+            "Relates to {{riskPromptInjection}} category.",
+            intra_lookup=_INTRA_LOOKUP,
+            ref_lookup=_REF_LOOKUP,
+        )
+        assert "Prompt Injection" in result
+        assert "{{riskPromptInjection}}" not in result
+        # Intra sentinels become plain title, not a markdown link
+        assert "[Prompt Injection](" not in result
+
+    def test_ref_sentinel_resolves_to_markdown_link(self):
+        """
+        Test that {{ref:cwe-89}} expands to a [title](url) markdown link.
+
+        Given: An entry string containing {{ref:cwe-89}} and a matching ref_lookup
+        When: collapse_column is called with intra_lookup and ref_lookup
+        Then: The sentinel span is replaced by "[CWE-89: ...](url)" markdown link
+        """
+        _require_sentinel_module()
+        fn = _get_collapse_column()
+        result = fn(
+            "See {{ref:cwe-89}} for the classification.",
+            intra_lookup=_INTRA_LOOKUP,
+            ref_lookup=_REF_LOOKUP,
+        )
+        assert "[CWE-89: Improper Neutralization of SQL Commands]" in result
+        assert "https://cwe.mitre.org/data/definitions/89.html" in result
+        assert "{{ref:cwe-89}}" not in result
+
+    def test_mixed_sentinels_both_expanded(self):
+        """
+        Test that a string with both intra and ref sentinels expands both.
+
+        Given: A string containing {{riskPromptInjection}} and {{ref:cwe-89}}
+        When: collapse_column is called with both lookup dicts
+        Then: Both sentinels are expanded; neither raw sentinel span remains
+        """
+        _require_sentinel_module()
+        fn = _get_collapse_column()
+        result = fn(
+            "{{riskPromptInjection}} is covered by {{ref:cwe-89}}.",
+            intra_lookup=_INTRA_LOOKUP,
+            ref_lookup=_REF_LOOKUP,
+        )
+        assert "Prompt Injection" in result
+        assert "CWE-89" in result
+        assert "{{riskPromptInjection}}" not in result
+        assert "{{ref:cwe-89}}" not in result
+
+    def test_multi_element_list_collapses_and_expands(self):
+        """
+        Test that a list of strings is collapsed and sentinels are expanded.
+
+        Given: A list where one element contains {{componentModelServing}} and
+               lookups are provided
+        When: collapse_column is called with the list and lookup kwargs
+        Then: The collapsed output contains the expanded title and uses <br> separators
+        """
+        _require_sentinel_module()
+        fn = _get_collapse_column()
+        entry = [
+            "First plain item.",
+            "References {{componentModelServing}}.",
+        ]
+        result = fn(entry, intra_lookup=_INTRA_LOOKUP, ref_lookup=_REF_LOOKUP)
+        assert "First plain item" in result
+        assert "Model Serving Infrastructure" in result
+        assert "{{componentModelServing}}" not in result
+        assert "<br>" in result
+
+    def test_none_lookups_leave_sentinels_unchanged(self):
+        """
+        Test that when intra_lookup and ref_lookup are None (default), sentinels
+        are passed through unchanged — they are not resolved and no error is raised.
+
+        Given: An entry string containing {{riskPromptInjection}} and NO lookup kwargs
+        When: collapse_column is called without lookup arguments
+        Then: The raw sentinel span appears verbatim in the output (no resolution)
+              and no exception is raised
+
+        This is the backward-compat contract: pre-A7 callers don't supply lookups
+        so they get sentinel pass-through until the table generators are wired up.
+        """
+        fn = _get_collapse_column()
+        # Must not raise even though the sentinel has no lookup to resolve against.
+        result = fn("Has {{riskPromptInjection}} in it.")
+        # Sentinel passes through unchanged when lookups are None.
+        assert "{{riskPromptInjection}}" in result
+
+    def test_explicit_none_lookups_leave_sentinels_unchanged(self):
+        """
+        Test that passing None explicitly for both lookups leaves sentinels unchanged.
+
+        Given: A string with a sentinel and explicit None for both lookup kwargs
+        When: collapse_column is called with intra_lookup=None, ref_lookup=None
+        Then: The sentinel is NOT expanded and no error is raised
+        """
+        fn = _get_collapse_column()
+        result = fn(
+            "Has {{ref:cwe-89}} in it.",
+            intra_lookup=None,
+            ref_lookup=None,
+        )
+        assert "{{ref:cwe-89}}" in result
+
+    def test_unresolved_intra_sentinel_raises_with_lookups(self):
+        """
+        Test that an unknown intra sentinel raises UnresolvedSentinelError when lookups
+        are provided (not None).
+
+        Given: A string containing {{riskTypoFooBar}} (not in intra_lookup) and
+               non-None lookup dicts
+        When: collapse_column is called
+        Then: UnresolvedSentinelError is raised with .sentinel == "{{riskTypoFooBar}}"
+
+        This is the task 2.5.3 hard-fail gate: collapse_column must never swallow
+        an unresolved sentinel when the caller has opted in by supplying lookups.
+        """
+        _require_sentinel_module()
+        fn = _get_collapse_column()
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            fn(
+                "References {{riskTypoFooBar}} which does not exist.",
+                intra_lookup={"riskOtherRisk": "Other Risk"},
+                ref_lookup={},
+            )
+        assert exc_info.value.sentinel == "{{riskTypoFooBar}}"
+
+    def test_unresolved_ref_sentinel_raises_with_lookups(self):
+        """
+        Test that an unknown ref sentinel raises UnresolvedSentinelError when lookups
+        are provided (not None).
+
+        Given: A string containing {{ref:cve-2024-99999}} with an empty ref_lookup
+        When: collapse_column is called with non-None lookup dicts
+        Then: UnresolvedSentinelError is raised with .sentinel == "{{ref:cve-2024-99999}}"
+        """
+        _require_sentinel_module()
+        fn = _get_collapse_column()
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            fn(
+                "See {{ref:cve-2024-99999}}.",
+                intra_lookup=_INTRA_LOOKUP,
+                ref_lookup={},
+            )
+        assert exc_info.value.sentinel == "{{ref:cve-2024-99999}}"
+
+    def test_field_path_kwarg_accepted(self):
+        """
+        Test that collapse_column accepts an optional field_path kwarg (for error messages).
+
+        Given: A call with a field_path kwarg supplied
+        When: collapse_column is called on plain text
+        Then: No error is raised; the field_path is accepted silently (used only
+              in UnresolvedSentinelError messages if a sentinel fails to resolve)
+        """
+        fn = _get_collapse_column()
+        # Should not raise
+        result = fn(
+            "Plain text.",
+            intra_lookup=_INTRA_LOOKUP,
+            ref_lookup=_REF_LOOKUP,
+            field_path="risks[0].description[0]",
+        )
+        assert "Plain text" in result
+
+    def test_field_path_in_unresolved_error_when_provided(self):
+        """
+        Test that the field_path kwarg is propagated to UnresolvedSentinelError.
+
+        Given: A string with an unknown sentinel and a field_path kwarg
+        When: collapse_column raises UnresolvedSentinelError
+        Then: exc.field_path matches the supplied field_path string
+        """
+        _require_sentinel_module()
+        fn = _get_collapse_column()
+        fp = "risks[3].longDescription[0]"
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            fn(
+                "{{riskBadRef}} is wrong.",
+                intra_lookup={},
+                ref_lookup={},
+                field_path=fp,
+            )
+        assert exc_info.value.field_path == fp
+
+
+# ============================================================================
+# TestFormatExternalReferences
+# ============================================================================
+
+
+class TestFormatExternalReferences:
+    """
+    Direct tests of the new public helper format_external_references(refs) -> str.
+
+    Contracted output format:
+      "## References\\n- [title](url) (type)\\n- [title](url) (type)\\n"
+
+    When refs is empty or None, the function returns "" (empty string, no header).
+    Items are emitted in source order (no sorting).
+
+    Known limitation: title and url are author-controlled (schema-validated) fields.
+    Brackets and parens in titles are not escaped; this is intentional since the
+    content is trusted YAML author input and escaping would corrupt intentional
+    formatting.
+    """
+
+    def test_empty_list_returns_empty_string(self):
+        """
+        Test that an empty list returns "" with no header.
+
+        Given: refs=[]
+        When: format_external_references([])
+        Then: Returns exactly "" — no markdown is emitted
+        """
+        fn = _get_format_external_references()
+        assert fn([]) == ""
+
+    def test_none_returns_empty_string(self):
+        """
+        Test that None input returns "".
+
+        Given: refs=None
+        When: format_external_references(None)
+        Then: Returns exactly ""
+        """
+        fn = _get_format_external_references()
+        assert fn(None) == ""
+
+    def test_single_entry_produces_header_and_one_bullet(self):
+        """
+        Test that a single-entry list produces a header and exactly one bullet.
+
+        Given: refs=[{type: "cwe", title: "CWE-89: SQL Injection", url: "https://..."}]
+        When: format_external_references is called
+        Then: Output starts with "## References" and contains exactly one "- [" bullet
+
+        Output shape pinned:
+          ## References
+          - [CWE-89: SQL Injection](https://cwe.mitre.org/data/definitions/89.html) (cwe)
+        """
+        fn = _get_format_external_references()
+        refs = [
+            {
+                "type": "cwe",
+                "id": "cwe-89",
+                "title": "CWE-89: SQL Injection",
+                "url": "https://cwe.mitre.org/data/definitions/89.html",
+            }
+        ]
+        result = fn(refs)
+        assert result.startswith("## References")
+        assert "- [CWE-89: SQL Injection](https://cwe.mitre.org/data/definitions/89.html)" in result
+        assert "(cwe)" in result
+        # Exactly one bullet
+        assert result.count("- [") == 1
+
+    def test_multiple_entries_in_source_order(self):
+        """
+        Test that multiple entries produce multiple bullets in source order.
+
+        Given: refs with two entries (entry A then entry B)
+        When: format_external_references is called
+        Then: Both bullets appear; entry A's bullet precedes entry B's bullet
+
+        Source-order contract: the function must NOT sort entries.
+        """
+        fn = _get_format_external_references()
+        refs = [
+            {
+                "type": "paper",
+                "id": "zhou-2023-poisoning",
+                "title": "Zhou et al. 2023 - Data Poisoning",
+                "url": "https://example.com/zhou-2023",
+            },
+            {
+                "type": "cwe",
+                "id": "cwe-89",
+                "title": "CWE-89: SQL Injection",
+                "url": "https://cwe.mitre.org/data/definitions/89.html",
+            },
+        ]
+        result = fn(refs)
+        assert result.count("- [") == 2
+        zhou_pos = result.index("Zhou et al.")
+        cwe_pos = result.index("CWE-89:")
+        assert zhou_pos < cwe_pos, "First entry (Zhou) must appear before second entry (CWE-89) in output"
+
+    def test_output_contains_type_annotation(self):
+        """
+        Test that the reference type (e.g. "paper", "cwe") appears in parentheses.
+
+        Given: A ref entry with type="atlas"
+        When: format_external_references is called
+        Then: "(atlas)" appears in the output
+        """
+        fn = _get_format_external_references()
+        refs = [
+            {
+                "type": "atlas",
+                "id": "aml-t0020",
+                "title": "MITRE ATLAS AML.T0020",
+                "url": "https://atlas.mitre.org/techniques/AML.T0020",
+            }
+        ]
+        result = fn(refs)
+        assert "(atlas)" in result
+
+    def test_output_header_is_h2_references(self):
+        """
+        Test that the section header is exactly "## References" (H2, not H1 or H3).
+
+        Given: Any non-empty refs list
+        When: format_external_references is called
+        Then: The output contains "## References" (two hashes, not one or three)
+        """
+        fn = _get_format_external_references()
+        refs = [{"type": "cwe", "id": "cwe-89", "title": "CWE-89", "url": "https://example.com"}]
+        result = fn(refs)
+        assert "## References" in result
+        assert "### References" not in result
+        assert result.count("# References") == 1  # only one header occurrence
+
+    def test_special_chars_in_title_not_escaped(self):
+        """
+        Test that special characters in titles are NOT escaped.
+
+        Given: A ref entry whose title contains angle brackets and ampersands
+        When: format_external_references is called
+        Then: The raw title string appears verbatim in the output
+
+        Known limitation: author-controlled titles are trusted. The schema validates
+        externalReferences[].title as a string but does not restrict characters.
+        Escaping would corrupt intentional formatting (e.g. "<br>" in a title).
+        """
+        fn = _get_format_external_references()
+        refs = [
+            {
+                "type": "spec",
+                "id": "spec-abc",
+                "title": "A & B <spec>",
+                "url": "https://example.com/spec",
+            }
+        ]
+        result = fn(refs)
+        # Title appears verbatim (not HTML-escaped)
+        assert "A & B <spec>" in result
+
+    def test_three_entries_produces_three_bullets(self):
+        """
+        Test that three entries produce three bullets.
+
+        Given: refs list with three entries
+        When: format_external_references is called
+        Then: The output contains exactly three "- [" bullet lines
+        """
+        fn = _get_format_external_references()
+        refs = [
+            {"type": "cwe", "id": f"cwe-{i}", "title": f"CWE-{i}", "url": f"https://example.com/{i}"}
+            for i in range(3)
+        ]
+        result = fn(refs)
+        assert result.count("- [") == 3
+
+
+# ============================================================================
+# TestFullDetailTableSentinelIntegration
+# ============================================================================
+
+
+class TestFullDetailTableSentinelIntegration:
+    """
+    End-to-end tests via FullDetailTableGenerator.generate(yaml_data, ytype).
+
+    The generator accepts optional `intra_lookup` and `ref_lookup` constructor
+    parameters (both default None). When None, sentinels pass through unchanged.
+    When supplied, sentinels are expanded via collapse_column's new keyword args.
+
+    Fixture design: all intra sentinels in YAML data reference ids that are
+    ALSO present in the same synthesized yaml_data dict. This avoids any
+    dependency on the live corpus for cross-file resolution in generator tests.
+    Tests that require cross-file refs test through collapse_column directly
+    (see TestCollapseColumnSentinelExpansion above).
+    """
+
+    def test_no_sentinels_output_unchanged_from_pre_a7(self):
+        """
+        Test that YAML data without any sentinels produces the same output
+        regardless of whether lookups are supplied or omitted.
+
+        Given: YAML data with plain-text prose fields (no {{ }} spans)
+        When: FullDetailTableGenerator.generate is called with and without lookups
+        Then: Both calls succeed and produce identical output — no regression
+
+        This is the no-op guard: A7 wiring must not break any pre-existing output.
+        """
+        gen_cls = _get_full_detail_generator()
+        yaml_data = _make_risks_yaml_data()
+
+        gen_no_lookup = gen_cls()
+        gen_with_lookup = gen_cls(intra_lookup=_INTRA_LOOKUP, ref_lookup=_REF_LOOKUP)
+
+        out_no_lookup = gen_no_lookup.generate(yaml_data, "risks")
+        out_with_lookup = gen_with_lookup.generate(yaml_data, "risks")
+
+        assert out_no_lookup == out_with_lookup
+
+    def test_intra_sentinel_in_description_expanded_in_output(self):
+        """
+        Test that an intra sentinel in a prose field is expanded in the table output
+        when intra_lookup is supplied.
+
+        Given: YAML data where longDescription contains "{{riskPromptInjection}}"
+               and intra_lookup has riskPromptInjection → "Prompt Injection"
+        When: FullDetailTableGenerator.generate is called with that intra_lookup
+        Then: The table output contains "Prompt Injection" and does NOT contain
+              the raw sentinel span "{{riskPromptInjection}}"
+
+        Note: longDescription is in the 'collapsable' set at line 229 of yaml_to_markdown.py.
+        """
+        _require_sentinel_module()
+        gen_cls = _get_full_detail_generator()
+
+        yaml_data = {
+            "risks": [
+                {
+                    "id": "riskPromptInjection",
+                    "title": "Prompt Injection",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short."],
+                    "longDescription": ["See {{riskPromptInjection}} risk category."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                }
+            ]
+        }
+        intra = {"riskPromptInjection": "Prompt Injection"}
+
+        gen = gen_cls(intra_lookup=intra, ref_lookup={})
+        output = gen.generate(yaml_data, "risks")
+
+        assert "Prompt Injection" in output
+        assert "{{riskPromptInjection}}" not in output
+
+    def test_ref_sentinel_in_description_expanded_to_link(self):
+        """
+        Test that a ref sentinel in a prose field is expanded to a markdown link
+        when ref_lookup is supplied.
+
+        Given: YAML data where description contains "{{ref:cwe-89}}" and
+               ref_lookup has cwe-89 → {title, url}
+        When: FullDetailTableGenerator.generate is called with that ref_lookup
+        Then: The table output contains the linked title and does NOT contain
+              the raw "{{ref:cwe-89}}" sentinel span
+        """
+        _require_sentinel_module()
+        gen_cls = _get_full_detail_generator()
+
+        yaml_data = {
+            "risks": [
+                {
+                    "id": "riskTestBeta",
+                    "title": "Beta Risk",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short."],
+                    "longDescription": ["Covered by {{ref:cwe-89}}."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                }
+            ]
+        }
+        ref = {
+            "cwe-89": {
+                "title": "CWE-89: Improper Neutralization of SQL Commands",
+                "url": "https://cwe.mitre.org/data/definitions/89.html",
+            }
+        }
+
+        gen = gen_cls(intra_lookup={}, ref_lookup=ref)
+        output = gen.generate(yaml_data, "risks")
+
+        assert "CWE-89: Improper Neutralization of SQL Commands" in output
+        assert "https://cwe.mitre.org/data/definitions/89.html" in output
+        assert "{{ref:cwe-89}}" not in output
+
+    def test_external_references_sub_section_emitted_after_table(self):
+        """
+        Test that a ## References for {id} sub-section appears after the main table
+        when an entry has a non-empty externalReferences array.
+
+        Given: YAML data with one risk that has two externalReferences entries
+        When: FullDetailTableGenerator.generate is called
+        Then: The output contains a "## References for riskTestGamma" section
+              with two bullet lines; this section appears AFTER the markdown table
+              (i.e., the index of "## References for" in the output is greater
+              than the index where the markdown table ends)
+
+        Contract for position: the output is structured as:
+          <markdown table>\n\n## References for {id}\n- [title](url) (type)\n...
+
+        The markdown table ends at the last "|" line before the References section.
+        """
+        gen_cls = _get_full_detail_generator()
+
+        yaml_data = {
+            "risks": [
+                {
+                    "id": "riskTestGamma",
+                    "title": "Gamma Risk",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short."],
+                    "longDescription": ["Long."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                    "externalReferences": [
+                        {
+                            "type": "cwe",
+                            "id": "cwe-89",
+                            "title": "CWE-89: SQL Injection",
+                            "url": "https://cwe.mitre.org/data/definitions/89.html",
+                        },
+                        {
+                            "type": "paper",
+                            "id": "zhou-2023-poisoning",
+                            "title": "Zhou et al. 2023 - Data Poisoning",
+                            "url": "https://example.com/zhou-2023",
+                        },
+                    ],
+                }
+            ]
+        }
+
+        gen = gen_cls()
+        output = gen.generate(yaml_data, "risks")
+
+        # Sub-section header uses the entry id
+        assert "## References for riskTestGamma" in output
+
+        # Both reference bullets appear
+        assert "CWE-89: SQL Injection" in output
+        assert "Zhou et al. 2023 - Data Poisoning" in output
+
+        # Sub-section is AFTER the main table
+        table_end_idx = output.rfind("|")
+        refs_idx = output.index("## References for riskTestGamma")
+        assert refs_idx > table_end_idx, (
+            f"## References for section (pos {refs_idx}) must appear after "
+            f"the last table pipe (pos {table_end_idx})"
+        )
+
+    def test_unresolved_intra_sentinel_raises_error(self):
+        """
+        Test that FullDetailTableGenerator.generate raises UnresolvedSentinelError
+        when a prose field contains an intra sentinel that is not in intra_lookup.
+
+        Given: YAML data where longDescription contains {{riskTypoFooBar}} (no such key
+               in the supplied intra_lookup)
+        When: FullDetailTableGenerator.generate is called with a non-None intra_lookup
+        Then: UnresolvedSentinelError is raised with .sentinel == "{{riskTypoFooBar}}"
+
+        This is the task 2.5.3 markdown-side hard-fail gate.
+        """
+        _require_sentinel_module()
+        gen_cls = _get_full_detail_generator()
+
+        yaml_data = {
+            "risks": [
+                {
+                    "id": "riskBadSentinel",
+                    "title": "Bad Sentinel",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short."],
+                    "longDescription": ["Mentions {{riskTypoFooBar}} which is unknown."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                }
+            ]
+        }
+
+        gen = gen_cls(intra_lookup={}, ref_lookup={})
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            gen.generate(yaml_data, "risks")
+
+        assert exc_info.value.sentinel == "{{riskTypoFooBar}}"
+
+    def test_unresolved_ref_sentinel_raises_error(self):
+        """
+        Test that FullDetailTableGenerator.generate raises UnresolvedSentinelError
+        when a prose field contains a ref sentinel with no matching ref_lookup entry.
+
+        Given: YAML data where longDescription contains {{ref:cve-2024-99999}} and
+               ref_lookup is empty
+        When: FullDetailTableGenerator.generate is called with non-None lookups
+        Then: UnresolvedSentinelError is raised with .sentinel == "{{ref:cve-2024-99999}}"
+        """
+        _require_sentinel_module()
+        gen_cls = _get_full_detail_generator()
+
+        yaml_data = {
+            "risks": [
+                {
+                    "id": "riskBadRef",
+                    "title": "Bad Ref",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short."],
+                    "longDescription": ["See {{ref:cve-2024-99999}}."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                }
+            ]
+        }
+
+        gen = gen_cls(intra_lookup={}, ref_lookup={})
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            gen.generate(yaml_data, "risks")
+
+        assert exc_info.value.sentinel == "{{ref:cve-2024-99999}}"
+
+
+# ============================================================================
+# TestUnresolvedSentinelMarkdownSide
+# ============================================================================
+
+
+class TestUnresolvedSentinelMarkdownSide:
+    """
+    Explicit task 2.5.3 gate: unresolved sentinels are hard build failures on the
+    markdown side. These tests reach through the table generator's generate() call.
+    """
+
+    def test_intra_typo_in_long_description_raises(self):
+        """
+        Test that a risk with a typo'd intra sentinel in longDescription raises
+        UnresolvedSentinelError when FullDetailTableGenerator.generate is called
+        with non-None lookups.
+
+        Given: risks YAML containing {{riskTypoFooBar}} in longDescription[0]
+               and no risk having id "riskTypoFooBar" in intra_lookup
+        When: FullDetailTableGenerator.generate is called
+        Then: UnresolvedSentinelError is raised
+              .sentinel == "{{riskTypoFooBar}}"
+              .field_path contains the entry id and field name
+        """
+        _require_sentinel_module()
+        gen_cls = _get_full_detail_generator()
+
+        yaml_data = {
+            "risks": [
+                {
+                    "id": "riskWithTypo",
+                    "title": "Risk With Typo",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short."],
+                    "longDescription": ["Contains {{riskTypoFooBar}} sentinel."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                }
+            ]
+        }
+
+        gen = gen_cls(intra_lookup={}, ref_lookup={})
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            gen.generate(yaml_data, "risks")
+
+        exc = exc_info.value
+        assert exc.sentinel == "{{riskTypoFooBar}}"
+        # field_path must be non-empty and informative
+        assert exc.field_path, "field_path must be non-empty"
+        # Should reference the entry id and/or the field name
+        assert "riskWithTypo" in exc.field_path or "longDescription" in exc.field_path, (
+            f"field_path should reference entry id or field name; got: {exc.field_path!r}"
+        )
+
+    def test_ref_typo_in_description_raises(self):
+        """
+        Test that a risk with an unknown ref id in description raises
+        UnresolvedSentinelError.
+
+        Given: risks YAML containing {{ref:cve-2024-99999}} in longDescription[0]
+               and no externalReferences entry with id "cve-2024-99999" in ref_lookup
+        When: FullDetailTableGenerator.generate is called with non-None lookups
+        Then: UnresolvedSentinelError is raised
+              .sentinel == "{{ref:cve-2024-99999}}"
+        """
+        _require_sentinel_module()
+        gen_cls = _get_full_detail_generator()
+
+        yaml_data = {
+            "risks": [
+                {
+                    "id": "riskWithBadRef",
+                    "title": "Risk With Bad Ref",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short."],
+                    "longDescription": ["See {{ref:cve-2024-99999}}."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                }
+            ]
+        }
+
+        gen = gen_cls(intra_lookup={}, ref_lookup={})
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            gen.generate(yaml_data, "risks")
+
+        exc = exc_info.value
+        assert exc.sentinel == "{{ref:cve-2024-99999}}"
+
+    def test_error_field_path_includes_entry_id_and_field_name(self):
+        """
+        Test that the UnresolvedSentinelError field_path identifies the entry id
+        and the YAML field name so the author can pinpoint the problem.
+
+        Given: risks YAML where entry "riskFindMe" has {{riskTypoXyz}} in longDescription[0]
+        When: FullDetailTableGenerator.generate raises UnresolvedSentinelError
+        Then: exc.field_path includes "riskFindMe" (entry id) and "longDescription" (field)
+              OR includes a positional reference such as "risks[0].longDescription[0]"
+        """
+        _require_sentinel_module()
+        gen_cls = _get_full_detail_generator()
+
+        yaml_data = {
+            "risks": [
+                {
+                    "id": "riskFindMe",
+                    "title": "Find Me",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short."],
+                    "longDescription": ["Contains {{riskTypoXyz}}."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                }
+            ]
+        }
+
+        gen = gen_cls(intra_lookup={}, ref_lookup={})
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            gen.generate(yaml_data, "risks")
+
+        exc = exc_info.value
+        assert exc.field_path, "field_path must be non-empty"
+        has_entry_ref = "riskFindMe" in exc.field_path or "risks[0]" in exc.field_path
+        has_field_ref = "longDescription" in exc.field_path
+        assert has_entry_ref or has_field_ref, (
+            f"field_path should identify entry 'riskFindMe' or field 'longDescription'; got: {exc.field_path!r}"
+        )
+
+    def test_error_is_not_caught_by_summary_generator_either(self):
+        """
+        Test that SummaryTableGenerator also propagates UnresolvedSentinelError.
+
+        Given: YAML data with a typo'd intra sentinel in description and non-None lookups
+        When: SummaryTableGenerator.generate is called
+        Then: UnresolvedSentinelError propagates (is not caught internally)
+
+        Both FullDetailTableGenerator and SummaryTableGenerator must hard-fail.
+        """
+        _require_sentinel_module()
+        gen_cls = _get_summary_generator()
+
+        yaml_data = {
+            "risks": [
+                {
+                    "id": "riskSummaryBad",
+                    "title": "Summary Bad",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Contains {{riskBogusId}}."],
+                    "longDescription": ["Long."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                }
+            ]
+        }
+
+        gen = gen_cls(intra_lookup={}, ref_lookup={})
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            gen.generate(yaml_data, "risks")
+
+        assert exc_info.value.sentinel == "{{riskBogusId}}"
+
+
+# ============================================================================
+# TestConvertTypeSurfacing
+# ============================================================================
+
+
+class TestConvertTypeSurfacing:
+    """
+    Tests for the convert_type() user-facing CLI surface.
+
+    convert_type catches all exceptions, prints an error, and returns False.
+    The task 2.5.3 contract for this surface:
+      - convert_type returns False when a sentinel is unresolved.
+      - The error printed to stdout includes the sentinel span.
+
+    Design note: convert_type reads from a YAML file on disk, so these tests use
+    tmp_path to write synthesized YAML files with bad sentinels.
+    """
+
+    def test_convert_type_returns_false_on_unresolved_sentinel(self, tmp_path: Path):
+        """
+        Test that convert_type returns False when a YAML file contains an unresolved
+        intra sentinel and the generator is wired with non-None lookups.
+
+        Given: A temporary YAML file with a risk whose longDescription contains
+               {{riskTypoFooBar}} (no such id exists)
+        When: convert_type is called targeting that file with full format
+        Then: Returns False and prints an error message to stdout
+
+        Note: convert_type's current try/except at line 1112 catches all exceptions
+        and prints "❌ Error converting {ytype}: {e}". After A7, the error message
+        should include the unresolved sentinel span.
+        """
+        _require_sentinel_module()
+
+        # Write a minimal risks YAML with a bad sentinel
+        yaml_data = {
+            "risks": [
+                {
+                    "id": "riskBadForConvert",
+                    "title": "Bad Sentinel Risk",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short."],
+                    "longDescription": ["Contains {{riskTypoFooBar}}."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                }
+            ]
+        }
+        import yaml as _yaml
+
+        input_file = tmp_path / "risks.yaml"
+        input_file.write_text(_yaml.dump(yaml_data), encoding="utf-8")
+        output_file = tmp_path / "out.md"
+
+        result = _ytm.convert_type(
+            ytype="risks",
+            table_format="full",
+            input_file=input_file,
+            output_file=output_file,
+            quiet=True,
+        )
+
+        assert result is False
+
+    def test_convert_type_error_message_contains_sentinel(self, tmp_path: Path, capsys):
+        """
+        Test that the error message printed by convert_type includes the unresolved
+        sentinel span so the author can identify the problem.
+
+        Given: A YAML file with {{riskTypoFooBar}} in a prose field
+        When: convert_type is called and returns False
+        Then: The captured stdout contains the sentinel span "{{riskTypoFooBar}}"
+              (or at minimum the outer riskTypoFooBar id)
+
+        The existing error-print surface is:
+          print(f"❌ Error converting {ytype}: {e}")
+        where {e} is str(UnresolvedSentinelError). Since UnresolvedSentinelError's
+        __str__ always includes both .sentinel and .field_path (per test contract in
+        test_sentinel_expansion.py), the sentinel span will appear in stdout.
+        """
+        _require_sentinel_module()
+
+        import yaml as _yaml
+
+        yaml_data = {
+            "risks": [
+                {
+                    "id": "riskSentinelMsg",
+                    "title": "Sentinel Msg Risk",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short."],
+                    "longDescription": ["Bad ref: {{riskTypoFooBar}}."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                }
+            ]
+        }
+        input_file = tmp_path / "risks.yaml"
+        input_file.write_text(_yaml.dump(yaml_data), encoding="utf-8")
+        output_file = tmp_path / "out.md"
+
+        # quiet=False so error is printed
+        result = _ytm.convert_type(
+            ytype="risks",
+            table_format="full",
+            input_file=input_file,
+            output_file=output_file,
+            quiet=False,
+        )
+        captured = capsys.readouterr()
+
+        assert result is False
+        # Error message should mention the sentinel or its id fragment
+        assert "riskTypoFooBar" in captured.out, (
+            f"Expected sentinel id in error output; got stdout:\n{captured.out!r}"
+        )
+
+
+# ============================================================================
+# TestExternalReferencesIntegration
+# ============================================================================
+
+
+class TestExternalReferencesIntegration:
+    """
+    Confirms that ## References for {id} sub-sections render correctly in the
+    combined output from FullDetailTableGenerator.generate.
+    """
+
+    def test_single_risk_with_refs_emits_sub_section(self):
+        """
+        Test that a single risk with two externalReferences produces a
+        "## References for {id}" sub-section with two bullets.
+
+        Given: YAML with one risk having externalReferences=[{cwe-89}, {zhou-2023-poisoning}]
+        When: FullDetailTableGenerator.generate is called
+        Then: Output contains:
+              - "## References for riskWithExtRefs"
+              - A bullet for CWE-89 in source order
+              - A bullet for zhou-2023-poisoning in source order
+        """
+        gen_cls = _get_full_detail_generator()
+
+        yaml_data = {
+            "risks": [
+                {
+                    "id": "riskWithExtRefs",
+                    "title": "Risk With Ext Refs",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short."],
+                    "longDescription": ["Long."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                    "externalReferences": [
+                        {
+                            "type": "cwe",
+                            "id": "cwe-89",
+                            "title": "CWE-89: SQL Injection",
+                            "url": "https://cwe.mitre.org/data/definitions/89.html",
+                        },
+                        {
+                            "type": "paper",
+                            "id": "zhou-2023-poisoning",
+                            "title": "Zhou et al. 2023 - Data Poisoning",
+                            "url": "https://example.com/zhou-2023",
+                        },
+                    ],
+                }
+            ]
+        }
+
+        gen = gen_cls()
+        output = gen.generate(yaml_data, "risks")
+
+        assert "## References for riskWithExtRefs" in output
+        assert "CWE-89: SQL Injection" in output
+        assert "Zhou et al. 2023 - Data Poisoning" in output
+        # Two bullets
+        bullets_after_header = output[output.index("## References for riskWithExtRefs") :]
+        assert bullets_after_header.count("- [") >= 2
+
+    def test_multiple_risks_with_refs_emit_multiple_sub_sections(self):
+        """
+        Test that multiple risks each with externalReferences produce
+        multiple distinct ## References for {id} sub-sections.
+
+        Given: YAML with two risks: riskAlpha (one ext ref) and riskBeta (one ext ref)
+        When: FullDetailTableGenerator.generate is called
+        Then: Output contains both "## References for riskAlpha" and
+              "## References for riskBeta"
+        """
+        gen_cls = _get_full_detail_generator()
+
+        yaml_data = {
+            "risks": [
+                {
+                    "id": "riskAlpha",
+                    "title": "Alpha",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short."],
+                    "longDescription": ["Long."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                    "externalReferences": [
+                        {"type": "cwe", "id": "cwe-1", "title": "CWE-1 Title", "url": "https://example.com/1"}
+                    ],
+                },
+                {
+                    "id": "riskBeta",
+                    "title": "Beta",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short."],
+                    "longDescription": ["Long."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                    "externalReferences": [
+                        {
+                            "type": "paper",
+                            "id": "paper-2",
+                            "title": "Paper 2 Title",
+                            "url": "https://example.com/2",
+                        }
+                    ],
+                },
+            ]
+        }
+
+        gen = gen_cls()
+        output = gen.generate(yaml_data, "risks")
+
+        assert "## References for riskAlpha" in output
+        assert "## References for riskBeta" in output
+
+    def test_no_external_references_no_sub_sections(self):
+        """
+        Test that YAML data where no entry has externalReferences produces
+        no ## References for headers in the output.
+
+        Given: YAML with one risk that has no externalReferences field
+        When: FullDetailTableGenerator.generate is called
+        Then: "## References for" does NOT appear anywhere in the output
+        """
+        gen_cls = _get_full_detail_generator()
+
+        yaml_data = _make_risks_yaml_data()
+        gen = gen_cls()
+        output = gen.generate(yaml_data, "risks")
+
+        assert "## References for" not in output
+
+    def test_references_sections_appear_after_main_table(self):
+        """
+        Test that all ## References for sub-sections appear AFTER the main markdown
+        table in the output string.
+
+        Given: YAML with one risk that has externalReferences
+        When: FullDetailTableGenerator.generate is called
+        Then: The string index of "## References for" is greater than the index
+              of the last "|" character in the output (which marks end of the table)
+        """
+        gen_cls = _get_full_detail_generator()
+
+        yaml_data = {
+            "risks": [
+                {
+                    "id": "riskPositionCheck",
+                    "title": "Position Check",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short."],
+                    "longDescription": ["Long."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                    "externalReferences": [
+                        {
+                            "type": "cwe",
+                            "id": "cwe-89",
+                            "title": "CWE-89",
+                            "url": "https://cwe.mitre.org/data/definitions/89.html",
+                        }
+                    ],
+                }
+            ]
+        }
+
+        gen = gen_cls()
+        output = gen.generate(yaml_data, "risks")
+
+        table_end_idx = output.rfind("|")
+        refs_idx = output.index("## References for riskPositionCheck")
+        assert refs_idx > table_end_idx, (
+            f"## References for section (pos {refs_idx}) must appear after "
+            f"the last table pipe (pos {table_end_idx})"
+        )
+
+    def test_empty_external_references_list_no_sub_section(self):
+        """
+        Test that an empty externalReferences list on an entry does NOT emit
+        a ## References for sub-section.
+
+        Given: YAML with one risk that has externalReferences=[]
+        When: FullDetailTableGenerator.generate is called
+        Then: "## References for" does NOT appear in the output
+        """
+        gen_cls = _get_full_detail_generator()
+
+        yaml_data = {
+            "risks": [
+                {
+                    "id": "riskEmptyExtRefs",
+                    "title": "Empty Ext Refs",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short."],
+                    "longDescription": ["Long."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                    "externalReferences": [],
+                }
+            ]
+        }
+
+        gen = gen_cls()
+        output = gen.generate(yaml_data, "risks")
+
+        assert "## References for" not in output
+
+
+# ============================================================================
+# TestSummaryTableSentinelIntegration
+# ============================================================================
+
+
+class TestSummaryTableSentinelIntegration:
+    """
+    Integration tests for SummaryTableGenerator (parallel to FullDetail tests).
+
+    SummaryTableGenerator uses collapse_column on shortDescription/description.
+    The same sentinel-wiring and References-emission contract applies.
+    """
+
+    def test_summary_generator_constructor_accepts_lookup_kwargs(self):
+        """
+        Test that SummaryTableGenerator accepts intra_lookup and ref_lookup kwargs.
+
+        Given: Calls to SummaryTableGenerator() with and without lookup kwargs
+        When: Both constructors are called
+        Then: No TypeError is raised — both signatures are accepted
+
+        This is the backward-compat smoke test for the constructor change.
+        """
+        gen_cls = _get_summary_generator()
+        # No kwargs — pre-A7 call site
+        gen1 = gen_cls()
+        assert gen1 is not None
+
+        # With kwargs — post-A7 wired call
+        gen2 = gen_cls(intra_lookup=_INTRA_LOOKUP, ref_lookup=_REF_LOOKUP)
+        assert gen2 is not None
+
+    def test_summary_generator_expands_intra_sentinel_in_short_desc(self):
+        """
+        Test that SummaryTableGenerator expands an intra sentinel in shortDescription.
+
+        Given: YAML data where a risk's shortDescription contains {{riskPromptInjection}}
+               and intra_lookup has that id
+        When: SummaryTableGenerator.generate is called with non-None intra_lookup
+        Then: Output contains "Prompt Injection" and NOT the raw sentinel span
+        """
+        _require_sentinel_module()
+        gen_cls = _get_summary_generator()
+
+        yaml_data = {
+            "risks": [
+                {
+                    "id": "riskPromptInjection",
+                    "title": "Prompt Injection",
+                    "category": "riskCatTest",
+                    "shortDescription": ["See {{riskPromptInjection}} category."],
+                    "longDescription": ["Long."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                }
+            ]
+        }
+        intra = {"riskPromptInjection": "Prompt Injection"}
+
+        gen = gen_cls(intra_lookup=intra, ref_lookup={})
+        output = gen.generate(yaml_data, "risks")
+
+        assert "Prompt Injection" in output
+        assert "{{riskPromptInjection}}" not in output
+
+    def test_summary_generator_external_references_section_emitted(self):
+        """
+        Test that SummaryTableGenerator emits ## References for {id} after the table.
+
+        Given: YAML data with one risk having one externalReferences entry
+        When: SummaryTableGenerator.generate is called
+        Then: Output contains "## References for {risk-id}" sub-section with one bullet
+        """
+        gen_cls = _get_summary_generator()
+
+        yaml_data = {
+            "risks": [
+                {
+                    "id": "riskSummaryWithRefs",
+                    "title": "Summary With Refs",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short."],
+                    "longDescription": ["Long."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                    "externalReferences": [
+                        {
+                            "type": "cwe",
+                            "id": "cwe-89",
+                            "title": "CWE-89: SQL Injection",
+                            "url": "https://cwe.mitre.org/data/definitions/89.html",
+                        }
+                    ],
+                }
+            ]
+        }
+
+        gen = gen_cls()
+        output = gen.generate(yaml_data, "risks")
+
+        assert "## References for riskSummaryWithRefs" in output
+        assert "CWE-89: SQL Injection" in output
+
+
+# ============================================================================
+# Test Summary
+# ============================================================================
+"""
+Test Summary
+============
+Total test classes: 7
+Total tests:        41
+
+- TestCollapseColumnSentinelExpansion (13):
+    plain text passthrough (no kwargs), newlines normalised (no kwargs),
+    plain text unchanged with lookups, intra sentinel → plain title,
+    ref sentinel → markdown link, mixed sentinels both expanded,
+    multi-element list collapsed + expanded, None lookups pass-through (no error),
+    explicit None pass-through, unresolved intra raises, unresolved ref raises,
+    field_path kwarg accepted, field_path propagated to error
+
+- TestFormatExternalReferences (8):
+    empty list → "", None → "", single entry → header + one bullet,
+    multiple entries in source order, type annotation in parens,
+    H2 header (not H1/H3), special chars not escaped, three entries → three bullets
+
+- TestFullDetailTableSentinelIntegration (6):
+    no sentinels → output unchanged pre/post-A7, intra sentinel expanded in table,
+    ref sentinel expanded to link in table, externalReferences sub-section emitted
+    after table, unresolved intra raises UnresolvedSentinelError,
+    unresolved ref raises UnresolvedSentinelError
+
+- TestUnresolvedSentinelMarkdownSide (4):
+    intra typo in longDescription raises (field_path check),
+    ref typo in description raises, field_path names entry+field,
+    SummaryTableGenerator also propagates error
+
+- TestConvertTypeSurfacing (2):
+    convert_type returns False on unresolved sentinel,
+    error message stdout contains sentinel id
+
+- TestExternalReferencesIntegration (5):
+    single risk with refs → sub-section with two bullets,
+    multiple risks with refs → multiple sub-sections,
+    no externalReferences → no sub-section headers,
+    sub-sections appear after main table (position check),
+    empty externalReferences list → no sub-section
+
+- TestSummaryTableSentinelIntegration (3):
+    constructor accepts lookup kwargs (backward compat),
+    intra sentinel expanded in shortDescription,
+    externalReferences sub-section emitted
+
+Coverage target: 90%+ on the new A7 wiring in yaml_to_markdown.py
+
+Key contracts pinned:
+  - collapse_column(entry, *, intra_lookup=None, ref_lookup=None, field_path=...)
+    → when lookups are None, sentinels pass through; when non-None, sentinels expand
+  - format_external_references(refs) -> str  (new public helper)
+  - FullDetailTableGenerator(intra_lookup=None, ref_lookup=None)
+  - SummaryTableGenerator(intra_lookup=None, ref_lookup=None)
+  - ## References for {entry-id} sub-section after the markdown table
+  - UnresolvedSentinelError propagates through generate(); convert_type returns False
+"""

--- a/scripts/hooks/tests/test_yaml_to_markdown_sentinel_expansion.py
+++ b/scripts/hooks/tests/test_yaml_to_markdown_sentinel_expansion.py
@@ -1459,6 +1459,314 @@ class TestSummaryTableSentinelIntegration:
 
 
 # ============================================================================
+# TestPerEntryRefLookupCollision  (RED — ADR-016 D6 per-entry scope)
+# ============================================================================
+
+
+def _write_sibling_yamls(directory: Path) -> None:
+    """Write minimal sibling YAML files so yaml_to_markdown_table's intra_lookup build succeeds.
+
+    yaml_to_markdown_table scans risks.yaml, controls.yaml, components.yaml, and personas.yaml
+    in the same directory to populate intra_lookup.  The collision tests use a synthesised
+    risks.yaml as the primary file; the other three are empty stubs so the scan is silent.
+    """
+    import yaml as _yaml
+
+    (directory / "controls.yaml").write_text(_yaml.dump({"controls": []}), encoding="utf-8")
+    (directory / "components.yaml").write_text(_yaml.dump({"components": []}), encoding="utf-8")
+    (directory / "personas.yaml").write_text(_yaml.dump({"personas": []}), encoding="utf-8")
+
+
+def _write_sibling_yamls_for_controls(directory: Path) -> None:
+    """Write minimal sibling YAML files when controls.yaml is the primary file under test."""
+    import yaml as _yaml
+
+    (directory / "risks.yaml").write_text(_yaml.dump({"risks": []}), encoding="utf-8")
+    (directory / "components.yaml").write_text(_yaml.dump({"components": []}), encoding="utf-8")
+    (directory / "personas.yaml").write_text(_yaml.dump({"personas": []}), encoding="utf-8")
+
+
+class TestPerEntryRefLookupCollision:
+    """
+    RED-phase tests for ADR-016 D6 rule 3: ref-lookup scope is per-entry.
+
+    The current implementation at yaml_to_markdown.py:1051-1063 builds a single
+    flat ref_lookup by iterating all entries' externalReferences with last-write-wins
+    on id collision.  This violates the per-entry scope rule: if risk-A and risk-B
+    both declare externalReferences[].id = "shared" with different titles/urls, then
+    risk-A's {{ref:shared}} resolves to whichever entry was loaded last.
+
+    These tests assert the correct post-fix behaviour:
+    - A1/A2: each entry's {{ref:shared}} resolves to THAT entry's own ref metadata,
+      not a sibling's.
+    - B1: a sentinel that references an id declared only in a different entry must
+      raise UnresolvedSentinelError (per-entry scope: unknown to this entry = unresolved).
+
+    On HEAD ebe4504 all tests in this class are expected to FAIL (RED phase).
+
+    Generators under test reach yaml_to_markdown_table, not the generator classes
+    directly, because the bug lives in yaml_to_markdown_table's ref_lookup build
+    logic (lines 1051-1063), not inside the generator classes themselves.
+    """
+
+    def test_a1_full_detail_risks_collision_each_entry_resolves_own_ref(self, tmp_path: Path):
+        """
+        A1: FullDetailTableGenerator via yaml_to_markdown_table resolves {{ref:shared}}
+        to the declaring entry's own ref, not the last-loaded one.
+
+        Given: risks.yaml with two risks:
+               - riskAlpha: externalReferences [{id:"shared", title:"CWE-A Title", url:".../A"}]
+                            longDescription: "... see {{ref:shared}} for details ..."
+               - riskBeta:  externalReferences [{id:"shared", title:"CWE-B Title", url:".../B"}]
+                            longDescription: "... see {{ref:shared}} as well ..."
+        When: yaml_to_markdown_table(risks_yaml, "risks", table_format="full") is called
+        Then: (post-fix contract)
+              - The row for riskAlpha contains "CWE-A Title" and does NOT contain "CWE-B Title"
+              - The row for riskBeta  contains "CWE-B Title" and does NOT contain "CWE-A Title"
+
+        RED failure (HEAD ebe4504):
+              The flat last-write-wins lookup means BOTH rows resolve to the last-loaded
+              ref ("CWE-B Title" if riskBeta is last in YAML order).  The assertion
+              "riskAlpha row contains CWE-A Title" fails.
+        """
+        _require_sentinel_module()
+        import yaml as _yaml
+
+        risks_data = {
+            "risks": [
+                {
+                    "id": "riskAlpha",
+                    "title": "Alpha Risk",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short alpha."],
+                    "longDescription": ["Alpha: see {{ref:shared}} for details."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                    "externalReferences": [
+                        {
+                            "id": "shared",
+                            "type": "cwe",
+                            "title": "CWE-A Title",
+                            "url": "https://cwe.mitre.org/A",
+                        }
+                    ],
+                },
+                {
+                    "id": "riskBeta",
+                    "title": "Beta Risk",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short beta."],
+                    "longDescription": ["Beta: see {{ref:shared}} as well."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                    "externalReferences": [
+                        {
+                            "id": "shared",
+                            "type": "cwe",
+                            "title": "CWE-B Title",
+                            "url": "https://cwe.mitre.org/B",
+                        }
+                    ],
+                },
+            ]
+        }
+        risks_file = tmp_path / "risks.yaml"
+        risks_file.write_text(_yaml.dump(risks_data), encoding="utf-8")
+        _write_sibling_yamls(tmp_path)
+
+        output = _ytm.yaml_to_markdown_table(risks_file, "risks", table_format="full")
+
+        # Bound the row-isolation slice to the table portion only — the
+        # post-table "## References for {id}" sub-sections legitimately list
+        # both entries' titles and would defeat row isolation if included.
+        table_end = output.find("## References for")
+        table = output if table_end == -1 else output[:table_end]
+        alpha_idx = table.find("riskAlpha")
+        beta_idx = table.find("riskBeta")
+        assert alpha_idx != -1, "riskAlpha not found in table"
+        assert beta_idx != -1, "riskBeta not found in table"
+
+        # The table is sorted by id, so riskAlpha row comes before riskBeta row.
+        alpha_region = table[alpha_idx:beta_idx]
+        beta_region = table[beta_idx:]
+
+        assert "CWE-A Title" in alpha_region, (
+            f"riskAlpha row must resolve {{{{ref:shared}}}} to its own 'CWE-A Title'; "
+            f"alpha_region:\n{alpha_region!r}"
+        )
+        assert "CWE-B Title" not in alpha_region, (
+            "riskAlpha row must NOT contain 'CWE-B Title' (cross-entry collision)"
+        )
+        assert "CWE-B Title" in beta_region, (
+            f"riskBeta row must resolve {{{{ref:shared}}}} to its own 'CWE-B Title'; beta_region:\n{beta_region!r}"
+        )
+        assert "CWE-A Title" not in beta_region, (
+            "riskBeta row must NOT contain 'CWE-A Title' (cross-entry collision)"
+        )
+
+    def test_a2_summary_controls_collision_each_entry_resolves_own_ref(self, tmp_path: Path):
+        """
+        A2: SummaryTableGenerator via yaml_to_markdown_table resolves {{ref:shared}}
+        to the declaring entry's own ref (controls, summary format).
+
+        Given: controls.yaml with two controls sharing externalReferences[].id = "shared":
+               - controlAlpha: ref title "NIST-A Title"; description "... {{ref:shared}} ..."
+               - controlBeta:  ref title "NIST-B Title"; description "... {{ref:shared}} ..."
+        When: yaml_to_markdown_table(controls_yaml, "controls", table_format="summary") is called
+        Then: (post-fix contract)
+              - controlAlpha's row contains "NIST-A Title" and does NOT contain "NIST-B Title"
+              - controlBeta's row contains "NIST-B Title" and does NOT contain "NIST-A Title"
+
+        RED failure (HEAD ebe4504):
+              The flat lookup means both rows resolve to the last-loaded ref.
+              The per-entry assertion fails.
+        """
+        _require_sentinel_module()
+        import yaml as _yaml
+
+        controls_data = {
+            "controls": [
+                {
+                    "id": "controlAlpha",
+                    "title": "Alpha Control",
+                    "category": "controlsData",
+                    "description": ["Alpha uses {{ref:shared}} specification."],
+                    "risks": [],
+                    "components": [],
+                    "externalReferences": [
+                        {
+                            "id": "shared",
+                            "type": "nist",
+                            "title": "NIST-A Title",
+                            "url": "https://nist.gov/A",
+                        }
+                    ],
+                },
+                {
+                    "id": "controlBeta",
+                    "title": "Beta Control",
+                    "category": "controlsData",
+                    "description": ["Beta follows {{ref:shared}} guidelines."],
+                    "risks": [],
+                    "components": [],
+                    "externalReferences": [
+                        {
+                            "id": "shared",
+                            "type": "nist",
+                            "title": "NIST-B Title",
+                            "url": "https://nist.gov/B",
+                        }
+                    ],
+                },
+            ]
+        }
+        controls_file = tmp_path / "controls.yaml"
+        controls_file.write_text(_yaml.dump(controls_data), encoding="utf-8")
+        _write_sibling_yamls_for_controls(tmp_path)
+
+        output = _ytm.yaml_to_markdown_table(controls_file, "controls", table_format="summary")
+
+        # Bound row isolation to the table portion only (References sections
+        # come after the table and would sweep both entries' titles).
+        table_end = output.find("## References for")
+        table = output if table_end == -1 else output[:table_end]
+        alpha_idx = table.find("controlAlpha")
+        beta_idx = table.find("controlBeta")
+        assert alpha_idx != -1, "controlAlpha not found in table"
+        assert beta_idx != -1, "controlBeta not found in table"
+
+        alpha_region = table[alpha_idx:beta_idx]
+        beta_region = table[beta_idx:]
+
+        assert "NIST-A Title" in alpha_region, (
+            f"controlAlpha row must resolve {{{{ref:shared}}}} to 'NIST-A Title'; alpha_region:\n{alpha_region!r}"
+        )
+        assert "NIST-B Title" not in alpha_region, (
+            "controlAlpha row must NOT contain 'NIST-B Title' (cross-entry collision)"
+        )
+        assert "NIST-B Title" in beta_region, (
+            f"controlBeta row must resolve {{{{ref:shared}}}} to 'NIST-B Title'; beta_region:\n{beta_region!r}"
+        )
+        assert "NIST-A Title" not in beta_region, (
+            "controlBeta row must NOT contain 'NIST-A Title' (cross-entry collision)"
+        )
+
+    def test_b1_cross_entry_ref_id_raises_unresolved_error(self, tmp_path: Path):
+        """
+        B1: A {{ref:id}} sentinel that is declared in a different entry but NOT in
+        the entry that uses it must raise UnresolvedSentinelError after the fix.
+
+        Given: risks.yaml with two risks:
+               - riskAlpha: externalReferences=[]  (declares NO refs)
+                            longDescription: "... see {{ref:cve-2024-99999}} ..."
+               - riskBeta:  externalReferences=[{id:"cve-2024-99999", ...}]
+                            longDescription: (no sentinel)
+        When: yaml_to_markdown_table(risks_yaml, "risks", table_format="full") is called
+        Then: (post-fix contract)
+              UnresolvedSentinelError is raised for riskAlpha's reference to
+              "cve-2024-99999" because that id is not in riskAlpha's own
+              externalReferences (per-entry scope).
+
+        RED failure (HEAD ebe4504):
+              The flat lookup contains "cve-2024-99999" from riskBeta, so riskAlpha's
+              sentinel resolves successfully and NO exception is raised.
+              pytest.raises sees "DID NOT RAISE" — the correct RED failure signal.
+        """
+        _require_sentinel_module()
+        import yaml as _yaml
+
+        risks_data = {
+            "risks": [
+                {
+                    "id": "riskAlpha",
+                    "title": "Alpha Risk",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short alpha."],
+                    "longDescription": ["Alpha mentions {{ref:cve-2024-99999}} for context."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                    # riskAlpha declares NO externalReferences — it doesn't own this ref
+                    "externalReferences": [],
+                },
+                {
+                    "id": "riskBeta",
+                    "title": "Beta Risk",
+                    "category": "riskCatTest",
+                    "shortDescription": ["Short beta."],
+                    "longDescription": ["Beta description with no sentinel."],
+                    "examples": [],
+                    "personas": [],
+                    "controls": [],
+                    "externalReferences": [
+                        {
+                            "id": "cve-2024-99999",
+                            "type": "cve",
+                            "title": "CVE-2024-99999 Title",
+                            "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-99999",
+                        }
+                    ],
+                },
+            ]
+        }
+        risks_file = tmp_path / "risks.yaml"
+        risks_file.write_text(_yaml.dump(risks_data), encoding="utf-8")
+        _write_sibling_yamls(tmp_path)
+
+        # Post-fix: riskAlpha's {{ref:cve-2024-99999}} must raise because
+        # cve-2024-99999 is NOT in riskAlpha's own externalReferences.
+        # RED: on HEAD ebe4504 the flat lookup resolves it via riskBeta → no exception.
+        with pytest.raises(UnresolvedSentinelError) as exc_info:
+            _ytm.yaml_to_markdown_table(risks_file, "risks", table_format="full")
+
+        assert "cve-2024-99999" in str(exc_info.value), (
+            f"Error message must identify the unresolved ref id; got: {exc_info.value!r}"
+        )
+
+
+# ============================================================================
 # Test Summary
 # ============================================================================
 """

--- a/scripts/hooks/yaml_to_markdown.py
+++ b/scripts/hooks/yaml_to_markdown.py
@@ -27,6 +27,14 @@ from pathlib import Path
 import pandas as pd
 import yaml
 
+# Ensure repo root is on sys.path so scripts.hooks._sentinel_expansion resolves
+# when this file is invoked directly as a script (not only as a module).
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.hooks._sentinel_expansion import expand_sentinels_to_text  # noqa: E402
+
 # Configuration: easily modifiable paths
 DEFAULT_INPUT_DIR = Path("risk-map/yaml")
 DEFAULT_OUTPUT_DIR = Path("risk-map/tables")
@@ -120,21 +128,89 @@ def format_mappings(entry) -> str:
     return "<br>".join(parts)
 
 
-def collapse_column(entry) -> str:
-    """Collapse multi-line or nested list content into HTML-formatted string."""
+def format_external_references(refs: list[dict] | None) -> str:
+    """Format an externalReferences array as a markdown section with bullet list.
+
+    Returns a "## References" section with one bullet per entry, or "" when
+    refs is empty or None.
+
+    Per ADR-016 D3, externalReferences entries carry schema-validated
+    title/url/type fields. Brackets and parens in titles are not escaped —
+    markdown injection is a known limitation under the trusted-author posture.
+
+    Args:
+        refs: list of dicts with keys title, url, type; or None
+
+    Returns:
+        Markdown section string starting with "## References\\n", or ""
+    """
+    if not refs:
+        return ""
+    bullets = "\n".join(f"- [{r['title']}]({r['url']}) ({r['type']})" for r in refs)
+    return f"## References\n{bullets}\n"
+
+
+_REFS_HEADER = "## References\n"
+
+
+def _references_bullets_only(refs: list[dict] | None) -> str:
+    """Return format_external_references(refs) with the leading "## References" header stripped.
+
+    Per-entry sub-sections in the table generators emit their own
+    "## References for {id}" header, so the helper's generic header would
+    stack visually if concatenated raw. This trims it cleanly.
+    """
+    rendered = format_external_references(refs)
+    if rendered.startswith(_REFS_HEADER):
+        return rendered[len(_REFS_HEADER) :]
+    return rendered
+
+
+def collapse_column(
+    entry,
+    *,
+    intra_lookup: dict[str, str] | None = None,
+    ref_lookup: dict[str, dict] | None = None,
+    field_path: str = "",
+) -> str:
+    """Collapse multi-line or nested list content into HTML-formatted string.
+
+    When both intra_lookup and ref_lookup are supplied (not None), sentinel
+    spans are expanded via expand_sentinels_to_text before newline conversion.
+    When either is None (the default), sentinels pass through unchanged so
+    pre-A7 call sites keep working.
+
+    An unresolved sentinel raises UnresolvedSentinelError and is never swallowed.
+
+    Args:
+        entry: string, list of strings, or other value to format
+        intra_lookup: entity-id -> title map; None means no expansion
+        ref_lookup: ref-id -> {title, url} map; None means no expansion
+        field_path: location string for error messages (e.g. "risks[0].longDescription[0]")
+    """
     # Handle pandas NaN values - check type first to avoid array ambiguity
     if not isinstance(entry, (str, list)) and pd.isna(entry):
         return ""
 
+    # Assemble raw text before any HTML conversion, then optionally expand sentinels.
     if isinstance(entry, str):
-        return entry.replace("- >", "").replace("\n", "<br>")
+        raw = entry.replace("- >", "")
     elif isinstance(entry, list) and len(entry) == 1:
-        return entry[0].replace("- >", "").replace("\n", "<br>")
+        raw = entry[0].replace("- >", "")
     elif not isinstance(entry, list):
         return str(entry) if entry else ""
+    else:
+        flattened_list = list(chain.from_iterable(item if isinstance(item, list) else [item] for item in entry))
+        raw = "<br> ".join(flattened_list).replace("- >", "")
 
-    flattened_list = list(chain.from_iterable(item if isinstance(item, list) else [item] for item in entry))
-    full_desc = "<br> ".join(flattened_list).replace("- >", "").replace("\n", "<br>")
+    # Expand sentinels before newline→<br> conversion so markdown links survive intact.
+    # Only expand when both lookups are supplied; None means the caller has not opted in.
+    if intra_lookup is not None and ref_lookup is not None:
+        raw = expand_sentinels_to_text(
+            raw, intra_lookup=intra_lookup, ref_lookup=ref_lookup, field_path=field_path
+        )
+
+    full_desc = raw.replace("\n", "<br>")
 
     return full_desc
 
@@ -152,14 +228,24 @@ class TableGenerator(ABC):
     and defines how to transform YAML data into markdown tables.
     """
 
-    def __init__(self, input_dir: Path = DEFAULT_INPUT_DIR):
+    def __init__(
+        self,
+        input_dir: Path = DEFAULT_INPUT_DIR,
+        *,
+        intra_lookup: dict[str, str] | None = None,
+        ref_lookup: dict[str, dict] | None = None,
+    ):
         """
         Initialize table generator.
 
         Args:
             input_dir: Directory containing YAML source files
+            intra_lookup: entity-id -> title map for sentinel expansion; None disables expansion
+            ref_lookup: ref-id -> {title, url} map for sentinel expansion; None disables expansion
         """
         self.input_dir = input_dir
+        self.intra_lookup = intra_lookup
+        self.ref_lookup = ref_lookup
         self._yaml_cache = {}  # Cache for loaded YAML files
 
     @abstractmethod
@@ -219,22 +305,43 @@ class FullDetailTableGenerator(TableGenerator):
         """
         Generate full detail markdown table.
 
+        When intra_lookup and ref_lookup are set on the instance, sentinel spans
+        in collapsable fields are expanded per-row before the table is rendered.
+        Entries with a non-empty externalReferences array get a "## References for {id}"
+        sub-section appended after the main table.
+
         Args:
             yaml_data: Parsed YAML data dictionary
             ytype: Type of data (components, controls, risks)
 
         Returns:
-            Formatted markdown table string
+            Formatted markdown table string, followed by any References sub-sections
         """
         collapsable = ["description", "shortDescription", "longDescription", "examples"]
 
-        # Convert to DataFrame
-        df = pd.DataFrame(yaml_data.get(ytype))
+        entries = yaml_data.get(ytype) or []
+        sorted_entries = sorted(entries, key=lambda e: e.get("id", ""))
 
-        # Apply column-specific formatting
+        # Convert to DataFrame; drop externalReferences — it's rendered as sub-sections below.
+        df = pd.DataFrame(entries)
+        if "externalReferences" in df.columns:
+            df = df.drop(columns=["externalReferences"])
+
+        # Apply column-specific formatting; use per-row sentinel expansion for prose fields.
         for col in df.columns:
             if col in collapsable:
-                df[col] = df[col].apply(collapse_column)
+                if self.intra_lookup is not None and self.ref_lookup is not None:
+                    # Per-row expansion: thread row index into field_path for error messages.
+                    df = df.reset_index(drop=True)
+                    for row_idx in range(len(df)):
+                        df.at[row_idx, col] = collapse_column(
+                            df.at[row_idx, col],
+                            intra_lookup=self.intra_lookup,
+                            ref_lookup=self.ref_lookup,
+                            field_path=f"{ytype}[{row_idx}].{col}",
+                        )
+                else:
+                    df[col] = df[col].apply(collapse_column)
             elif col == "edges":
                 df[col] = df[col].apply(format_edges)
             elif col == "tourContent":
@@ -245,9 +352,16 @@ class FullDetailTableGenerator(TableGenerator):
                 df[col] = df[col].apply(format_list)
 
         df_filled = df.fillna("").sort_values("id")
+        table = df_filled.to_markdown(index=False)
 
-        # Convert to markdown
-        return df_filled.to_markdown(index=False)
+        # Append per-entry References sub-sections for entries with externalReferences.
+        sections = [table]
+        for entry in sorted_entries:
+            refs = entry.get("externalReferences")
+            if refs:
+                sections.append(f"\n## References for {entry['id']}\n{_references_bullets_only(refs)}")
+
+        return "\n".join(sections)
 
 
 class SummaryTableGenerator(TableGenerator):
@@ -261,30 +375,57 @@ class SummaryTableGenerator(TableGenerator):
         """
         Generate summary markdown table.
 
+        When intra_lookup and ref_lookup are set on the instance, sentinel spans
+        in the description field are expanded before the table is rendered.
+        Entries with a non-empty externalReferences array get a "## References for {id}"
+        sub-section appended after the main table.
+
         Args:
             yaml_data: Parsed YAML data dictionary
             ytype: Type of data (components, controls, risks)
 
         Returns:
-            Formatted markdown table string
+            Formatted markdown table string, followed by any References sub-sections
         """
-        items = yaml_data.get(ytype, [])
+        items = yaml_data.get(ytype, []) or []
+        sorted_items = sorted(items, key=lambda e: e.get("id", ""))
 
         rows = []
-        for item in items:
+        for row_idx, item in enumerate(items):
             # Prefer shortDescription over description
             desc = item.get("shortDescription") or item.get("description", "")
+
+            if desc and self.intra_lookup is not None and self.ref_lookup is not None:
+                # Expand sentinels; field_path points at the source field and row.
+                field_name = "shortDescription" if item.get("shortDescription") else "description"
+                collapsed = collapse_column(
+                    desc,
+                    intra_lookup=self.intra_lookup,
+                    ref_lookup=self.ref_lookup,
+                    field_path=f"{ytype}[{row_idx}].{field_name}",
+                )
+            else:
+                collapsed = collapse_column(desc) if desc else ""
 
             row = {
                 "ID": item.get("id", ""),
                 "Title": item.get("title", ""),
-                "Description": collapse_column(desc) if desc else "",
+                "Description": collapsed,
                 "Category": item.get("category", ""),
             }
             rows.append(row)
 
         df = pd.DataFrame(rows).sort_values("ID")
-        return df.to_markdown(index=False)
+        table = df.to_markdown(index=False)
+
+        # Append per-entry References sub-sections for entries with externalReferences.
+        sections = [table]
+        for entry in sorted_items:
+            refs = entry.get("externalReferences")
+            if refs:
+                sections.append(f"\n## References for {entry['id']}\n{_references_bullets_only(refs)}")
+
+        return "\n".join(sections)
 
 
 class PersonaSummaryTableGenerator(TableGenerator):
@@ -822,6 +963,38 @@ def yaml_to_markdown_table(yaml_file, ytype, table_format: str = "full", flat: b
     # Get input directory for cross-reference lookups
     input_dir = Path(yaml_file).parent
 
+    # Build intra_lookup from all four corpus files; tolerate missing siblings.
+    # XRef generators don't expand prose, but passing lookups here is harmless.
+    intra_lookup: dict[str, str] = {}
+    for fname, key in (
+        ("risks.yaml", "risks"),
+        ("controls.yaml", "controls"),
+        ("components.yaml", "components"),
+        ("personas.yaml", "personas"),
+    ):
+        fpath = input_dir / fname
+        if not fpath.exists():
+            continue
+        with open(fpath) as fh:
+            sibling = yaml.safe_load(fh) or {}
+        for item in sibling.get(key, []) or []:
+            if isinstance(item, dict) and "id" in item and "title" in item:
+                intra_lookup[item["id"]] = item["title"]
+
+    # Build flat ref_lookup from this file's externalReferences entries.
+    # ADR-016 D2 enforces per-entry id uniqueness but allows cross-entry collision
+    # (two risks may each define ref id "cwe-89"). This flat lookup last-write-wins
+    # on collision; per-entry keying (matching _build_ref_lookup in
+    # build_persona_site_data.py) is the correct long-term fix and is deferred
+    # to a Phase B B2 follow-up since the current corpus has zero externalReferences.
+    ref_lookup: dict[str, dict] = {}
+    for entry in data.get(ytype, []) or []:
+        if not isinstance(entry, dict):
+            continue
+        for ref in entry.get("externalReferences") or []:
+            if isinstance(ref, dict) and "id" in ref:
+                ref_lookup[ref["id"]] = {"title": ref.get("title", ""), "url": ref.get("url", "")}
+
     # Create generator instance and generate table
     # Handle persona-specific generators
     if ytype == "personas":
@@ -849,7 +1022,7 @@ def yaml_to_markdown_table(yaml_file, ytype, table_format: str = "full", flat: b
         else:
             generator_class = TABLE_GENERATORS[table_format]
 
-    generator = generator_class(input_dir=input_dir)
+    generator = generator_class(input_dir=input_dir, intra_lookup=intra_lookup, ref_lookup=ref_lookup)
 
     return generator.generate(data, ytype)
 

--- a/scripts/hooks/yaml_to_markdown.py
+++ b/scripts/hooks/yaml_to_markdown.py
@@ -477,9 +477,11 @@ class PersonaSummaryTableGenerator(TableGenerator):
             df = pd.DataFrame(rows).sort_values("ID")
         table = df.to_markdown(index=False)
 
-        # Append per-persona References sub-sections in insertion order.
+        # Append per-persona References sub-sections in id-sorted order so they
+        # follow the table's row order (the DataFrame is sort_values("ID") above).
+        sorted_items = sorted(items, key=lambda e: e.get("id", ""))
         sections = [table]
-        for entry in items:
+        for entry in sorted_items:
             refs = entry.get("externalReferences")
             if refs:
                 sections.append(f"\n## References for {entry['id']}\n{_references_bullets_only(refs)}")
@@ -573,9 +575,11 @@ class PersonaFullDetailTableGenerator(TableGenerator):
             df = pd.DataFrame(rows).sort_values("ID")
         table = df.to_markdown(index=False)
 
-        # Append per-persona References sub-sections in insertion order.
+        # Append per-persona References sub-sections in id-sorted order so they
+        # follow the table's row order (the DataFrame is sort_values("ID") above).
+        sorted_items = sorted(items, key=lambda e: e.get("id", ""))
         sections = [table]
-        for entry in items:
+        for entry in sorted_items:
             refs = entry.get("externalReferences")
             if refs:
                 sections.append(f"\n## References for {entry['id']}\n{_references_bullets_only(refs)}")

--- a/scripts/hooks/yaml_to_markdown.py
+++ b/scripts/hooks/yaml_to_markdown.py
@@ -450,12 +450,22 @@ class PersonaSummaryTableGenerator(TableGenerator):
 
         items = yaml_data.get("personas", [])
         rows = []
-        for item in items:
+        for idx, item in enumerate(items):
             desc = item.get("description", "")
+            if desc and self.intra_lookup is not None and self.ref_lookup is not None:
+                # Expand sentinels in description; field_path uses insertion-order index.
+                collapsed = collapse_column(
+                    desc,
+                    intra_lookup=self.intra_lookup,
+                    ref_lookup=self.ref_lookup,
+                    field_path=f"personas[{idx}].description",
+                )
+            else:
+                collapsed = collapse_column(desc) if desc else ""
             row = {
                 "ID": item.get("id", ""),
                 "Title": item.get("title", ""),
-                "Description": collapse_column(desc) if desc else "",
+                "Description": collapsed,
                 "Status": "Deprecated" if item.get("deprecated", False) else "",
             }
             rows.append(row)
@@ -465,7 +475,16 @@ class PersonaSummaryTableGenerator(TableGenerator):
             df = pd.DataFrame(columns=["ID", "Title", "Description", "Status"])
         else:
             df = pd.DataFrame(rows).sort_values("ID")
-        return df.to_markdown(index=False)
+        table = df.to_markdown(index=False)
+
+        # Append per-persona References sub-sections in insertion order.
+        sections = [table]
+        for entry in items:
+            refs = entry.get("externalReferences")
+            if refs:
+                sections.append(f"\n## References for {entry['id']}\n{_references_bullets_only(refs)}")
+
+        return "\n".join(sections)
 
 
 class PersonaFullDetailTableGenerator(TableGenerator):
@@ -490,14 +509,49 @@ class PersonaFullDetailTableGenerator(TableGenerator):
 
         items = yaml_data.get("personas", [])
         rows = []
-        for item in items:
+        for idx, item in enumerate(items):
+            desc = item.get("description", "")
+            if self.intra_lookup is not None and self.ref_lookup is not None:
+                # Expand sentinels in description; field_path uses insertion-order index.
+                collapsed_desc = collapse_column(
+                    desc,
+                    intra_lookup=self.intra_lookup,
+                    ref_lookup=self.ref_lookup,
+                    field_path=f"personas[{idx}].description",
+                )
+                # Expand sentinels in each responsibilities item before passing to format_list.
+                expanded_resp = [
+                    expand_sentinels_to_text(
+                        r,
+                        intra_lookup=self.intra_lookup,
+                        ref_lookup=self.ref_lookup,
+                        field_path=f"personas[{idx}].responsibilities[{i}]",
+                    )
+                    for i, r in enumerate(item.get("responsibilities", []))
+                ]
+                # Expand sentinels in each identificationQuestions item.
+                expanded_idq = [
+                    expand_sentinels_to_text(
+                        q,
+                        intra_lookup=self.intra_lookup,
+                        ref_lookup=self.ref_lookup,
+                        field_path=f"personas[{idx}].identificationQuestions[{i}]",
+                    )
+                    for i, q in enumerate(item.get("identificationQuestions", []))
+                ]
+            else:
+                # No lookups: pass through unchanged (pre-A7 backward compat).
+                collapsed_desc = collapse_column(desc)
+                expanded_resp = item.get("responsibilities", [])
+                expanded_idq = item.get("identificationQuestions", [])
+
             row = {
                 "ID": item.get("id", ""),
                 "Title": item.get("title", ""),
-                "Description": collapse_column(item.get("description", "")),
+                "Description": collapsed_desc,
                 "Status": "Deprecated" if item.get("deprecated", False) else "",
-                "Responsibilities": format_list(item.get("responsibilities", []), prefix="- "),
-                "Identification Questions": format_list(item.get("identificationQuestions", []), prefix="- "),
+                "Responsibilities": format_list(expanded_resp, prefix="- "),
+                "Identification Questions": format_list(expanded_idq, prefix="- "),
                 "Mappings": format_mappings(item.get("mappings", {})),
             }
             rows.append(row)
@@ -517,7 +571,16 @@ class PersonaFullDetailTableGenerator(TableGenerator):
             )
         else:
             df = pd.DataFrame(rows).sort_values("ID")
-        return df.to_markdown(index=False)
+        table = df.to_markdown(index=False)
+
+        # Append per-persona References sub-sections in insertion order.
+        sections = [table]
+        for entry in items:
+            refs = entry.get("externalReferences")
+            if refs:
+                sections.append(f"\n## References for {entry['id']}\n{_references_bullets_only(refs)}")
+
+        return "\n".join(sections)
 
 
 class PersonaXRefTableGenerator(TableGenerator):

--- a/scripts/hooks/yaml_to_markdown.py
+++ b/scripts/hooks/yaml_to_markdown.py
@@ -166,6 +166,16 @@ def _references_bullets_only(refs: list[dict] | None) -> str:
     return rendered
 
 
+def _build_ref_lookup(entry: dict) -> dict[str, dict]:
+    """Build a ref-id -> {"title", "url"} map from a single entity's externalReferences.
+
+    Per ADR-016 D6 rule 3, ref-id resolution scope is per-entry: a ref id
+    declared on one entry must not resolve from a sibling entry's
+    externalReferences. Mirrors scripts/build_persona_site_data.py's helper.
+    """
+    return {ref["id"]: {"title": ref["title"], "url": ref["url"]} for ref in entry.get("externalReferences", [])}
+
+
 def collapse_column(
     entry,
     *,
@@ -247,6 +257,18 @@ class TableGenerator(ABC):
         self.intra_lookup = intra_lookup
         self.ref_lookup = ref_lookup
         self._yaml_cache = {}  # Cache for loaded YAML files
+
+    def _ref_lookup_for_entry(self, entry: dict) -> dict[str, dict]:
+        """Return per-entry ref lookup; fall back to constructor lookup for legacy/test paths.
+
+        Public path (yaml_to_markdown_table) passes ref_lookup={} so cross-entry
+        refs hard-fail per ADR-016 D6 rule 3. The fallback supports tests that
+        inject a flat ref_lookup directly into the constructor.
+        """
+        local = _build_ref_lookup(entry)
+        if local:
+            return local
+        return self.ref_lookup or {}
 
     @abstractmethod
     def generate(self, yaml_data: dict, ytype: str) -> str:
@@ -332,12 +354,15 @@ class FullDetailTableGenerator(TableGenerator):
             if col in collapsable:
                 if self.intra_lookup is not None and self.ref_lookup is not None:
                     # Per-row expansion: thread row index into field_path for error messages.
+                    # entries[row_idx] aligns with df.at[row_idx, col] because df is built
+                    # from `entries` (insertion order, line above) and sort_values runs only
+                    # at line 354 — after this loop completes.
                     df = df.reset_index(drop=True)
                     for row_idx in range(len(df)):
                         df.at[row_idx, col] = collapse_column(
                             df.at[row_idx, col],
                             intra_lookup=self.intra_lookup,
-                            ref_lookup=self.ref_lookup,
+                            ref_lookup=self._ref_lookup_for_entry(entries[row_idx]),
                             field_path=f"{ytype}[{row_idx}].{col}",
                         )
                 else:
@@ -401,7 +426,7 @@ class SummaryTableGenerator(TableGenerator):
                 collapsed = collapse_column(
                     desc,
                     intra_lookup=self.intra_lookup,
-                    ref_lookup=self.ref_lookup,
+                    ref_lookup=self._ref_lookup_for_entry(item),
                     field_path=f"{ytype}[{row_idx}].{field_name}",
                 )
             else:
@@ -457,7 +482,7 @@ class PersonaSummaryTableGenerator(TableGenerator):
                 collapsed = collapse_column(
                     desc,
                     intra_lookup=self.intra_lookup,
-                    ref_lookup=self.ref_lookup,
+                    ref_lookup=self._ref_lookup_for_entry(item),
                     field_path=f"personas[{idx}].description",
                 )
             else:
@@ -514,11 +539,13 @@ class PersonaFullDetailTableGenerator(TableGenerator):
         for idx, item in enumerate(items):
             desc = item.get("description", "")
             if self.intra_lookup is not None and self.ref_lookup is not None:
+                # Build per-entry lookup once and reuse across all three expansion sites.
+                row_ref_lookup = self._ref_lookup_for_entry(item)
                 # Expand sentinels in description; field_path uses insertion-order index.
                 collapsed_desc = collapse_column(
                     desc,
                     intra_lookup=self.intra_lookup,
-                    ref_lookup=self.ref_lookup,
+                    ref_lookup=row_ref_lookup,
                     field_path=f"personas[{idx}].description",
                 )
                 # Expand sentinels in each responsibilities item before passing to format_list.
@@ -526,7 +553,7 @@ class PersonaFullDetailTableGenerator(TableGenerator):
                     expand_sentinels_to_text(
                         r,
                         intra_lookup=self.intra_lookup,
-                        ref_lookup=self.ref_lookup,
+                        ref_lookup=row_ref_lookup,
                         field_path=f"personas[{idx}].responsibilities[{i}]",
                     )
                     for i, r in enumerate(item.get("responsibilities", []))
@@ -536,7 +563,7 @@ class PersonaFullDetailTableGenerator(TableGenerator):
                     expand_sentinels_to_text(
                         q,
                         intra_lookup=self.intra_lookup,
-                        ref_lookup=self.ref_lookup,
+                        ref_lookup=row_ref_lookup,
                         field_path=f"personas[{idx}].identificationQuestions[{i}]",
                     )
                     for i, q in enumerate(item.get("identificationQuestions", []))
@@ -1048,19 +1075,11 @@ def yaml_to_markdown_table(yaml_file, ytype, table_format: str = "full", flat: b
             if isinstance(item, dict) and "id" in item and "title" in item:
                 intra_lookup[item["id"]] = item["title"]
 
-    # Build flat ref_lookup from this file's externalReferences entries.
-    # ADR-016 D2 enforces per-entry id uniqueness but allows cross-entry collision
-    # (two risks may each define ref id "cwe-89"). This flat lookup last-write-wins
-    # on collision; per-entry keying (matching _build_ref_lookup in
-    # build_persona_site_data.py) is the correct long-term fix and is deferred
-    # to a Phase B B2 follow-up since the current corpus has zero externalReferences.
+    # ref_lookup is built per-entry by the generator via _ref_lookup_for_entry;
+    # this matches build_persona_site_data.py's _build_ref_lookup pattern
+    # (ADR-016 D6 rule 3, per-entry resolution scope). The empty dict here makes
+    # any sentinel that escapes per-entry lookup hard-fail.
     ref_lookup: dict[str, dict] = {}
-    for entry in data.get(ytype, []) or []:
-        if not isinstance(entry, dict):
-            continue
-        for ref in entry.get("externalReferences") or []:
-            if isinstance(ref, dict) and "id" in ref:
-                ref_lookup[ref["id"]] = {"title": ref.get("title", ""), "url": ref.get("url", "")}
 
     # Create generator instance and generate table
     # Handle persona-specific generators

--- a/scripts/hooks/yaml_to_markdown.py
+++ b/scripts/hooks/yaml_to_markdown.py
@@ -355,8 +355,8 @@ class FullDetailTableGenerator(TableGenerator):
                 if self.intra_lookup is not None and self.ref_lookup is not None:
                     # Per-row expansion: thread row index into field_path for error messages.
                     # entries[row_idx] aligns with df.at[row_idx, col] because df is built
-                    # from `entries` (insertion order, line above) and sort_values runs only
-                    # at line 354 — after this loop completes.
+                    # from `entries` (insertion order, line above) and sort_values on
+                    # df_filled runs only after this loop completes.
                     df = df.reset_index(drop=True)
                     for row_idx in range(len(df)):
                         df.at[row_idx, col] = collapse_column(


### PR DESCRIPTION
## Conformance sweep A7: builder updates (sentinel expansion)

Closes #269

## Summary

- **Threads ADR-016 D5 sentinel expansion through both downstream builders** — `scripts/build_persona_site_data.py` (persona-site producer; ADR-011 contract holder) and `scripts/hooks/yaml_to_markdown.py` (table generator).
- **Authors a shared expansion helper** `scripts/hooks/_sentinel_expansion.py` consumed by both builders — single tokenizer + sentinel-resolution surface so persona-site (structured) and table-generator (markdown) emissions stay in lockstep on grammar.
- **Per ADR-016 D5 wire form `{{<entity-id>}}`**: intra-doc `{{<entity-id>}}` resolves against an `intra_lookup` to the entity's title; external `{{ref:<identifier>}}` resolves against a per-entry `ref_lookup` (built from each entry's `externalReferences`) to a typed link or "title (url)" string per the consumer convention. `externalReferences` arrays pass through unchanged.
- **Hard-fails on unresolved sentinels** — `UnresolvedSentinelError` propagates from both builders. CI catches a typo'd sentinel before the corpus is regenerated.
- **All 4 wired generators emit per-entry `## References for {id}` sub-sections** (`SummaryTableGenerator`, `FullDetailTableGenerator`, `PersonaSummaryTableGenerator`, `PersonaFullDetailTableGenerator`) — id-sorted to match table-row order; bullet-list formatter shared.
- **Backward-compatible by default**: both `intra_lookup` and `ref_lookup` parameters default to `None`; passing `None` produces the identical pre-A7 passthrough, so generators / consumers that don't yet supply lookups remain green. Verified by byte-identity comparisons against pre-A7 generator output on the live corpus, preserved through every post-review commit.

## Commit-by-commit

| # | SHA | Subject | Role |
|---|---|---|---|
| 1 | `a0b0f74` | `feat(builder): expand sentinels in persona site data` | SWE — `build_persona_site_data.py` + new `_sentinel_expansion.py` helper |
| 2 | `be61b38` | `feat(generator): expand sentinels in yaml_to_markdown tables` | SWE — `yaml_to_markdown.py` `collapse_column` + `format_external_references` + `## References` sub-section emission |
| 3 | `9668278` | `chore(tests): reword RED-phase comments now that helpers exist` | tests — declarative present-tense rewording of import-guard docstrings (mirrors A3's precedent in `test_prose_tokens.py`) |
| 4 | `05318e5` | `feat(generator): expand sentinels in persona table generators` | SWE — `PersonaSummaryTableGenerator` + `PersonaFullDetailTableGenerator`; same-file scope close per the A8 lesson |
| 5 | `39574d2` | `chore(generator): align persona References ordering + tighten test docs` | SWE — full-branch reviewer fixes (M1 sort-order parity + M2 RED-phrasing scrub + L1 count correction) |
| 6 | `ebe4504` | `fix(builder): expand sentinels in nested prose groups` | SWE — closes review comment 3205726385; `normalize_text_entries` nested-list branch now mirrors the str-leaf branch via `expand_sentinels_to_items`, ADR-016 D5 hard-fail |
| 7 | `71987bb` | `fix(generator): scope ref_lookup per-entry in yaml_to_markdown` | SWE — closes review comment 3205728391; `_build_ref_lookup(entry)` + `_ref_lookup_for_entry` thread per-entry lookups through all four generator classes; ADR-016 D6 rule 3 |
| 8 | `4a8c066` | `chore(generator): drop stale line-number from row-alignment comment` | housekeeping — internal review caught a stale `line 354` reference in the `FullDetailTableGenerator` row-alignment comment; replaced with a behavioural description |
| 9 | `67f184e` | `fix(builder): expand sentinels in identificationQuestions` | SWE — internal review surfaced a builder/markdown asymmetry on `identificationQuestions`; builder now expands per question via `expand_sentinels_to_text`, matching `PersonaFullDetailTableGenerator` and applying ADR-016 D5 hard-fail to that field on both sides |

> SHAs reflect the post-rebase branch state (`upstream/main` at `d84a26f`). The originally-posted commit list referenced pre-rebase SHAs; the rebase replayed those five commits unchanged, and rows 6-9 are the post-review additions.

## Architect-tagged vs. SWE-tagged commits

All 9 commits are SWE/testing-authored implementation. No ADR amendments are required for A7 — ADR-016 D5's wire format was settled in A8 (PR #272 / `{{<entity-id>}}`) and the builders implement that contract verbatim.

Commits 1+2 land the core builder/generator changes; commit 3 is a tests-only RED-phase scrub follow-up to commits 1+2; commit 4 closes the same-file persona-generator scope that the A8 amendment lesson surfaced; commit 5 lands the full-branch reviewer's required fixes. Commits 6+7 address shrey-bagga's two `[major]` review items — both fixes pulled in *because* the original deferrals were bounded by current corpus state ("nested groups have no sentinels today," "zero externalReferences in corpus today") rather than the ADR-decision contract; `feedback_scope_bounding.md` rule applied to both. Commit 8 is a housekeeping cleanup from an internal review. Commit 9 closes a builder/markdown asymmetry on `identificationQuestions` that the same review surfaced — a related sibling of the same pattern (scope bounded by the field's `string[]` schema shape rather than by D5's "every prose-field leaf walked" decision).

## Scope boundaries

In scope (this PR):
- New: `scripts/hooks/_sentinel_expansion.py` — shared expansion helper hosting `expand_sentinels_to_text`, `expand_sentinels_to_items`, lookup-builder utilities, `UnresolvedSentinelError`
- Edit: `scripts/build_persona_site_data.py` — `normalize_text_entries` + `build_site_data` thread `intra_lookup` / `ref_lookup`; nested-list inner strings now expand per ADR-016 D5 (commit 6); `identificationQuestions` now expand per question via `expand_sentinels_to_text` (commit 9); per-persona `externalReferences` pass-through; structured prose items per ADR-011 contract extension landed in A2 PR #261
- Edit: `scripts/hooks/yaml_to_markdown.py`:
  - `collapse_column` accepts `intra_lookup` / `ref_lookup` (default `None`); both expand inline
  - `format_external_references` (new) emits the `## References for {id}` bullet-list sub-section
  - `yaml_to_markdown_table` assembles `intra_lookup` from sibling YAML files; per-entry `ref_lookup` is built inside each generator via the new `_build_ref_lookup(entry)` helper + `TableGenerator._ref_lookup_for_entry` method (commit 7), restoring lockstep with `build_persona_site_data.py`'s sister helper
  - `PersonaSummaryTableGenerator` + `PersonaFullDetailTableGenerator` thread the same lookups through `description`, expand sentinels per-item in `responsibilities` + `identificationQuestions`, and emit per-entry References in id-sorted order
- New tests:
  - `scripts/hooks/tests/test_sentinel_expansion.py` — shared helper unit + behavioral tests
  - `scripts/hooks/tests/test_build_persona_site_data_sentinel_expansion.py` — persona-site producer behavioral tests, including `TestNestedGroupSentinelExpansion` (commit 6) and `TestIdentificationQuestionsSentinelExpansion` (commit 9)
  - `scripts/hooks/tests/test_yaml_to_markdown_sentinel_expansion.py` — table-generator + risk/control sub-section emission, including `TestPerEntryRefLookupCollision` (commit 7)
  - `scripts/hooks/tests/test_yaml_to_markdown_persona_sentinel_expansion.py` — persona-generator coverage, including `TestPersonaPerEntryRefLookupCollision` (commit 7)

Out of scope (deferred):
- **YAML content migration to sentinels** → Phase B (B1 + B2 sub-PRs on `develop`); A7 ships builders that handle pre-migration corpus (no sentinels) and post-migration corpus (sentinels) interchangeably without configuration changes
- **Schema changes** → A2's territory (already merged via PR #261)
- **Validator extensions** → A4's territory (in flight; PR open against #268)
- **Block-mode flip on warn-only linters** → sweep-closing sub-PR (plan § 2.7.1)
- **Site renderer (`renderProse` activation)** → A6's territory (sanitizer landed dormant via PR #245; activation tracked at follow-up #254)

## Test plan

- [x] `pytest scripts/hooks/tests` clean (2125 passed / 5 skipped) — +47 new tests across nested-group, per-entry-collision, and idQuestions-expansion coverage since the initial review
- [x] `ruff check` + `ruff format --check` clean
- [x] `pre-commit run --all-files` clean (warn-only diagnostics from A3 prose linters present per pre-A7 baseline; A7 introduces no new warn-only diagnostics)
- [x] Byte-identity preserved on both regenerated artifacts: `risk-map/tables/**` and `site/generated/persona-site-data.json` — verified after each post-review commit
- [x] Live corpus regenerates without `UnresolvedSentinelError` (no sentinels in current YAML; safety-net fail-fast verified by negative-fixture tests in all three sentinel-expansion test suites)
- [ ] Reviewer spot-check on at least one persona-page render (after merge → develop content migration → site activation in #254)

