### PR TITLE
Conformance sweep A4: validator extensions (6 ADR-driven checks)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -225,6 +225,13 @@ repos:
         files: ^risk-map/yaml/(controls|frameworks|personas|risks)\.yaml$
         pass_filenames: false
 
+      - id: validate-lifecycle-stage
+        name: 'risk-map: lifecycle stage order uniqueness'
+        language: system
+        entry: python3 scripts/hooks/validate_riskmap.py --mode lifecycle
+        files: ^risk-map/yaml/lifecycle-stage\.yaml$
+        pass_filenames: false
+
       - id: validate-workflow-uses-pinning
         name: 'github-actions: enforce SHA-pinned uses references'
         language: system

--- a/scripts/hooks/precommit/_prose_tokens.py
+++ b/scripts/hooks/precommit/_prose_tokens.py
@@ -150,6 +150,18 @@ _RE_PIPE_TABLE_ROW = re.compile(r"\|[^\n]*(?:\n|$)")
 # Folded-bullet drift (ADR-020 D4): at least one leading whitespace char, then "- ",
 # then the rest of the line up to (and including) the trailing \n or end of string.
 # Leading whitespace distinguishes this from column-0 list markers (INVALID_LIST).
+#
+# Source-form vs. parsed-form drift distinction:
+#   Source-form drift: the raw decoded string retains indentation (e.g. from quoted
+#   scalars or literal-block scalars), so "   - item" lines arrive with leading
+#   whitespace — caught here as INVALID_FOLDED_BULLET.
+#
+#   Parsed-form drift: YAML's ">" folded-scalar parser collapses indentation, so
+#   embedded "- item" lines arrive at column 0 in the Python string.  These fire
+#   INVALID_LIST (Rule 5), not INVALID_FOLDED_BULLET.  Both real-world cases from
+#   issue #225 use ">" folded scalars and therefore surface as INVALID_LIST.
+#   The INVALID_LIST diagnostic message cross-references ADR-020 D4 so readers
+#   understand the connection between the two code paths.
 _RE_FOLDED_BULLET = re.compile(r"\s+\-\s[^\n]*(?:\n|$)")
 
 # Sentinel ref identifier: letters, digits, hyphens, underscores, and dots.

--- a/scripts/hooks/precommit/validate_yaml_prose_subset.py
+++ b/scripts/hooks/precommit/validate_yaml_prose_subset.py
@@ -67,7 +67,9 @@ _REASONS: dict[TokenKind, str] = {
     TokenKind.INVALID_URL: "inline URL not permitted in prose; use externalReferences + {{ref:...}} sentinel",
     TokenKind.INVALID_HTML: "raw HTML tag not permitted in prose",
     TokenKind.INVALID_HEADING: "markdown heading not permitted in prose",
-    TokenKind.INVALID_LIST: "markdown list marker at column 0 not permitted in prose",
+    TokenKind.INVALID_LIST: (
+        "list marker at column 0 not permitted in prose (may be folded-bullet drift — see ADR-020 D4)"
+    ),
     TokenKind.INVALID_CODE: "code block / inline code not permitted in prose",
     TokenKind.INVALID_IMAGE: "markdown image not permitted in prose",
     TokenKind.INVALID_BLOCKQUOTE: "markdown blockquote not permitted in prose",

--- a/scripts/hooks/riskmap_validator/graphing/base.py
+++ b/scripts/hooks/riskmap_validator/graphing/base.py
@@ -28,7 +28,7 @@ import yaml
 
 from riskmap_validator.models import ComponentNode, ControlNode, RiskNode
 
-from .graph_utils import MermaidConfigLoader, UnionFind
+from .graph_utils import MermaidConfigLoader, UnionFind, _get_schema_categories
 
 
 class BaseGraph:
@@ -61,6 +61,10 @@ class BaseGraph:
                 instance using default configuration paths.
         """
         self.config_loader = config_loader or MermaidConfigLoader.get_instance()
+        # Emit a warning for each schema category that lacks a styling entry.
+        # Fires once per (message, category, module) by default; test suites using
+        # warnings.simplefilter("always") will see all occurrences.
+        self.config_loader.emit_missing_category_warnings(_get_schema_categories())
         self._category_names_cache = None
         self.controls: dict[str, ControlNode] = {}
         self.risks: dict[str, RiskNode] = {}

--- a/scripts/hooks/riskmap_validator/graphing/graph_utils.py
+++ b/scripts/hooks/riskmap_validator/graphing/graph_utils.py
@@ -1,9 +1,46 @@
+import json
 from pathlib import Path
 from typing import Any
 
 import yaml
 
 from ..config import DEFAULT_MERMAID_CONFIG_FILE
+
+# ---------------------------------------------------------------------------
+# Schema category helper
+# ---------------------------------------------------------------------------
+
+_schema_categories_cache: set[str] | None = None
+
+
+def _get_schema_categories() -> set[str]:
+    """
+    Read component category IDs from components.schema.json, with caching.
+
+    Resolves the schema path relative to this file's location:
+    scripts/hooks/riskmap_validator/graphing/graph_utils.py
+    parents[4] is the worktree root, giving:
+    <root>/risk-map/schemas/components.schema.json
+
+    Returns:
+        Set of category ID strings declared in the schema enum.
+        Returns empty set on any error (file missing, JSON parse error,
+        unexpected key structure) so callers degrade gracefully.
+    """
+    global _schema_categories_cache
+    if _schema_categories_cache is not None:
+        return _schema_categories_cache
+
+    try:
+        schema_path = Path(__file__).resolve().parents[4] / "risk-map" / "schemas" / "components.schema.json"
+        with open(schema_path, encoding="utf-8") as fh:
+            schema = json.load(fh)
+        _schema_categories_cache = set(schema["definitions"]["category"]["properties"]["id"]["enum"])
+    except Exception:
+        # Degrade gracefully: missing file, bad JSON, or unexpected key structure.
+        _schema_categories_cache = set()
+
+    return _schema_categories_cache
 
 
 class MermaidConfigLoader:

--- a/scripts/hooks/riskmap_validator/graphing/graph_utils.py
+++ b/scripts/hooks/riskmap_validator/graphing/graph_utils.py
@@ -342,6 +342,54 @@ class MermaidConfigLoader:
         result = self._get_safe_value("sharedElements", "componentCategories", default={})
         return result if isinstance(result, dict) else {}
 
+    def get_missing_category_warnings(self, schema_categories: set[str]) -> list[str]:
+        """
+        Return one warning string per schema category absent from styling config.
+
+        Checks schema_categories against the keys in
+        sharedElements.componentCategories in the loaded config (or emergency
+        defaults). Direction is schema → styling only: extra styling keys that
+        the schema does not enumerate are ignored and produce no warning.
+
+        Args:
+            schema_categories: Set of category IDs declared by
+                components.schema.json (e.g. from the "id" enum). Caller is
+                responsible for deriving this set; this method does not load
+                the schema itself.
+
+        Returns:
+            List of warning strings, one per missing category. Each string
+            contains the missing category ID. Returns [] when every schema
+            category has a styling entry, or when schema_categories is empty.
+        """
+        if not schema_categories:
+            return []
+
+        styled_keys = set(self.get_component_category_styles().keys())
+        return [
+            f"Missing styling entry for component category '{cat}' in componentCategories config"
+            for cat in schema_categories
+            if cat not in styled_keys
+        ]
+
+    def emit_missing_category_warnings(self, schema_categories: set[str]) -> None:
+        """
+        Emit a warning for each schema category absent from styling config.
+
+        Thin wrapper around get_missing_category_warnings() that surfaces
+        warnings via the standard warnings module so they are visible to
+        operators at runtime without requiring callers to inspect the return
+        value.
+
+        Args:
+            schema_categories: Set of category IDs declared by
+                components.schema.json. See get_missing_category_warnings().
+        """
+        import warnings
+
+        for message in self.get_missing_category_warnings(schema_categories):
+            warnings.warn(message, stacklevel=2)
+
     def get_css_classes(self) -> dict:
         """
         Get CSS class definitions for graph styling.

--- a/scripts/hooks/riskmap_validator/validator.py
+++ b/scripts/hooks/riskmap_validator/validator.py
@@ -3,6 +3,7 @@ Core validation logic for component edge consistency and lifecycle stage orderin
 
 Provides the ComponentEdgeValidator class that validates bidirectional
 edge consistency in component relationship YAML files, the
+LifecycleOrderCheckResult dataclass returned by the lifecycle check,
 check_lifecycle_stage_order_uniqueness function that validates order
 uniqueness across lifecycle stage entries, check_controls_components_mirror
 that validates control→component references against the component ID set

--- a/scripts/hooks/riskmap_validator/validator.py
+++ b/scripts/hooks/riskmap_validator/validator.py
@@ -1,15 +1,19 @@
 """
-Core validation logic for component edge consistency.
+Core validation logic for component edge consistency and lifecycle stage ordering.
 
 Provides the ComponentEdgeValidator class that validates bidirectional
-edge consistency in component relationship YAML files.
+edge consistency in component relationship YAML files, and the
+check_lifecycle_stage_order_uniqueness function that validates order
+uniqueness across lifecycle stage entries.
 
 Dependencies:
     - PyYAML: For YAML file parsing
     - .models: ComponentNode data model
 """
 
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from .models import ComponentNode
 from .utils import parse_components_yaml
@@ -215,3 +219,65 @@ class ComponentEdgeValidator:
         except EdgeValidationError as e:
             self.log(f"Validation error: {e}", "error")
             return False
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle stage order uniqueness check (ADR-022 D4)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LifecycleOrderCheckResult:
+    """
+    Result of a lifecycle stage order uniqueness check.
+
+    Attributes:
+        is_valid: True when all order values are unique, False if any duplicate found.
+        errors: List of human-readable error strings, empty on success.
+    """
+
+    is_valid: bool
+    errors: list[str] = field(default_factory=list)
+
+
+def check_lifecycle_stage_order_uniqueness(data: dict[str, Any]) -> LifecycleOrderCheckResult:
+    """
+    Check that every lifecycleStage carries a unique order value.
+
+    Per ADR-022 D4: uniqueness across array items is awkward in JSON Schema;
+    this validator check is the cleaner path. This function blocks immediately
+    on any duplicate — there is no warn-only mode, because the corpus is clean
+    at landing.
+
+    The function assumes each stage dict contains an 'order' key (integer). Structural
+    validation (missing keys, wrong types) is the schema layer's responsibility.
+
+    Args:
+        data: Parsed lifecycle-stage YAML content, expected shape:
+              {"lifecycleStages": [{"id": str, "order": int, ...}, ...]}
+
+    Returns:
+        LifecycleOrderCheckResult with is_valid=True and empty errors if all
+        order values are unique; is_valid=False and a non-empty errors list
+        identifying each set of colliding stage IDs and the duplicated value.
+    """
+    stages: list[dict[str, Any]] = data.get("lifecycleStages", [])
+
+    # Map each order value to the list of stage IDs that carry it.
+    order_to_ids: dict[int, list[str]] = {}
+    for stage in stages:
+        order = stage["order"]
+        stage_id = stage["id"]
+        order_to_ids.setdefault(order, []).append(stage_id)
+
+    errors: list[str] = []
+    for order_value, ids in order_to_ids.items():
+        if len(ids) > 1:
+            # Include both the duplicated value and all colliding IDs so a developer
+            # reading CI output can locate the defect without inspecting the YAML directly.
+            colliders = ", ".join(ids)
+            errors.append(
+                f"Duplicate lifecycleStage order value {order_value}: stages [{colliders}] all carry this order"
+            )
+
+    return LifecycleOrderCheckResult(is_valid=len(errors) == 0, errors=errors)

--- a/scripts/hooks/riskmap_validator/validator.py
+++ b/scripts/hooks/riskmap_validator/validator.py
@@ -4,9 +4,11 @@ Core validation logic for component edge consistency and lifecycle stage orderin
 Provides the ComponentEdgeValidator class that validates bidirectional
 edge consistency in component relationship YAML files, the
 check_lifecycle_stage_order_uniqueness function that validates order
-uniqueness across lifecycle stage entries, and check_controls_components_mirror
+uniqueness across lifecycle stage entries, check_controls_components_mirror
 that validates control→component references against the component ID set
-(ADR-020 D7).
+(ADR-020 D7), and check_category_subcategory_nesting that validates each
+component's (category, subcategory) pair against the categories block
+declaration (ADR-018 D6).
 
 Dependencies:
     - PyYAML: For YAML file parsing
@@ -325,6 +327,61 @@ def check_controls_components_mirror(
                 warnings.append(
                     f"Control '{control_id}' references component '{component_ref}' "
                     f"which does not exist in components.yaml"
+                )
+
+    return warnings
+
+
+# ---------------------------------------------------------------------------
+# Category/subcategory nesting check (ADR-018 D6 / task 2.3.9)
+# ---------------------------------------------------------------------------
+
+
+def check_category_subcategory_nesting(
+    components: dict[str, ComponentNode],
+    category_to_subcategories: dict[str, set[str]],
+) -> list[str]:
+    """
+    Check that every component's (category, subcategory) pair is declared in the
+    categories block.
+
+    Per ADR-018 D6: the schema enforces individual enum membership but not
+    cross-field nesting (e.g., a component can pass schema with category=A,
+    subcategory=B even when B is nested under category=C). This validator closes
+    that gap.
+
+    Two warning classes are emitted (Path A, orchestrator-pinned):
+      Class 1 (mismatch): subcategory is present but not nested under the
+        claimed category.  Covers unknown categories too — a category absent
+        from category_to_subcategories has no valid subcategories.
+      Class 2 (absent): subcategory is None (missing).
+
+    The component ID in warnings is the dict key, not ComponentNode.title.
+
+    Args:
+        components: Dict mapping component IDs to ComponentNode objects, as
+                    returned by parse_components_yaml().
+        category_to_subcategories: Maps each top-level category ID to the set
+                    of valid subcategory IDs declared under it.  Build this from
+                    the YAML's top-level ``categories:`` block.
+
+    Returns:
+        List of human-readable warning strings; empty when all pairs are valid.
+    """
+    warnings: list[str] = []
+
+    for component_id, node in components.items():
+        if node.subcategory is None:
+            # Class 2: subcategory absent — surface for content debt tracking.
+            warnings.append(f"Component '{component_id}' (category '{node.category}') is missing a subcategory")
+        else:
+            # Class 1: subcategory present — check it is nested under the claimed category.
+            # An unknown category is treated as having no valid subcategories.
+            valid_subcategories = category_to_subcategories.get(node.category, set())
+            if node.subcategory not in valid_subcategories:
+                warnings.append(
+                    f"Component '{component_id}' claims category '{node.category}' "
+                    f"but subcategory '{node.subcategory}' is not nested under that category"
                 )
 
     return warnings

--- a/scripts/hooks/riskmap_validator/validator.py
+++ b/scripts/hooks/riskmap_validator/validator.py
@@ -2,20 +2,22 @@
 Core validation logic for component edge consistency and lifecycle stage ordering.
 
 Provides the ComponentEdgeValidator class that validates bidirectional
-edge consistency in component relationship YAML files, and the
+edge consistency in component relationship YAML files, the
 check_lifecycle_stage_order_uniqueness function that validates order
-uniqueness across lifecycle stage entries.
+uniqueness across lifecycle stage entries, and check_controls_components_mirror
+that validates control→component references against the component ID set
+(ADR-020 D7).
 
 Dependencies:
     - PyYAML: For YAML file parsing
-    - .models: ComponentNode data model
+    - .models: ComponentNode and ControlNode data models
 """
 
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .models import ComponentNode
+from .models import ComponentNode, ControlNode
 from .utils import parse_components_yaml
 
 
@@ -281,3 +283,48 @@ def check_lifecycle_stage_order_uniqueness(data: dict[str, Any]) -> LifecycleOrd
             )
 
     return LifecycleOrderCheckResult(is_valid=len(errors) == 0, errors=errors)
+
+
+# ---------------------------------------------------------------------------
+# Controls↔components mirror check (ADR-020 D7 / task 2.3.8)
+# ---------------------------------------------------------------------------
+
+# Literals that are valid component values but do not reference a real component ID.
+# "all" means the control applies to every component; "none" means no specific component.
+_COMPONENT_ESCAPE_HATCHES: frozenset[str] = frozenset({"all", "none"})
+
+
+def check_controls_components_mirror(
+    controls: dict[str, ControlNode],
+    component_ids: set[str],
+) -> list[str]:
+    """
+    Check that every component ID in controls[].components exists in component_ids.
+
+    Per ADR-020 D7: direction is one-way (control → component). The literals
+    "all" and "none" are escape hatches and must not be flagged as missing.
+
+    Args:
+        controls: Dict mapping control IDs to ControlNode objects, as returned
+                  by parse_controls_yaml().
+        component_ids: Set of valid top-level component IDs, typically
+                       set(parse_components_yaml(...).keys()).
+
+    Returns:
+        List of human-readable warning strings, one per (control_id,
+        missing_component_id) pair.  Empty list when all references resolve.
+    """
+    warnings: list[str] = []
+
+    for control_id, node in controls.items():
+        for component_ref in node.components:
+            # Skip documented escape hatches — they are not real component IDs.
+            if component_ref in _COMPONENT_ESCAPE_HATCHES:
+                continue
+            if component_ref not in component_ids:
+                warnings.append(
+                    f"Control '{control_id}' references component '{component_ref}' "
+                    f"which does not exist in components.yaml"
+                )
+
+    return warnings

--- a/scripts/hooks/tests/conftest.py
+++ b/scripts/hooks/tests/conftest.py
@@ -7,11 +7,14 @@ multiple test modules in the validation system test suite.
 
 # Import test modules for type hints and fixtures
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
+import yaml
 from riskmap_validator.models import ComponentNode, ControlNode, RiskNode
 from riskmap_validator.validator import ComponentEdgeValidator
 
@@ -583,3 +586,76 @@ def count_mermaid_edges(mermaid_content: str) -> int:
     # Count arrow patterns: -->, -.->
     edge_pattern = r"[\w\[\]]+\s*[-\.]*>\s*[\w\[\]]+"
     return len(re.findall(edge_pattern, mermaid_content))
+
+
+# ============================================================================
+# Shared helpers for validate_riskmap.py warn-only check tests
+# ============================================================================
+#
+# These fixtures support the controls↔components mirror check (ADR-020 D7) and
+# the category/subcategory nesting check (ADR-018 D6) tests, which both build
+# minimal synthesised corpora and invoke validate_riskmap.py via subprocess.
+# Lifecycle-uniqueness tests retain their own corpus helpers because their
+# signatures differ (4-file corpus, no extra-args support).
+
+
+@pytest.fixture
+def make_component():
+    """Return a callable that builds minimal ComponentNode instances for tests.
+
+    The callable signature is (title, category, subcategory=None) -> ComponentNode.
+    Edges default to empty lists since the warn-only checks do not exercise
+    bidirectional edge validation.
+    """
+
+    def _make(title: str, category: str, subcategory: str | None = None) -> ComponentNode:
+        return ComponentNode(
+            title=title,
+            category=category,
+            subcategory=subcategory,
+            to_edges=[],
+            from_edges=[],
+        )
+
+    return _make
+
+
+@pytest.fixture
+def write_riskmap_corpus():
+    """Return a callable that writes a minimal three-file corpus and returns the base.
+
+    The callable writes components.yaml, controls.yaml, and a risks.yaml stub
+    under base/risk-map/yaml/ — the minimum for validate_riskmap.py --force
+    to load without ENOENT on a missing risks file.
+    """
+
+    def _write(base: Path, components: dict[str, Any], controls: dict[str, Any]) -> Path:
+        yaml_dir = base / "risk-map" / "yaml"
+        yaml_dir.mkdir(parents=True)
+        (yaml_dir / "components.yaml").write_text(yaml.dump(components), encoding="utf-8")
+        (yaml_dir / "controls.yaml").write_text(yaml.dump(controls), encoding="utf-8")
+        (yaml_dir / "risks.yaml").write_text(yaml.dump({"risks": []}), encoding="utf-8")
+        return base
+
+    return _write
+
+
+@pytest.fixture
+def run_validate_riskmap():
+    """Return a callable that runs validate_riskmap.py via subprocess.
+
+    Always passes --force (bypass git-staged check) and --allow-isolated
+    (skip orphan check so minimal synthesised corpora pass).  Extra args
+    (e.g. "--block") are forwarded after these defaults.
+    """
+    script = Path(__file__).parent.parent / "validate_riskmap.py"
+
+    def _run(cwd: Path, *extra_args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(script), "--force", "--allow-isolated", *extra_args],
+            capture_output=True,
+            text=True,
+            cwd=str(cwd),
+        )
+
+    return _run

--- a/scripts/hooks/tests/conftest.py
+++ b/scripts/hooks/tests/conftest.py
@@ -166,6 +166,20 @@ def personas_schema_path(risk_map_schemas_dir: Path) -> Path:
 
 
 @pytest.fixture(scope="session")
+def lifecycle_stage_yaml_path(risk_map_yaml_dir: Path) -> Path:
+    """
+    Path to lifecycle-stage.yaml file.
+
+    Args:
+        risk_map_yaml_dir: YAML directory path fixture
+
+    Returns:
+        Path: Absolute path to lifecycle-stage.yaml
+    """
+    return risk_map_yaml_dir / "lifecycle-stage.yaml"
+
+
+@pytest.fixture(scope="session")
 def base_uri(risk_map_schemas_dir: Path) -> str:
     """
     Base URI for schema validation with check-jsonschema.

--- a/scripts/hooks/tests/test_category_subcategory_nesting.py
+++ b/scripts/hooks/tests/test_category_subcategory_nesting.py
@@ -65,8 +65,6 @@ import yaml
 # ---------------------------------------------------------------------------
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from riskmap_validator.models import ComponentNode  # noqa: E402
-
 # Deferred import: check_category_subcategory_nesting does not exist yet.
 # Re-raised inside the fixture so pure-function tests fail individually
 # while CLI test collection succeeds.
@@ -126,28 +124,9 @@ def nesting_fn():
     return check_category_subcategory_nesting
 
 
-def _make_component(
-    title: str,
-    category: str,
-    subcategory: str | None = None,
-) -> ComponentNode:
-    """Construct a ComponentNode for testing.
-
-    Args:
-        title: Component display title.
-        category: Category ID claimed by the component.
-        subcategory: Optional subcategory ID; None means absent.
-
-    Returns:
-        A ComponentNode with minimal required fields populated.
-    """
-    return ComponentNode(
-        title=title,
-        category=category,
-        subcategory=subcategory,
-        to_edges=[],
-        from_edges=[],
-    )
+# ComponentNode construction is delegated to the shared `make_component`
+# fixture in conftest.py; corpus writing and CLI invocation use
+# `write_riskmap_corpus` and `run_validate_riskmap` from the same module.
 
 
 # ---------------------------------------------------------------------------
@@ -246,26 +225,6 @@ _CLEAN_CONTROLS: dict[str, Any] = {
 }
 
 
-def _write_corpus(base: Path, components: dict[str, Any], controls: dict[str, Any]) -> Path:
-    """Write a minimal two-file corpus under base/risk-map/yaml/ and return base."""
-    yaml_dir = base / "risk-map" / "yaml"
-    yaml_dir.mkdir(parents=True)
-    (yaml_dir / "components.yaml").write_text(yaml.dump(components), encoding="utf-8")
-    (yaml_dir / "controls.yaml").write_text(yaml.dump(controls), encoding="utf-8")
-    (yaml_dir / "risks.yaml").write_text(yaml.dump({"risks": []}), encoding="utf-8")
-    return base
-
-
-def _run(cwd: Path, *extra_args: str) -> subprocess.CompletedProcess:
-    """Run validate_riskmap.py via subprocess with --force --allow-isolated."""
-    return subprocess.run(
-        [sys.executable, str(_SCRIPT), "--force", "--allow-isolated", *extra_args],
-        capture_output=True,
-        text=True,
-        cwd=str(cwd),
-    )
-
-
 # ===========================================================================
 # 1. Pure-function tests — check_category_subcategory_nesting()
 # ===========================================================================
@@ -279,20 +238,22 @@ class TestCheckCategorySubcategoryNesting:
     custom ComponentNode dicts.
     """
 
-    def test_clean_components_return_empty_list(self, nesting_fn):
+    def test_clean_components_return_empty_list(self, nesting_fn, make_component):
         """
         Given: components with consistent (category, subcategory) pairs
         When: check_category_subcategory_nesting() is called
         Then: returns an empty list
         """
         components = {
-            "componentX": _make_component("X", "componentsInfrastructure", "componentsData"),
-            "componentY": _make_component("Y", "componentsModel", "componentsModelTraining"),
+            "componentX": make_component("X", "componentsInfrastructure", "componentsData"),
+            "componentY": make_component("Y", "componentsModel", "componentsModelTraining"),
         }
         result = nesting_fn(components, _NESTING_MAP)
         assert result == [], f"Expected no warnings on clean input; got: {result}"
 
-    def test_class1_mismatched_nesting_produces_warning_naming_component_and_subcategory(self, nesting_fn):
+    def test_class1_mismatched_nesting_produces_warning_naming_component_and_subcategory(
+        self, nesting_fn, make_component
+    ):
         """
         Given: a component claims category=componentsModel, subcategory=componentsData
                (componentsData is nested under componentsInfrastructure, not Model)
@@ -301,7 +262,7 @@ class TestCheckCategorySubcategoryNesting:
               orphan subcategory
         """
         components = {
-            "componentMismatch": _make_component("Mismatch", "componentsModel", "componentsData"),
+            "componentMismatch": make_component("Mismatch", "componentsModel", "componentsData"),
         }
         result = nesting_fn(components, _NESTING_MAP)
         assert len(result) >= 1, f"Expected ≥1 warning for mismatched nesting; got: {result}"
@@ -311,22 +272,22 @@ class TestCheckCategorySubcategoryNesting:
             f"Expected 'componentsData' (orphan subcategory) in warning text; got: {result}"
         )
 
-    def test_class1_multiple_mismatches_each_surfaces_independently(self, nesting_fn):
+    def test_class1_multiple_mismatches_each_surfaces_independently(self, nesting_fn, make_component):
         """
         Given: two components with different mismatch pairs
         When: check_category_subcategory_nesting() is called
         Then: both component IDs appear in the combined warning text
         """
         components = {
-            "componentBad1": _make_component("Bad1", "componentsModel", "componentsData"),
-            "componentBad2": _make_component("Bad2", "componentsApplication", "componentsModelTraining"),
+            "componentBad1": make_component("Bad1", "componentsModel", "componentsData"),
+            "componentBad2": make_component("Bad2", "componentsApplication", "componentsModelTraining"),
         }
         result = nesting_fn(components, _NESTING_MAP)
         combined = " ".join(result)
         assert "componentBad1" in combined, f"Expected 'componentBad1'; got: {result}"
         assert "componentBad2" in combined, f"Expected 'componentBad2'; got: {result}"
 
-    def test_class2_absent_subcategory_produces_warning(self, nesting_fn):
+    def test_class2_absent_subcategory_produces_warning(self, nesting_fn, make_component):
         """
         Given: a component with category but no subcategory (absent)
         When: check_category_subcategory_nesting() is called
@@ -334,22 +295,22 @@ class TestCheckCategorySubcategoryNesting:
               (Path A: schema permits absence, but the validator surfaces it)
         """
         components = {
-            "componentMissing": _make_component("Missing", "componentsModel", subcategory=None),
+            "componentMissing": make_component("Missing", "componentsModel", subcategory=None),
         }
         result = nesting_fn(components, _NESTING_MAP)
         assert len(result) >= 1, f"Expected ≥1 warning for absent subcategory; got: {result}"
         combined = " ".join(result)
         assert "componentMissing" in combined, f"Expected 'componentMissing' in warning text; got: {result}"
 
-    def test_mixed_class1_and_class2_both_surfaced(self, nesting_fn):
+    def test_mixed_class1_and_class2_both_surfaced(self, nesting_fn, make_component):
         """
         Given: one Class-1 mismatch + one Class-2 absence in the same input
         When: check_category_subcategory_nesting() is called
         Then: both offending component IDs appear in the combined output
         """
         components = {
-            "componentMismatchCase": _make_component("Mismatch", "componentsModel", "componentsData"),
-            "componentAbsentCase": _make_component("Absent", "componentsApplication", subcategory=None),
+            "componentMismatchCase": make_component("Mismatch", "componentsModel", "componentsData"),
+            "componentAbsentCase": make_component("Absent", "componentsApplication", subcategory=None),
         }
         result = nesting_fn(components, _NESTING_MAP)
         combined = " ".join(result)
@@ -374,21 +335,21 @@ class TestCheckCategorySubcategoryNesting:
         result = nesting_fn({}, _NESTING_MAP)
         assert isinstance(result, list), f"Expected list, got {type(result)}: {result}"
 
-    def test_each_warning_is_a_string(self, nesting_fn):
+    def test_each_warning_is_a_string(self, nesting_fn, make_component):
         """
         Given: a dirty input that produces warnings
         When: check_category_subcategory_nesting() is called
         Then: every element of the returned list is a str
         """
         components = {
-            "componentBad": _make_component("Bad", "componentsModel", "componentsData"),
+            "componentBad": make_component("Bad", "componentsModel", "componentsData"),
         }
         result = nesting_fn(components, _NESTING_MAP)
         assert all(isinstance(w, str) for w in result), (
             f"Expected all-str warnings; got types: {[type(w) for w in result]}"
         )
 
-    def test_unknown_category_in_component_produces_warning(self, nesting_fn):
+    def test_unknown_category_in_component_produces_warning(self, nesting_fn, make_component):
         """
         Given: a component claims a category absent from the nesting map
         When: check_category_subcategory_nesting() is called
@@ -397,7 +358,7 @@ class TestCheckCategorySubcategoryNesting:
               no valid subcategories and always mismatches)
         """
         components = {
-            "componentUnknownCat": _make_component("UnknownCat", "componentsDoesNotExist", "componentsData"),
+            "componentUnknownCat": make_component("UnknownCat", "componentsDoesNotExist", "componentsData"),
         }
         result = nesting_fn(components, _NESTING_MAP)
         assert len(result) >= 1, f"Expected ≥1 warning when category is absent from nesting map; got: {result}"
@@ -459,19 +420,19 @@ class TestNestingBlockToggleCLI:
     The clean and no-block cases PASS today (regression guards).
     """
 
-    def test_live_corpus_no_block_flag_exits_0(self):
+    def test_live_corpus_no_block_flag_exits_0(self, run_validate_riskmap):
         """
         Given: actual repo as cwd, no --block
         When: validate_riskmap.py --force --allow-isolated runs
         Then: exit 0 (warnings printed but don't fail; today's behavior)
         """
-        result = _run(_REPO_ROOT)
+        result = run_validate_riskmap(_REPO_ROOT)
         assert result.returncode == 0, (
             f"Expected exit 0 without --block on live corpus; got {result.returncode}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
 
-    def test_live_corpus_with_block_flag_exits_1(self):
+    def test_live_corpus_with_block_flag_exits_1(self, run_validate_riskmap):
         """
         Given: actual repo as cwd, --block
         When: validate_riskmap.py --force --allow-isolated --block runs
@@ -482,7 +443,7 @@ class TestNestingBlockToggleCLI:
         task 2.3.8. After 2.3.9 is wired, both the nesting warnings and the
         mirror warnings contribute.
         """
-        result = _run(_REPO_ROOT, "--block")
+        result = run_validate_riskmap(_REPO_ROOT, "--block")
         assert result.returncode == 1, (
             f"Expected exit 1 with --block on live corpus; got {result.returncode}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
@@ -493,40 +454,42 @@ class TestNestingBlockToggleCLI:
             f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
         )
 
-    def test_clean_corpus_with_block_exits_0(self, tmp_path):
+    def test_clean_corpus_with_block_exits_0(self, tmp_path, write_riskmap_corpus, run_validate_riskmap):
         """
         Given: synthesised corpus with consistent nesting + clean controls
         When: validate_riskmap.py --force --allow-isolated --block runs
         Then: exit 0 (no warnings to promote)
         """
-        _write_corpus(tmp_path, _CLEAN_COMPONENTS, _CLEAN_CONTROLS)
-        result = _run(tmp_path, "--block")
+        write_riskmap_corpus(tmp_path, _CLEAN_COMPONENTS, _CLEAN_CONTROLS)
+        result = run_validate_riskmap(tmp_path, "--block")
         assert result.returncode == 0, (
             f"Expected exit 0 with --block on clean corpus; got {result.returncode}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
 
-    def test_dirty_nesting_with_block_exits_1(self, tmp_path):
+    def test_dirty_nesting_with_block_exits_1(self, tmp_path, write_riskmap_corpus, run_validate_riskmap):
         """
         Given: synthesised corpus with mismatched nesting (componentBad) + clean controls
         When: validate_riskmap.py --force --allow-isolated --block runs
         Then: exit 1 (nesting warning fires the toggle; mirror stays silent)
         """
-        _write_corpus(tmp_path, _DIRTY_NESTING_COMPONENTS, _CLEAN_CONTROLS)
-        result = _run(tmp_path, "--block")
+        write_riskmap_corpus(tmp_path, _DIRTY_NESTING_COMPONENTS, _CLEAN_CONTROLS)
+        result = run_validate_riskmap(tmp_path, "--block")
         assert result.returncode == 1, (
             f"Expected exit 1 with --block on dirty-nesting corpus; got {result.returncode}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
 
-    def test_dirty_nesting_no_block_flag_exits_0_and_emits_warning(self, tmp_path):
+    def test_dirty_nesting_no_block_flag_exits_0_and_emits_warning(
+        self, tmp_path, write_riskmap_corpus, run_validate_riskmap
+    ):
         """
         Given: synthesised dirty-nesting corpus, no --block
         When: validate_riskmap.py --force --allow-isolated runs
         Then: exit 0 (warn-only preserved) AND output names the offending component
         """
-        _write_corpus(tmp_path, _DIRTY_NESTING_COMPONENTS, _CLEAN_CONTROLS)
-        result = _run(tmp_path)
+        write_riskmap_corpus(tmp_path, _DIRTY_NESTING_COMPONENTS, _CLEAN_CONTROLS)
+        result = run_validate_riskmap(tmp_path)
         assert result.returncode == 0, (
             f"Expected exit 0 without --block on dirty-nesting corpus; got {result.returncode}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"

--- a/scripts/hooks/tests/test_category_subcategory_nesting.py
+++ b/scripts/hooks/tests/test_category_subcategory_nesting.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+"""
+Tests for the category/subcategory nesting check (task 2.3.9 / issue #268).
+
+Per ADR-018 D6: every component's `(category, subcategory)` pair must match
+the file's `categories[].subcategory[]` declaration. The schema enforces
+individual enum membership but NOT the nesting (e.g., a component declaring
+`category: componentsModel, subcategory: componentsData` passes schema
+today even though `componentsData` is nested under `componentsInfrastructure`).
+
+The check ships warn-only and rides the SAME `--block` flag on
+`validate_riskmap.py` that 2.3.8 introduced (no new flag).
+
+Path A (orchestrator-pinned): emit warnings for BOTH classes.
+  - Class 1 (mismatch): subcategory present + not nested under claimed category.
+  - Class 2 (absent):   category present + subcategory missing.
+
+Live corpus state (verified 2026-05-04):
+  - 0 mismatched-nesting components (per ADR-018 D6, "no component has this
+    drift today; the gap is a backstop class").
+  - 7 components missing subcategory: componentDataStorage, componentModelStorage,
+    componentModelServing, componentTheModel, componentApplication,
+    componentApplicationOutputHandling, componentApplicationInputHandling.
+
+Symbol contract
+---------------
+Pure-function tests import `check_category_subcategory_nesting` from
+`riskmap_validator.validator`. SWE must expose a callable with that name.
+Signature (SWE's call, but tests assume this shape):
+
+    check_category_subcategory_nesting(
+        components: dict[str, ComponentNode],
+        category_to_subcategories: dict[str, set[str]],
+    ) -> list[str]
+
+`category_to_subcategories` maps each top-level category ID -> set of valid
+subcategory IDs nested under it. Caller derives this from the YAML's
+top-level `categories:` block.
+
+Returns a list of human-readable warning strings; empty list when clean.
+
+Test structure
+--------------
+1. TestCheckCategorySubcategoryNesting
+   Pure-function tests on check_category_subcategory_nesting().
+   FAIL today with ImportError (function not yet implemented).
+
+2. TestNestingBlockToggleCLI
+   Subprocess-based end-to-end tests on validate_riskmap.py reusing the
+   --block flag from 2.3.8. The dirty-with-block test FAILS today because
+   the nesting check is not yet wired into main(). The --help-shows-block
+   test PASSES today (regression guard on 2.3.8's flag).
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# sys.path injection — same pattern as the mirror test
+# ---------------------------------------------------------------------------
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from riskmap_validator.models import ComponentNode  # noqa: E402
+
+# Deferred import: check_category_subcategory_nesting does not exist yet.
+# Re-raised inside the fixture so pure-function tests fail individually
+# while CLI test collection succeeds.
+try:
+    from riskmap_validator.validator import check_category_subcategory_nesting  # noqa: E402
+
+    _NESTING_IMPORT_ERROR: ImportError | None = None
+except ImportError as _e:
+    check_category_subcategory_nesting = None  # type: ignore[assignment]
+    _NESTING_IMPORT_ERROR = _e
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+# CLI script under test.
+_SCRIPT = Path(__file__).parent.parent / "validate_riskmap.py"
+
+# Repository root — used as cwd for live-corpus subprocess tests.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+# Known live-corpus components missing the `subcategory` field (2026-05-04).
+_LIVE_MISSING_SUBCATEGORY_IDS: frozenset[str] = frozenset(
+    {
+        "componentDataStorage",
+        "componentModelStorage",
+        "componentModelServing",
+        "componentTheModel",
+        "componentApplication",
+        "componentApplicationOutputHandling",
+        "componentApplicationInputHandling",
+    }
+)
+
+# Test-only nesting map — matches the exact live category declarations (verified 2026-05-04).
+_NESTING_MAP: dict[str, set[str]] = {
+    "componentsInfrastructure": {"componentsData"},
+    "componentsModel": {"componentsModelTraining", "componentsOrchestration"},
+    "componentsApplication": {"componentsAgent"},
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixture for deferred import
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def nesting_fn():
+    """Return check_category_subcategory_nesting, or fail with ImportError.
+
+    Lets the CLI test class collect and run independently of the function's
+    presence.
+    """
+    if _NESTING_IMPORT_ERROR is not None:
+        raise _NESTING_IMPORT_ERROR
+    return check_category_subcategory_nesting
+
+
+def _make_component(
+    title: str,
+    category: str,
+    subcategory: str | None = None,
+) -> ComponentNode:
+    """Construct a ComponentNode for testing.
+
+    Args:
+        title: Component display title.
+        category: Category ID claimed by the component.
+        subcategory: Optional subcategory ID; None means absent.
+
+    Returns:
+        A ComponentNode with minimal required fields populated.
+    """
+    return ComponentNode(
+        title=title,
+        category=category,
+        subcategory=subcategory,
+        to_edges=[],
+        from_edges=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Synthesized-corpus harness for subprocess tests
+# ---------------------------------------------------------------------------
+
+# Components.yaml with valid nesting + clean components (no mismatches, all
+# subcategories declared). One category ("componentsInfrastructure") has a
+# nested subcategory; components reference it consistently.
+_CLEAN_COMPONENTS: dict[str, Any] = {
+    "components": [
+        {
+            "id": "componentAlpha",
+            "title": "Alpha",
+            "category": "componentsInfrastructure",
+            "subcategory": "componentsData",
+            "edges": {"to": ["componentBeta"], "from": []},
+        },
+        {
+            "id": "componentBeta",
+            "title": "Beta",
+            "category": "componentsInfrastructure",
+            "subcategory": "componentsData",
+            "edges": {"to": [], "from": ["componentAlpha"]},
+        },
+    ],
+    "categories": [
+        {
+            "id": "componentsInfrastructure",
+            "title": "Infrastructure",
+            "subcategory": [
+                {"id": "componentsData", "title": "Data"},
+            ],
+        },
+        {
+            "id": "componentsModel",
+            "title": "Model",
+            "subcategory": [
+                {"id": "componentsModelTraining", "title": "Model Training"},
+            ],
+        },
+    ],
+}
+
+# Components.yaml with a mismatched-nesting component: componentBad claims
+# category=componentsModel, subcategory=componentsData (which is declared
+# under componentsInfrastructure, not componentsModel).
+_DIRTY_NESTING_COMPONENTS: dict[str, Any] = {
+    "components": [
+        {
+            "id": "componentAlpha",
+            "title": "Alpha",
+            "category": "componentsInfrastructure",
+            "subcategory": "componentsData",
+            "edges": {"to": ["componentBad"], "from": []},
+        },
+        {
+            "id": "componentBad",
+            "title": "Bad Nesting",
+            "category": "componentsModel",
+            "subcategory": "componentsData",  # MISMATCH — under Infrastructure
+            "edges": {"to": [], "from": ["componentAlpha"]},
+        },
+    ],
+    "categories": [
+        {
+            "id": "componentsInfrastructure",
+            "title": "Infrastructure",
+            "subcategory": [
+                {"id": "componentsData", "title": "Data"},
+            ],
+        },
+        {
+            "id": "componentsModel",
+            "title": "Model",
+            "subcategory": [
+                {"id": "componentsModelTraining", "title": "Model Training"},
+            ],
+        },
+    ],
+}
+
+# Clean controls — no dangling refs so the mirror check stays silent and
+# only the nesting check produces output.
+_CLEAN_CONTROLS: dict[str, Any] = {
+    "controls": [
+        {
+            "id": "controlClean",
+            "title": "Clean",
+            "category": "controlsGovernance",
+            "components": ["componentAlpha"],
+            "risks": [],
+            "personas": [],
+        }
+    ]
+}
+
+
+def _write_corpus(base: Path, components: dict[str, Any], controls: dict[str, Any]) -> Path:
+    """Write a minimal two-file corpus under base/risk-map/yaml/ and return base."""
+    yaml_dir = base / "risk-map" / "yaml"
+    yaml_dir.mkdir(parents=True)
+    (yaml_dir / "components.yaml").write_text(yaml.dump(components), encoding="utf-8")
+    (yaml_dir / "controls.yaml").write_text(yaml.dump(controls), encoding="utf-8")
+    (yaml_dir / "risks.yaml").write_text(yaml.dump({"risks": []}), encoding="utf-8")
+    return base
+
+
+def _run(cwd: Path, *extra_args: str) -> subprocess.CompletedProcess:
+    """Run validate_riskmap.py via subprocess with --force --allow-isolated."""
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), "--force", "--allow-isolated", *extra_args],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+    )
+
+
+# ===========================================================================
+# 1. Pure-function tests — check_category_subcategory_nesting()
+# ===========================================================================
+
+
+class TestCheckCategorySubcategoryNesting:
+    """Pure-function tests for check_category_subcategory_nesting().
+
+    Path A: emit warnings for both mismatched nesting (Class 1) and absent
+    subcategory (Class 2). All tests use module-level _NESTING_MAP plus
+    custom ComponentNode dicts.
+    """
+
+    def test_clean_components_return_empty_list(self, nesting_fn):
+        """
+        Given: components with consistent (category, subcategory) pairs
+        When: check_category_subcategory_nesting() is called
+        Then: returns an empty list
+        """
+        components = {
+            "componentX": _make_component("X", "componentsInfrastructure", "componentsData"),
+            "componentY": _make_component("Y", "componentsModel", "componentsModelTraining"),
+        }
+        result = nesting_fn(components, _NESTING_MAP)
+        assert result == [], f"Expected no warnings on clean input; got: {result}"
+
+    def test_class1_mismatched_nesting_produces_warning_naming_component_and_subcategory(self, nesting_fn):
+        """
+        Given: a component claims category=componentsModel, subcategory=componentsData
+               (componentsData is nested under componentsInfrastructure, not Model)
+        When: check_category_subcategory_nesting() is called
+        Then: 1 warning naming the component ID, the claimed category, and the
+              orphan subcategory
+        """
+        components = {
+            "componentMismatch": _make_component("Mismatch", "componentsModel", "componentsData"),
+        }
+        result = nesting_fn(components, _NESTING_MAP)
+        assert len(result) >= 1, f"Expected ≥1 warning for mismatched nesting; got: {result}"
+        combined = " ".join(result)
+        assert "componentMismatch" in combined, f"Expected 'componentMismatch' in warning text; got: {result}"
+        assert "componentsData" in combined, (
+            f"Expected 'componentsData' (orphan subcategory) in warning text; got: {result}"
+        )
+
+    def test_class1_multiple_mismatches_each_surfaces_independently(self, nesting_fn):
+        """
+        Given: two components with different mismatch pairs
+        When: check_category_subcategory_nesting() is called
+        Then: both component IDs appear in the combined warning text
+        """
+        components = {
+            "componentBad1": _make_component("Bad1", "componentsModel", "componentsData"),
+            "componentBad2": _make_component("Bad2", "componentsApplication", "componentsModelTraining"),
+        }
+        result = nesting_fn(components, _NESTING_MAP)
+        combined = " ".join(result)
+        assert "componentBad1" in combined, f"Expected 'componentBad1'; got: {result}"
+        assert "componentBad2" in combined, f"Expected 'componentBad2'; got: {result}"
+
+    def test_class2_absent_subcategory_produces_warning(self, nesting_fn):
+        """
+        Given: a component with category but no subcategory (absent)
+        When: check_category_subcategory_nesting() is called
+        Then: 1 warning naming the component ID and the claimed category
+              (Path A: schema permits absence, but the validator surfaces it)
+        """
+        components = {
+            "componentMissing": _make_component("Missing", "componentsModel", subcategory=None),
+        }
+        result = nesting_fn(components, _NESTING_MAP)
+        assert len(result) >= 1, f"Expected ≥1 warning for absent subcategory; got: {result}"
+        combined = " ".join(result)
+        assert "componentMissing" in combined, f"Expected 'componentMissing' in warning text; got: {result}"
+
+    def test_mixed_class1_and_class2_both_surfaced(self, nesting_fn):
+        """
+        Given: one Class-1 mismatch + one Class-2 absence in the same input
+        When: check_category_subcategory_nesting() is called
+        Then: both offending component IDs appear in the combined output
+        """
+        components = {
+            "componentMismatchCase": _make_component("Mismatch", "componentsModel", "componentsData"),
+            "componentAbsentCase": _make_component("Absent", "componentsApplication", subcategory=None),
+        }
+        result = nesting_fn(components, _NESTING_MAP)
+        combined = " ".join(result)
+        assert "componentMismatchCase" in combined, f"Expected mismatch case in warning; got: {result}"
+        assert "componentAbsentCase" in combined, f"Expected absent case in warning; got: {result}"
+
+    def test_empty_components_dict_returns_empty_list(self, nesting_fn):
+        """
+        Given: an empty components dict
+        When: check_category_subcategory_nesting() is called
+        Then: empty list (nothing to check)
+        """
+        result = nesting_fn({}, _NESTING_MAP)
+        assert result == [], f"Expected empty list on empty input; got: {result}"
+
+    def test_returns_list_type(self, nesting_fn):
+        """
+        Given: any input
+        When: check_category_subcategory_nesting() is called
+        Then: returns a list (never None or other type)
+        """
+        result = nesting_fn({}, _NESTING_MAP)
+        assert isinstance(result, list), f"Expected list, got {type(result)}: {result}"
+
+    def test_each_warning_is_a_string(self, nesting_fn):
+        """
+        Given: a dirty input that produces warnings
+        When: check_category_subcategory_nesting() is called
+        Then: every element of the returned list is a str
+        """
+        components = {
+            "componentBad": _make_component("Bad", "componentsModel", "componentsData"),
+        }
+        result = nesting_fn(components, _NESTING_MAP)
+        assert all(isinstance(w, str) for w in result), (
+            f"Expected all-str warnings; got types: {[type(w) for w in result]}"
+        )
+
+    def test_unknown_category_in_component_produces_warning(self, nesting_fn):
+        """
+        Given: a component claims a category absent from the nesting map
+        When: check_category_subcategory_nesting() is called
+        Then: 1 warning naming the component (the nesting check builds its map
+              from the YAML categories block; a category not present there has
+              no valid subcategories and always mismatches)
+        """
+        components = {
+            "componentUnknownCat": _make_component("UnknownCat", "componentsDoesNotExist", "componentsData"),
+        }
+        result = nesting_fn(components, _NESTING_MAP)
+        assert len(result) >= 1, f"Expected ≥1 warning when category is absent from nesting map; got: {result}"
+        combined = " ".join(result)
+        assert "componentUnknownCat" in combined, f"Expected component ID in warning; got: {result}"
+
+    def test_live_corpus_regression_surfaces_known_missing_subcategory(self, nesting_fn):
+        """
+        Given: the actual risk-map/yaml/components.yaml on disk
+        When: check_category_subcategory_nesting() is called against parsed input
+        Then: returns ≥7 warnings, and every known missing-subcategory component ID
+              appears in the combined output
+
+        The 7 known missing IDs are listed in _LIVE_MISSING_SUBCATEGORY_IDS.
+        Update this test if/when the content debt is remediated.
+        """
+        from riskmap_validator.utils import parse_components_yaml  # noqa: E402
+
+        components_path = _REPO_ROOT / "risk-map" / "yaml" / "components.yaml"
+        components = parse_components_yaml(components_path)
+
+        # Build the nesting map from the YAML's top-level categories block.
+        with open(components_path, encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+        nesting_map: dict[str, set[str]] = {}
+        for cat in data.get("categories", []):
+            cat_id = cat.get("id")
+            if not isinstance(cat_id, str):
+                continue
+            sub_ids = {sub.get("id") for sub in cat.get("subcategory", []) if isinstance(sub.get("id"), str)}
+            nesting_map[cat_id] = sub_ids
+
+        result = nesting_fn(components, nesting_map)
+        assert len(result) >= 7, (
+            f"Expected ≥7 warnings for known missing-subcategory debt; got {len(result)}: {result}"
+        )
+        combined = " ".join(result)
+        for component_id in _LIVE_MISSING_SUBCATEGORY_IDS:
+            assert component_id in combined, (
+                f"Expected '{component_id}' (known missing-subcategory case) in warning text; got: {result}"
+            )
+
+
+# ===========================================================================
+# 2. Subprocess CLI tests — validate_riskmap.py --block (reuses 2.3.8 flag)
+# ===========================================================================
+
+
+class TestNestingBlockToggleCLI:
+    """End-to-end tests on validate_riskmap.py for the nesting check.
+
+    Reuses the --block flag introduced by task 2.3.8. The dirty-with-block
+    cases FAIL today because the nesting check is not yet wired into main().
+    The clean and no-block cases PASS today (regression guards).
+    """
+
+    def test_live_corpus_no_block_flag_exits_0(self):
+        """
+        Given: actual repo as cwd, no --block
+        When: validate_riskmap.py --force --allow-isolated runs
+        Then: exit 0 (warnings printed but don't fail; today's behavior)
+        """
+        result = _run(_REPO_ROOT)
+        assert result.returncode == 0, (
+            f"Expected exit 0 without --block on live corpus; got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_live_corpus_with_block_flag_exits_1(self):
+        """
+        Given: actual repo as cwd, --block
+        When: validate_riskmap.py --force --allow-isolated --block runs
+        Then: exit 1 (combined nesting + mirror warnings fire the toggle;
+              7 missing subcategories + 3 mirror dangle ≥ 10 total)
+
+        Today (pre-2.3.9) exit 1 comes from the 3 mirror-dangle warnings from
+        task 2.3.8. After 2.3.9 is wired, both the nesting warnings and the
+        mirror warnings contribute.
+        """
+        result = _run(_REPO_ROOT, "--block")
+        assert result.returncode == 1, (
+            f"Expected exit 1 with --block on live corpus; got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        combined = result.stdout + result.stderr
+        assert any(cid in combined for cid in _LIVE_MISSING_SUBCATEGORY_IDS), (
+            f"Expected output to name at least one known missing-subcategory ID; "
+            f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+        )
+
+    def test_clean_corpus_with_block_exits_0(self, tmp_path):
+        """
+        Given: synthesised corpus with consistent nesting + clean controls
+        When: validate_riskmap.py --force --allow-isolated --block runs
+        Then: exit 0 (no warnings to promote)
+        """
+        _write_corpus(tmp_path, _CLEAN_COMPONENTS, _CLEAN_CONTROLS)
+        result = _run(tmp_path, "--block")
+        assert result.returncode == 0, (
+            f"Expected exit 0 with --block on clean corpus; got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_dirty_nesting_with_block_exits_1(self, tmp_path):
+        """
+        Given: synthesised corpus with mismatched nesting (componentBad) + clean controls
+        When: validate_riskmap.py --force --allow-isolated --block runs
+        Then: exit 1 (nesting warning fires the toggle; mirror stays silent)
+        """
+        _write_corpus(tmp_path, _DIRTY_NESTING_COMPONENTS, _CLEAN_CONTROLS)
+        result = _run(tmp_path, "--block")
+        assert result.returncode == 1, (
+            f"Expected exit 1 with --block on dirty-nesting corpus; got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_dirty_nesting_no_block_flag_exits_0_and_emits_warning(self, tmp_path):
+        """
+        Given: synthesised dirty-nesting corpus, no --block
+        When: validate_riskmap.py --force --allow-isolated runs
+        Then: exit 0 (warn-only preserved) AND output names the offending component
+        """
+        _write_corpus(tmp_path, _DIRTY_NESTING_COMPONENTS, _CLEAN_CONTROLS)
+        result = _run(tmp_path)
+        assert result.returncode == 0, (
+            f"Expected exit 0 without --block on dirty-nesting corpus; got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        # Without this assertion a silent skip would also pass exit-code-only.
+        combined = result.stdout + result.stderr
+        assert "componentBad" in combined, (
+            f"Expected warn output naming 'componentBad' even without --block; "
+            f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+        )
+
+    def test_help_output_contains_block_flag(self):
+        """
+        Given: --help output
+        When: validate_riskmap.py --help runs
+        Then: --block is documented (regression guard on 2.3.8's flag wiring;
+              must continue to be documented after 2.3.9 wires the second consumer)
+        """
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT), "--help"],
+            capture_output=True,
+            text=True,
+            cwd=str(_REPO_ROOT),
+        )
+        combined = result.stdout + result.stderr
+        assert "--block" in combined, f"Expected --block in --help output; got:\n{combined}"
+
+
+# ===========================================================================
+# Test Summary
+# ===========================================================================
+# Total tests: 16
+#
+# TestCheckCategorySubcategoryNesting (10 tests)
+#   — clean → empty list; class-1 mismatch → warning naming component +
+#     orphan subcategory; multiple class-1 mismatches; class-2 absence →
+#     warning naming component; mixed class-1 + class-2; empty dict;
+#     return type list; each element str; unknown category produces warning;
+#     live-corpus regression surfaces known 7 missing IDs.
+#
+# TestNestingBlockToggleCLI (6 tests)
+#   — live + no --block → exit 0; live + --block → exit 1;
+#     clean synthesised + --block → exit 0; dirty nesting + --block → exit 1;
+#     dirty nesting + no --block → exit 0 + warning emitted;
+#     --help still documents --block (regression guard).
+#
+# Red-phase failure modes
+#   - TestCheckCategorySubcategoryNesting: ImportError at fixture setup
+#     (check_category_subcategory_nesting not yet defined).
+#   - TestNestingBlockToggleCLI: dirty-with-block + dirty-no-block-emits-warning
+#     fail because the nesting check is not yet wired into main().
+#     live-no-block, clean-with-block, live-with-block (already exits 1
+#     because of mirror's 3 dangling refs after task 2.3.8 — passing for
+#     compatible reason), and --help (already passes after 2.3.8) pass today.

--- a/scripts/hooks/tests/test_category_subcategory_nesting.py
+++ b/scripts/hooks/tests/test_category_subcategory_nesting.py
@@ -408,11 +408,14 @@ class TestCheckCategorySubcategoryNesting:
         """
         Given: the actual risk-map/yaml/components.yaml on disk
         When: check_category_subcategory_nesting() is called against parsed input
-        Then: returns ≥7 warnings, and every known missing-subcategory component ID
+        Then: returns exactly 7 warnings, and every known missing-subcategory component ID
               appears in the combined output
 
-        The 7 known missing IDs are listed in _LIVE_MISSING_SUBCATEGORY_IDS.
-        Update this test if/when the content debt is remediated.
+        The 7 known missing IDs are listed in _LIVE_MISSING_SUBCATEGORY_IDS (as of 2026-05-04).
+        This assertion is intentionally exact (==, not >=) to guard BOTH directions of drift:
+        - cleanup reduces the count below 7 → fail (update the expected count + ID list)
+        - new content debt increases the count above 7 → fail (track the new defect)
+        Update this test and _LIVE_MISSING_SUBCATEGORY_IDS whenever the corpus changes.
         """
         from riskmap_validator.utils import parse_components_yaml  # noqa: E402
 
@@ -431,8 +434,10 @@ class TestCheckCategorySubcategoryNesting:
             nesting_map[cat_id] = sub_ids
 
         result = nesting_fn(components, nesting_map)
-        assert len(result) >= 7, (
-            f"Expected ≥7 warnings for known missing-subcategory debt; got {len(result)}: {result}"
+        assert len(result) == 7, (
+            "Expected exactly 7 warnings (the 7 known missing-subcategory components as of 2026-05-04). "
+            "If the corpus drifted (cleanup OR new defects), update this test and "
+            f"_LIVE_MISSING_SUBCATEGORY_IDS. Got {len(result)}: {result}"
         )
         combined = " ".join(result)
         for component_id in _LIVE_MISSING_SUBCATEGORY_IDS:

--- a/scripts/hooks/tests/test_controls_components_mirror.py
+++ b/scripts/hooks/tests/test_controls_components_mirror.py
@@ -494,17 +494,20 @@ class TestCheckControlsComponentsMirror:
     def test_live_corpus_regression_produces_known_dangling_refs(self, mirror_fn):
         """
         Running against the actual controls.yaml + components.yaml surfaces
-        the 3 known dangling references present as of 2026-05-04.
+        exactly the 3 known dangling references present as of 2026-05-04.
 
         Given: Parsed controls from risk-map/yaml/controls.yaml
                Parsed components from risk-map/yaml/components.yaml
         When: check_controls_components_mirror() is called
-        Then: Warning count >= 3 AND warnings mention componentInputHandling
+        Then: Warning count == 3 AND warnings mention componentInputHandling
               AND warnings mention componentOutputHandling
 
-        This is a live-corpus regression guard.  If the content debt is ever
-        remediated (componentInputHandling → componentApplicationInputHandling,
-        etc.), this test will need updating to reflect the new expected count.
+        This assertion is intentionally exact (==, not >=) to guard BOTH directions of drift:
+        - content debt remediated (cleanup) → count drops below 3 → fail (update expected count)
+        - new dangling refs introduced → count rises above 3 → fail (track the new defect)
+        If the content debt is ever remediated (componentInputHandling →
+        componentApplicationInputHandling, etc.), update this test and
+        _LIVE_DANGLING_COMPONENT_IDS to reflect the new expected count.
         """
         from riskmap_validator.utils import parse_components_yaml, parse_controls_yaml
 
@@ -517,7 +520,11 @@ class TestCheckControlsComponentsMirror:
 
         result = mirror_fn(controls, component_ids)
 
-        assert len(result) >= 3, f"Expected >= 3 warnings for known dangling refs; got {len(result)}: {result}"
+        assert len(result) == 3, (
+            "Expected exactly 3 warnings for known dangling refs (as of 2026-05-04). "
+            "If the corpus drifted (cleanup OR new defects), update this test and "
+            f"_LIVE_DANGLING_COMPONENT_IDS. Got {len(result)}: {result}"
+        )
         combined = " ".join(result)
         assert "componentInputHandling" in combined, (
             f"Expected 'componentInputHandling' in warnings; got: {result}"

--- a/scripts/hooks/tests/test_controls_components_mirror.py
+++ b/scripts/hooks/tests/test_controls_components_mirror.py
@@ -72,7 +72,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-import yaml
 
 # ---------------------------------------------------------------------------
 # sys.path injection — same pattern as the existing test files
@@ -244,54 +243,9 @@ _ESCAPE_ALL_CONTROLS: dict[str, Any] = {
 }
 
 
-def _write_corpus(
-    base: Path,
-    components: dict[str, Any],
-    controls: dict[str, Any],
-) -> Path:
-    """Write a minimal two-file corpus under base/risk-map/yaml/ and return base.
-
-    validate_riskmap.py also reads risks.yaml; we write a minimal stub.
-    The risks file is not exercised by the mirror check so its contents are
-    irrelevant as long as parse_risks_yaml() does not error.
-
-    Args:
-        base: Temporary directory root (from tmp_path fixture).
-        components: Parsed components.yaml content dict.
-        controls: Parsed controls.yaml content dict.
-
-    Returns:
-        The base path (for use as subprocess cwd).
-    """
-    yaml_dir = base / "risk-map" / "yaml"
-    yaml_dir.mkdir(parents=True)
-    (yaml_dir / "components.yaml").write_text(yaml.dump(components), encoding="utf-8")
-    (yaml_dir / "controls.yaml").write_text(yaml.dump(controls), encoding="utf-8")
-    # Minimal risks stub so the script doesn't fail on a missing file.
-    (yaml_dir / "risks.yaml").write_text(yaml.dump({"risks": []}), encoding="utf-8")
-    return base
-
-
-def _run(cwd: Path, *extra_args: str) -> subprocess.CompletedProcess:
-    """Run validate_riskmap.py via subprocess with --force and any extra args.
-
-    Always passes --force so the script validates regardless of git-staged state.
-    Always passes --allow-isolated so minimal synthesised corpora do not fail
-    the ComponentEdgeValidator's orphan check.
-
-    Args:
-        cwd: Working directory for the subprocess.
-        *extra_args: Additional CLI arguments (e.g. "--block").
-
-    Returns:
-        CompletedProcess with returncode, stdout, stderr.
-    """
-    return subprocess.run(
-        [sys.executable, str(_SCRIPT), "--force", "--allow-isolated", *extra_args],
-        capture_output=True,
-        text=True,
-        cwd=str(cwd),
-    )
+# Synthesised-corpus subprocess tests rely on the shared `write_riskmap_corpus`
+# and `run_validate_riskmap` fixtures (see conftest.py) so every warn-only
+# check test invokes the CLI through one consistent harness.
 
 
 # ===========================================================================
@@ -551,7 +505,7 @@ class TestBlockToggleCLI:
     # Has 3 known dangling refs (componentInputHandling ×1, componentOutputHandling ×2).
     # -----------------------------------------------------------------------
 
-    def test_live_corpus_no_block_flag_exits_0(self):
+    def test_live_corpus_no_block_flag_exits_0(self, run_validate_riskmap):
         """
         Running without --block against the live corpus exits 0.
 
@@ -562,13 +516,13 @@ class TestBlockToggleCLI:
         When: validate_riskmap.py --force --allow-isolated (no --block)
         Then: Exit code is 0
         """
-        result = _run(_REPO_ROOT)
+        result = run_validate_riskmap(_REPO_ROOT)
         assert result.returncode == 0, (
             f"Expected exit 0 without --block on live corpus; got {result.returncode}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
 
-    def test_live_corpus_with_block_flag_exits_1(self):
+    def test_live_corpus_with_block_flag_exits_1(self, run_validate_riskmap):
         """
         Running with --block against the live corpus exits 1 because the 3
         dangling component refs promote warnings to errors.
@@ -577,13 +531,13 @@ class TestBlockToggleCLI:
         When: validate_riskmap.py --force --allow-isolated --block
         Then: Exit code is 1 (mirror warnings promoted to failures)
         """
-        result = _run(_REPO_ROOT, "--block")
+        result = run_validate_riskmap(_REPO_ROOT, "--block")
         assert result.returncode == 1, (
             f"Expected exit 1 with --block on live corpus; got {result.returncode}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
 
-    def test_live_corpus_with_block_output_names_dangling_components(self):
+    def test_live_corpus_with_block_output_names_dangling_components(self, run_validate_riskmap):
         """
         When --block fires on the live corpus, the output text names the
         dangling component IDs so developers can locate the defects.
@@ -593,7 +547,7 @@ class TestBlockToggleCLI:
         Then: Output (stdout or stderr) mentions at least one of
               componentInputHandling or componentOutputHandling
         """
-        result = _run(_REPO_ROOT, "--block")
+        result = run_validate_riskmap(_REPO_ROOT, "--block")
         combined = result.stdout + result.stderr
         mentions_known_dangling = any(cid in combined for cid in _LIVE_DANGLING_COMPONENT_IDS)
         assert mentions_known_dangling, (
@@ -606,7 +560,7 @@ class TestBlockToggleCLI:
     # Synthesised clean corpus: no dangling refs → --block must NOT fire.
     # -----------------------------------------------------------------------
 
-    def test_clean_corpus_with_block_flag_exits_0(self, tmp_path):
+    def test_clean_corpus_with_block_flag_exits_0(self, tmp_path, write_riskmap_corpus, run_validate_riskmap):
         """
         Running with --block against a corpus with no dangling refs exits 0.
 
@@ -618,14 +572,14 @@ class TestBlockToggleCLI:
         When: validate_riskmap.py --force --allow-isolated --block (cwd=tmp_path)
         Then: Exit code is 0 (no mirror warnings to promote)
         """
-        _write_corpus(tmp_path, _MINIMAL_COMPONENTS, _CLEAN_CONTROLS)
-        result = _run(tmp_path, "--block")
+        write_riskmap_corpus(tmp_path, _MINIMAL_COMPONENTS, _CLEAN_CONTROLS)
+        result = run_validate_riskmap(tmp_path, "--block")
         assert result.returncode == 0, (
             f"Expected exit 0 with --block on clean corpus; got {result.returncode}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
 
-    def test_clean_corpus_no_block_flag_exits_0(self, tmp_path):
+    def test_clean_corpus_no_block_flag_exits_0(self, tmp_path, write_riskmap_corpus, run_validate_riskmap):
         """
         Running without --block against a clean corpus exits 0.
 
@@ -635,8 +589,8 @@ class TestBlockToggleCLI:
         When: validate_riskmap.py --force --allow-isolated (no --block)
         Then: Exit code is 0
         """
-        _write_corpus(tmp_path, _MINIMAL_COMPONENTS, _CLEAN_CONTROLS)
-        result = _run(tmp_path)
+        write_riskmap_corpus(tmp_path, _MINIMAL_COMPONENTS, _CLEAN_CONTROLS)
+        result = run_validate_riskmap(tmp_path)
         assert result.returncode == 0, (
             f"Expected exit 0 on clean corpus without --block; got {result.returncode}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
@@ -646,7 +600,7 @@ class TestBlockToggleCLI:
     # Synthesised dirty corpus: dangling refs present.
     # -----------------------------------------------------------------------
 
-    def test_dirty_corpus_with_block_flag_exits_1(self, tmp_path):
+    def test_dirty_corpus_with_block_flag_exits_1(self, tmp_path, write_riskmap_corpus, run_validate_riskmap):
         """
         Running with --block against a synthesised dirty corpus exits 1.
 
@@ -658,14 +612,14 @@ class TestBlockToggleCLI:
         When: validate_riskmap.py --force --allow-isolated --block
         Then: Exit code is 1
         """
-        _write_corpus(tmp_path, _MINIMAL_COMPONENTS, _DIRTY_CONTROLS)
-        result = _run(tmp_path, "--block")
+        write_riskmap_corpus(tmp_path, _MINIMAL_COMPONENTS, _DIRTY_CONTROLS)
+        result = run_validate_riskmap(tmp_path, "--block")
         assert result.returncode == 1, (
             f"Expected exit 1 with --block on dirty corpus; got {result.returncode}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
 
-    def test_dirty_corpus_no_block_flag_exits_0(self, tmp_path):
+    def test_dirty_corpus_no_block_flag_exits_0(self, tmp_path, write_riskmap_corpus, run_validate_riskmap):
         """
         Running WITHOUT --block against a dirty synthesised corpus exits 0.
 
@@ -677,8 +631,8 @@ class TestBlockToggleCLI:
         When: validate_riskmap.py --force --allow-isolated (no --block)
         Then: Exit code is 0 (warnings only, no failure)
         """
-        _write_corpus(tmp_path, _MINIMAL_COMPONENTS, _DIRTY_CONTROLS)
-        result = _run(tmp_path)
+        write_riskmap_corpus(tmp_path, _MINIMAL_COMPONENTS, _DIRTY_CONTROLS)
+        result = run_validate_riskmap(tmp_path)
         assert result.returncode == 0, (
             f"Expected exit 0 without --block on dirty corpus; got {result.returncode}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
@@ -691,7 +645,9 @@ class TestBlockToggleCLI:
             f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
         )
 
-    def test_dirty_corpus_with_block_output_names_missing_component(self, tmp_path):
+    def test_dirty_corpus_with_block_output_names_missing_component(
+        self, tmp_path, write_riskmap_corpus, run_validate_riskmap
+    ):
         """
         When --block fires, the output names the missing component ID.
 
@@ -699,14 +655,16 @@ class TestBlockToggleCLI:
         When: validate_riskmap.py --force --allow-isolated --block
         Then: Output mentions "componentDoesNotExist"
         """
-        _write_corpus(tmp_path, _MINIMAL_COMPONENTS, _DIRTY_CONTROLS)
-        result = _run(tmp_path, "--block")
+        write_riskmap_corpus(tmp_path, _MINIMAL_COMPONENTS, _DIRTY_CONTROLS)
+        result = run_validate_riskmap(tmp_path, "--block")
         combined = result.stdout + result.stderr
         assert "componentDoesNotExist" in combined, (
             f"Expected 'componentDoesNotExist' in output; stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
         )
 
-    def test_escape_hatch_all_corpus_with_block_exits_0(self, tmp_path):
+    def test_escape_hatch_all_corpus_with_block_exits_0(
+        self, tmp_path, write_riskmap_corpus, run_validate_riskmap
+    ):
         """
         A corpus where all controls use the "all" escape hatch exits 0 with --block.
 
@@ -717,8 +675,8 @@ class TestBlockToggleCLI:
         When: validate_riskmap.py --force --allow-isolated --block
         Then: Exit code is 0
         """
-        _write_corpus(tmp_path, _MINIMAL_COMPONENTS, _ESCAPE_ALL_CONTROLS)
-        result = _run(tmp_path, "--block")
+        write_riskmap_corpus(tmp_path, _MINIMAL_COMPONENTS, _ESCAPE_ALL_CONTROLS)
+        result = run_validate_riskmap(tmp_path, "--block")
         assert result.returncode == 0, (
             f"Expected exit 0 with --block when controls use 'all' escape hatch; "
             f"got {result.returncode}\n"

--- a/scripts/hooks/tests/test_controls_components_mirror.py
+++ b/scripts/hooks/tests/test_controls_components_mirror.py
@@ -1,0 +1,771 @@
+#!/usr/bin/env python3
+"""
+Tests for the controls↔components mirror check (task 2.3.8 / issue #268).
+
+Per ADR-020 D7: every component ID listed in controls[].components[] must
+exist as a top-level component ID in components.yaml.  The literals "all"
+and "none" are escape hatches — they are valid and must not be flagged.
+Direction is one-way: control → component (NOT bidirectional).
+
+The check ships warn-only with a --block toggle:
+  default (no --block): print warnings, exit 0
+  --block:              warnings become errors, exit 1
+
+This mirrors the pattern established by A3 (validate_yaml_prose_subset.py)
+and A3.7 / 2.3.6 (validate_framework_references.py / check_deprecated_persona_usage).
+
+Symbol contract
+---------------
+The pure-function tests import `check_controls_components_mirror` from
+`riskmap_validator.validator`.  SWE must expose a callable with that name.
+Signature (SWE's call, but tests assume this shape):
+
+    check_controls_components_mirror(
+        controls: dict[str, ControlNode],
+        component_ids: set[str],
+    ) -> list[str]
+
+Returns a list of human-readable warning strings, one per (control_id,
+missing_component_id) pair or per control (SWE's call).  Empty list means
+clean.
+
+Test structure
+--------------
+1. TestCheckControlsComponentsMirror
+   Pure-function tests on check_controls_components_mirror().
+   These tests FAIL today with ImportError (function not yet implemented).
+   They pin the observable contract so SWE can implement to make them pass.
+
+2. TestBlockToggleCLI
+   Subprocess-based end-to-end tests for the --block flag on validate_riskmap.py.
+   These tests FAIL today with argparse exit 2 ("unrecognised arguments: --block").
+
+Synthesised-corpus harness
+--------------------------
+validate_riskmap.py's --force mode reads components.yaml at the path
+risk-map/yaml/components.yaml relative to cwd.  The ComponentEdgeValidator
+runs first; components.yaml must therefore be structurally valid (bidirectional
+edges, no missing references).  We use --allow-isolated to skip the orphan check
+so minimal corpora don't need a fully-connected graph.
+
+Minimal components.yaml shape expected by parse_components_yaml():
+  - top-level key: components (list)
+  - each entry has: id (str), title (str), category (str)
+  - edges: {to: [...], from: [...]}  (optional, defaults to [])
+
+Minimal controls.yaml shape expected by parse_controls_yaml():
+  - top-level key: controls (list)
+  - each entry has: id (str), title (str), category (str)
+  - components: list[str]  (the field under test)
+
+Live-corpus debt (verified 2026-05-04):
+  controls.yaml references componentInputHandling (line 338) and
+  componentOutputHandling (lines 73 and 377).  Neither exists in
+  components.yaml — the actual components are
+  componentApplicationInputHandling / componentApplicationOutputHandling.
+  This produces ≥3 dangling reference instances across 3 controls.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# sys.path injection — same pattern as the existing test files
+# ---------------------------------------------------------------------------
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "riskmap_validator"))
+
+from riskmap_validator.models import ControlNode  # noqa: E402
+
+# Deferred import: check_controls_components_mirror does not exist yet.
+# We capture the ImportError here and re-raise it inside a pytest fixture so
+# that pure-function tests fail individually while CLI test collection succeeds.
+try:
+    from riskmap_validator.validator import check_controls_components_mirror  # noqa: E402
+
+    _MIRROR_IMPORT_ERROR: ImportError | None = None
+except ImportError as _e:
+    check_controls_components_mirror = None  # type: ignore[assignment]
+    _MIRROR_IMPORT_ERROR = _e
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+# Absolute path to the CLI script under test.
+_SCRIPT = Path(__file__).parent.parent / "validate_riskmap.py"
+
+# Repository root (worktree root) — used as cwd for live-corpus subprocess tests.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+# Known dangling component IDs in the live corpus (as of 2026-05-04).
+_LIVE_DANGLING_COMPONENT_IDS = {"componentInputHandling", "componentOutputHandling"}
+
+# Escape-hatch literals that must never produce a warning.
+_ESCAPE_HATCHES = ("all", "none")
+
+# A set of component IDs that represent a minimal valid component map for
+# pure-function tests — these IDs do NOT need to match any real YAML file.
+_VALID_COMPONENT_IDS = {"componentAlpha", "componentBeta", "componentGamma"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers for pure-function tests
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Fixture that makes the deferred import visible to pure-function tests.
+# If the function does not yet exist the fixture raises, failing the test
+# with an informative error (rather than AttributeError on None).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mirror_fn():
+    """Return check_controls_components_mirror, or fail with ImportError.
+
+    Pure-function tests request this fixture so that the ImportError from
+    the deferred import surfaces as a test failure rather than a collection
+    error.  This keeps the CLI tests collectible and runnable independently.
+    """
+    if _MIRROR_IMPORT_ERROR is not None:
+        raise _MIRROR_IMPORT_ERROR
+    return check_controls_components_mirror
+
+
+def _make_control(
+    ctrl_id: str,
+    components: list[str],
+    category: str = "controlsModel",
+) -> ControlNode:
+    """Construct a ControlNode for testing.
+
+    Args:
+        ctrl_id: Control identifier (also used as title for simplicity).
+        components: The components list to attach.
+        category: Category string (any non-empty value satisfies ControlNode).
+
+    Returns:
+        A ControlNode with minimal required fields populated.
+    """
+    return ControlNode(
+        title=ctrl_id,
+        category=category,
+        components=components,
+        risks=[],
+        personas=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers for synthesised-corpus subprocess tests
+# ---------------------------------------------------------------------------
+
+# Minimal components.yaml whose two components reference each other so
+# ComponentEdgeValidator does not fail on missing back-edges.
+_MINIMAL_COMPONENTS: dict[str, Any] = {
+    "components": [
+        {
+            "id": "componentAlpha",
+            "title": "Alpha",
+            "category": "componentsInfrastructure",
+            "edges": {"to": ["componentBeta"], "from": []},
+        },
+        {
+            "id": "componentBeta",
+            "title": "Beta",
+            "category": "componentsInfrastructure",
+            "edges": {"to": [], "from": ["componentAlpha"]},
+        },
+    ]
+}
+
+# controls.yaml that references only IDs present in _MINIMAL_COMPONENTS.
+_CLEAN_CONTROLS: dict[str, Any] = {
+    "controls": [
+        {
+            "id": "controlClean",
+            "title": "Clean Control",
+            "category": "controlsModel",
+            "components": ["componentAlpha", "componentBeta"],
+            "risks": [],
+            "personas": [],
+        }
+    ]
+}
+
+# controls.yaml that references a component ID absent from _MINIMAL_COMPONENTS.
+_DIRTY_CONTROLS: dict[str, Any] = {
+    "controls": [
+        {
+            "id": "controlDirty",
+            "title": "Dirty Control",
+            "category": "controlsModel",
+            "components": ["componentAlpha", "componentDoesNotExist"],
+            "risks": [],
+            "personas": [],
+        }
+    ]
+}
+
+# controls.yaml using only "all" escape hatch — must not trigger mirror warning.
+_ESCAPE_ALL_CONTROLS: dict[str, Any] = {
+    "controls": [
+        {
+            "id": "controlAll",
+            "title": "All Control",
+            "category": "controlsGovernance",
+            "components": ["all"],
+            "risks": [],
+            "personas": [],
+        }
+    ]
+}
+
+
+def _write_corpus(
+    base: Path,
+    components: dict[str, Any],
+    controls: dict[str, Any],
+) -> Path:
+    """Write a minimal two-file corpus under base/risk-map/yaml/ and return base.
+
+    validate_riskmap.py also reads risks.yaml; we write a minimal stub.
+    The risks file is not exercised by the mirror check so its contents are
+    irrelevant as long as parse_risks_yaml() does not error.
+
+    Args:
+        base: Temporary directory root (from tmp_path fixture).
+        components: Parsed components.yaml content dict.
+        controls: Parsed controls.yaml content dict.
+
+    Returns:
+        The base path (for use as subprocess cwd).
+    """
+    yaml_dir = base / "risk-map" / "yaml"
+    yaml_dir.mkdir(parents=True)
+    (yaml_dir / "components.yaml").write_text(yaml.dump(components), encoding="utf-8")
+    (yaml_dir / "controls.yaml").write_text(yaml.dump(controls), encoding="utf-8")
+    # Minimal risks stub so the script doesn't fail on a missing file.
+    (yaml_dir / "risks.yaml").write_text(yaml.dump({"risks": []}), encoding="utf-8")
+    return base
+
+
+def _run(cwd: Path, *extra_args: str) -> subprocess.CompletedProcess:
+    """Run validate_riskmap.py via subprocess with --force and any extra args.
+
+    Always passes --force so the script validates regardless of git-staged state.
+    Always passes --allow-isolated so minimal synthesised corpora do not fail
+    the ComponentEdgeValidator's orphan check.
+
+    Args:
+        cwd: Working directory for the subprocess.
+        *extra_args: Additional CLI arguments (e.g. "--block").
+
+    Returns:
+        CompletedProcess with returncode, stdout, stderr.
+    """
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), "--force", "--allow-isolated", *extra_args],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+    )
+
+
+# ===========================================================================
+# 1. Pure-function tests — check_controls_components_mirror()
+#    These tests FAIL today with ImportError (red phase).
+# ===========================================================================
+
+
+class TestCheckControlsComponentsMirror:
+    """Pure-function tests for check_controls_components_mirror().
+
+    The function does not exist yet.  Every test in this class requests the
+    `mirror_fn` fixture which raises ImportError when the symbol is absent,
+    causing each test to FAIL (not ERROR at collection time).  This keeps
+    TestBlockToggleCLI collectible and runnable independently.
+
+    Once SWE implements the function in riskmap_validator/validator.py,
+    these tests are the green-phase acceptance criteria.
+    """
+
+    def test_clean_controls_return_empty_list(self, mirror_fn):
+        """
+        All controls referencing only known component IDs returns empty list.
+
+        Given: controls dict where every component reference is in component_ids
+        When: check_controls_components_mirror() is called
+        Then: Returns an empty list (no warnings)
+        """
+        controls = {
+            "controlA": _make_control("controlA", ["componentAlpha", "componentBeta"]),
+            "controlB": _make_control("controlB", ["componentGamma"]),
+        }
+        result = mirror_fn(controls, _VALID_COMPONENT_IDS)
+        assert result == [], f"Expected no warnings for clean controls; got: {result}"
+
+    def test_single_dangling_ref_returns_warning_naming_control_and_component(self, mirror_fn):
+        """
+        One control referencing a missing component ID produces a warning
+        that names both the control ID and the missing component ID.
+
+        Given: controls dict with one control that references componentDoesNotExist
+               which is absent from component_ids
+        When: check_controls_components_mirror() is called
+        Then: Returns a non-empty list; warning text contains both
+              "controlMissing" and "componentDoesNotExist"
+        """
+        controls = {"controlMissing": _make_control("controlMissing", ["componentAlpha", "componentDoesNotExist"])}
+        result = mirror_fn(controls, _VALID_COMPONENT_IDS)
+        assert len(result) >= 1, f"Expected at least one warning; got: {result}"
+        combined = " ".join(result)
+        assert "controlMissing" in combined, f"Expected 'controlMissing' in warning text; got: {result}"
+        assert "componentDoesNotExist" in combined, (
+            f"Expected 'componentDoesNotExist' in warning text; got: {result}"
+        )
+
+    def test_multiple_dangling_refs_in_one_control_each_produces_warning(self, mirror_fn):
+        """
+        A control referencing two missing component IDs produces warnings
+        that mention both missing IDs.
+
+        Given: controlX references [componentAlpha, componentMissingA, componentMissingB]
+               where only componentAlpha is in component_ids
+        When: check_controls_components_mirror() is called
+        Then: The combined warning text mentions componentMissingA AND componentMissingB
+        """
+        controls = {
+            "controlX": _make_control(
+                "controlX",
+                ["componentAlpha", "componentMissingA", "componentMissingB"],
+            )
+        }
+        result = mirror_fn(controls, _VALID_COMPONENT_IDS)
+        assert len(result) >= 1, f"Expected at least one warning; got: {result}"
+        combined = " ".join(result)
+        assert "componentMissingA" in combined, f"Expected 'componentMissingA' in warnings; got: {result}"
+        assert "componentMissingB" in combined, f"Expected 'componentMissingB' in warnings; got: {result}"
+
+    def test_multiple_controls_with_dangling_refs_each_appears_in_warnings(self, mirror_fn):
+        """
+        Each control with a dangling reference appears in the warning output.
+
+        Given: controlP and controlQ each reference a missing component
+        When: check_controls_components_mirror() is called
+        Then: The combined warning text mentions controlP AND controlQ
+        """
+        controls = {
+            "controlP": _make_control("controlP", ["componentMissingX"]),
+            "controlQ": _make_control("controlQ", ["componentMissingY"]),
+        }
+        result = mirror_fn(controls, _VALID_COMPONENT_IDS)
+        assert len(result) >= 1, f"Expected at least one warning; got: {result}"
+        combined = " ".join(result)
+        assert "controlP" in combined, f"Expected 'controlP' in warnings; got: {result}"
+        assert "controlQ" in combined, f"Expected 'controlQ' in warnings; got: {result}"
+
+    def test_escape_hatch_all_produces_no_warning(self, mirror_fn):
+        """
+        A control with components: ["all"] produces no warning.
+
+        "all" is a documented escape hatch meaning the control applies to
+        all components.  It must not be flagged as a missing component ID.
+
+        Given: A control with components=["all"]
+        When: check_controls_components_mirror() is called
+        Then: Returns empty list
+        """
+        controls = {"controlAll": _make_control("controlAll", ["all"])}
+        result = mirror_fn(controls, _VALID_COMPONENT_IDS)
+        assert result == [], f"Expected no warning for escape hatch 'all'; got: {result}"
+
+    def test_escape_hatch_none_produces_no_warning(self, mirror_fn):
+        """
+        A control with components: ["none"] produces no warning.
+
+        "none" is a documented escape hatch meaning the control applies to
+        no specific component.  It must not be flagged as a missing component ID.
+
+        Given: A control with components=["none"]
+        When: check_controls_components_mirror() is called
+        Then: Returns empty list
+        """
+        controls = {"controlNone": _make_control("controlNone", ["none"])}
+        result = mirror_fn(controls, _VALID_COMPONENT_IDS)
+        assert result == [], f"Expected no warning for escape hatch 'none'; got: {result}"
+
+    def test_empty_components_list_produces_no_warning(self, mirror_fn):
+        """
+        A control with an empty components list produces no warning.
+
+        There is nothing to check; the function must not raise and must
+        return an empty list.
+
+        Given: A control with components=[]
+        When: check_controls_components_mirror() is called
+        Then: Returns empty list
+        """
+        controls = {"controlEmpty": _make_control("controlEmpty", [])}
+        result = mirror_fn(controls, _VALID_COMPONENT_IDS)
+        assert result == [], f"Expected no warning for empty components list; got: {result}"
+
+    def test_empty_controls_dict_returns_empty_list(self, mirror_fn):
+        """
+        Passing an empty controls dict returns an empty list without raising.
+
+        Given: controls={}
+        When: check_controls_components_mirror() is called
+        Then: Returns empty list
+        """
+        result = mirror_fn({}, _VALID_COMPONENT_IDS)
+        assert result == [], f"Expected empty list for empty controls dict; got: {result}"
+
+    def test_returns_list_type(self, mirror_fn):
+        """
+        The function always returns a list, never None.
+
+        Given: Any valid input
+        When: check_controls_components_mirror() is called
+        Then: Return value is a list instance
+        """
+        result = mirror_fn({}, set())
+        assert isinstance(result, list), f"Expected list; got {type(result)}"
+
+    def test_each_warning_is_a_string(self, mirror_fn):
+        """
+        Every element in the returned warnings list is a str.
+
+        Given: A controls dict with at least one dangling reference
+        When: check_controls_components_mirror() is called
+        Then: Every element in the returned list is a str instance
+        """
+        controls = {"controlBad": _make_control("controlBad", ["componentGhost"])}
+        result = mirror_fn(controls, _VALID_COMPONENT_IDS)
+        assert len(result) >= 1, "Expected at least one warning for this input"
+        for item in result:
+            assert isinstance(item, str), f"Expected str element; got {type(item)!r}: {item!r}"
+
+    def test_valid_component_refs_not_flagged_as_missing(self, mirror_fn):
+        """
+        Component IDs that exist in component_ids do not appear as missing refs.
+
+        Guards against false-positives: the function must only report IDs that
+        are absent from component_ids.
+
+        Given: A control referencing componentAlpha (present) and componentGhost (absent)
+        When: check_controls_components_mirror() is called
+        Then: "componentGhost" appears in the combined warning text;
+              the warning count does not exceed the number of missing IDs (1)
+        """
+        controls = {"controlMixed": _make_control("controlMixed", ["componentAlpha", "componentGhost"])}
+        result = mirror_fn(controls, _VALID_COMPONENT_IDS)
+        assert len(result) >= 1, "Expected a warning for componentGhost"
+        combined = " ".join(result)
+        assert "componentGhost" in combined, f"Expected 'componentGhost' in warning text; got: {result}"
+        # The valid reference must NOT appear in any warning text — guards
+        # against a false-positive where every listed component (valid or not)
+        # is flagged as missing.
+        assert "componentAlpha" not in combined, (
+            f"Expected 'componentAlpha' (valid ref) NOT in warning text; got: {result}"
+        )
+
+    def test_live_corpus_regression_produces_known_dangling_refs(self, mirror_fn):
+        """
+        Running against the actual controls.yaml + components.yaml surfaces
+        the 3 known dangling references present as of 2026-05-04.
+
+        Given: Parsed controls from risk-map/yaml/controls.yaml
+               Parsed components from risk-map/yaml/components.yaml
+        When: check_controls_components_mirror() is called
+        Then: Warning count >= 3 AND warnings mention componentInputHandling
+              AND warnings mention componentOutputHandling
+
+        This is a live-corpus regression guard.  If the content debt is ever
+        remediated (componentInputHandling → componentApplicationInputHandling,
+        etc.), this test will need updating to reflect the new expected count.
+        """
+        from riskmap_validator.utils import parse_components_yaml, parse_controls_yaml
+
+        components_path = _REPO_ROOT / "risk-map" / "yaml" / "components.yaml"
+        controls_path = _REPO_ROOT / "risk-map" / "yaml" / "controls.yaml"
+
+        components = parse_components_yaml(components_path)
+        controls = parse_controls_yaml(controls_path)
+        component_ids = set(components.keys())
+
+        result = mirror_fn(controls, component_ids)
+
+        assert len(result) >= 3, f"Expected >= 3 warnings for known dangling refs; got {len(result)}: {result}"
+        combined = " ".join(result)
+        assert "componentInputHandling" in combined, (
+            f"Expected 'componentInputHandling' in warnings; got: {result}"
+        )
+        assert "componentOutputHandling" in combined, (
+            f"Expected 'componentOutputHandling' in warnings; got: {result}"
+        )
+
+
+# ===========================================================================
+# 2. CLI tests — --block toggle on validate_riskmap.py
+#    These tests FAIL today with argparse exit 2 (red phase).
+# ===========================================================================
+
+
+class TestBlockToggleCLI:
+    """End-to-end CLI tests for the --block flag on validate_riskmap.py.
+
+    These tests fail in the red phase because --block does not yet exist on
+    validate_riskmap.py's argparse.  argparse exits 2 for unrecognised args.
+
+    Live-corpus tests use _REPO_ROOT as cwd.
+    Synthesised-corpus tests build a minimal two-file corpus in tmp_path.
+    """
+
+    # -----------------------------------------------------------------------
+    # Live corpus: the actual risk-map/yaml/ tree in the worktree.
+    # Has 3 known dangling refs (componentInputHandling ×1, componentOutputHandling ×2).
+    # -----------------------------------------------------------------------
+
+    def test_live_corpus_no_block_flag_exits_0(self):
+        """
+        Running without --block against the live corpus exits 0.
+
+        Warn-only default must not be broken by adding --block.  This is a
+        regression guard: today validate_riskmap.py exits 0 on the live corpus.
+
+        Given: The live risk-map/yaml/ corpus (3 dangling component refs)
+        When: validate_riskmap.py --force --allow-isolated (no --block)
+        Then: Exit code is 0
+        """
+        result = _run(_REPO_ROOT)
+        assert result.returncode == 0, (
+            f"Expected exit 0 without --block on live corpus; got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_live_corpus_with_block_flag_exits_1(self):
+        """
+        Running with --block against the live corpus exits 1 because the 3
+        dangling component refs promote warnings to errors.
+
+        Given: The live risk-map/yaml/ corpus (3 dangling component refs)
+        When: validate_riskmap.py --force --allow-isolated --block
+        Then: Exit code is 1 (mirror warnings promoted to failures)
+        """
+        result = _run(_REPO_ROOT, "--block")
+        assert result.returncode == 1, (
+            f"Expected exit 1 with --block on live corpus; got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_live_corpus_with_block_output_names_dangling_components(self):
+        """
+        When --block fires on the live corpus, the output text names the
+        dangling component IDs so developers can locate the defects.
+
+        Given: The live corpus and --block
+        When: validate_riskmap.py --force --allow-isolated --block
+        Then: Output (stdout or stderr) mentions at least one of
+              componentInputHandling or componentOutputHandling
+        """
+        result = _run(_REPO_ROOT, "--block")
+        combined = result.stdout + result.stderr
+        mentions_known_dangling = any(cid in combined for cid in _LIVE_DANGLING_COMPONENT_IDS)
+        assert mentions_known_dangling, (
+            "Expected output to name at least one dangling component ID "
+            f"({_LIVE_DANGLING_COMPONENT_IDS}); "
+            f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+        )
+
+    # -----------------------------------------------------------------------
+    # Synthesised clean corpus: no dangling refs → --block must NOT fire.
+    # -----------------------------------------------------------------------
+
+    def test_clean_corpus_with_block_flag_exits_0(self, tmp_path):
+        """
+        Running with --block against a corpus with no dangling refs exits 0.
+
+        The toggle must only promote warnings to failures when warnings
+        actually exist; a clean corpus always exits 0.
+
+        Given: A synthesised corpus where all controls reference components
+               that exist in components.yaml
+        When: validate_riskmap.py --force --allow-isolated --block (cwd=tmp_path)
+        Then: Exit code is 0 (no mirror warnings to promote)
+        """
+        _write_corpus(tmp_path, _MINIMAL_COMPONENTS, _CLEAN_CONTROLS)
+        result = _run(tmp_path, "--block")
+        assert result.returncode == 0, (
+            f"Expected exit 0 with --block on clean corpus; got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_clean_corpus_no_block_flag_exits_0(self, tmp_path):
+        """
+        Running without --block against a clean corpus exits 0.
+
+        Baseline sanity check that the synthesised-corpus harness is correct.
+
+        Given: A synthesised clean corpus
+        When: validate_riskmap.py --force --allow-isolated (no --block)
+        Then: Exit code is 0
+        """
+        _write_corpus(tmp_path, _MINIMAL_COMPONENTS, _CLEAN_CONTROLS)
+        result = _run(tmp_path)
+        assert result.returncode == 0, (
+            f"Expected exit 0 on clean corpus without --block; got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    # -----------------------------------------------------------------------
+    # Synthesised dirty corpus: dangling refs present.
+    # -----------------------------------------------------------------------
+
+    def test_dirty_corpus_with_block_flag_exits_1(self, tmp_path):
+        """
+        Running with --block against a synthesised dirty corpus exits 1.
+
+        Cross-checks that the toggle fires on a synthetic corpus, not just
+        the live one.
+
+        Given: A synthesised corpus where controlDirty references
+               componentDoesNotExist (absent from components.yaml)
+        When: validate_riskmap.py --force --allow-isolated --block
+        Then: Exit code is 1
+        """
+        _write_corpus(tmp_path, _MINIMAL_COMPONENTS, _DIRTY_CONTROLS)
+        result = _run(tmp_path, "--block")
+        assert result.returncode == 1, (
+            f"Expected exit 1 with --block on dirty corpus; got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_dirty_corpus_no_block_flag_exits_0(self, tmp_path):
+        """
+        Running WITHOUT --block against a dirty synthesised corpus exits 0.
+
+        Confirms warn-only default behaviour is preserved even when dangling
+        component refs exist.
+
+        Given: A synthesised corpus where controlDirty references
+               componentDoesNotExist (absent from components.yaml)
+        When: validate_riskmap.py --force --allow-isolated (no --block)
+        Then: Exit code is 0 (warnings only, no failure)
+        """
+        _write_corpus(tmp_path, _MINIMAL_COMPONENTS, _DIRTY_CONTROLS)
+        result = _run(tmp_path)
+        assert result.returncode == 0, (
+            f"Expected exit 0 without --block on dirty corpus; got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        # Warn-only must still emit the warning — exit-0 alone doesn't prove
+        # the check ran. Without this assertion, a silent skip would pass.
+        combined = result.stdout + result.stderr
+        assert "componentDoesNotExist" in combined, (
+            f"Expected warn output naming 'componentDoesNotExist' even without --block; "
+            f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+        )
+
+    def test_dirty_corpus_with_block_output_names_missing_component(self, tmp_path):
+        """
+        When --block fires, the output names the missing component ID.
+
+        Given: A synthesised dirty corpus (componentDoesNotExist dangling)
+        When: validate_riskmap.py --force --allow-isolated --block
+        Then: Output mentions "componentDoesNotExist"
+        """
+        _write_corpus(tmp_path, _MINIMAL_COMPONENTS, _DIRTY_CONTROLS)
+        result = _run(tmp_path, "--block")
+        combined = result.stdout + result.stderr
+        assert "componentDoesNotExist" in combined, (
+            f"Expected 'componentDoesNotExist' in output; stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+        )
+
+    def test_escape_hatch_all_corpus_with_block_exits_0(self, tmp_path):
+        """
+        A corpus where all controls use the "all" escape hatch exits 0 with --block.
+
+        The escape hatches must be respected end-to-end; the CLI must not
+        flag "all" as a missing component.
+
+        Given: A synthesised corpus where all controls use components: ["all"]
+        When: validate_riskmap.py --force --allow-isolated --block
+        Then: Exit code is 0
+        """
+        _write_corpus(tmp_path, _MINIMAL_COMPONENTS, _ESCAPE_ALL_CONTROLS)
+        result = _run(tmp_path, "--block")
+        assert result.returncode == 0, (
+            f"Expected exit 0 with --block when controls use 'all' escape hatch; "
+            f"got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    # -----------------------------------------------------------------------
+    # Flag discovery: --help must list --block
+    # -----------------------------------------------------------------------
+
+    def test_help_output_contains_block_flag(self):
+        """
+        The --help output documents the --block flag.
+
+        Given: The script is invoked with --help
+        When: validate_riskmap.py --help
+        Then: The --help text contains '--block'
+        """
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT), "--help"],
+            capture_output=True,
+            text=True,
+        )
+        # argparse --help exits 0
+        assert result.returncode == 0, f"--help unexpectedly exited {result.returncode}"
+        assert "--block" in result.stdout, f"Expected '--block' in --help output; got:\n{result.stdout}"
+
+
+# ===========================================================================
+# Test Summary
+# ===========================================================================
+# Total tests: 22
+#
+# TestCheckControlsComponentsMirror  (12 tests — pure function)
+#   — clean controls return empty list; single dangling ref names control +
+#     component; multiple missing refs in one control both appear; multiple
+#     controls each appear; escape "all" no warning; escape "none" no warning;
+#     empty components list no warning; empty controls dict no warning; return
+#     type is list; each element is str; valid refs not in warnings; live-corpus
+#     regression (>=3 warnings, componentInputHandling + componentOutputHandling).
+#
+# TestBlockToggleCLI  (10 tests — subprocess CLI)
+#   — live corpus + no --block -> exit 0 (regression guard);
+#     live corpus + --block -> exit 1 (3 dangling refs fire the toggle);
+#     live corpus + --block -> output names dangling component IDs;
+#     clean synthesised corpus + --block -> exit 0;
+#     clean synthesised corpus + no --block -> exit 0;
+#     dirty synthesised corpus + --block -> exit 1;
+#     dirty synthesised corpus + no --block -> exit 0 (warn-only preserved);
+#     dirty corpus + --block -> output names missing component;
+#     escape-hatch "all" corpus + --block -> exit 0;
+#     --help output contains '--block'.
+#
+# Red-phase failure modes
+#   - TestCheckControlsComponentsMirror: ImportError at collection time
+#     (check_controls_components_mirror not yet defined in validator.py)
+#   - TestBlockToggleCLI: argparse exit 2
+#     ("unrecognised arguments: --block") for all tests that pass --block,
+#     including --help (which today shows no --block flag in the output);
+#     the no-block exit-code tests pass today (see note below).
+#
+# Tests that pass today (intentional)
+#   - test_live_corpus_no_block_flag_exits_0: regression guard on existing
+#     behaviour; validate_riskmap.py already exits 0 on the live corpus.
+#   - test_clean_corpus_no_block_flag_exits_0: same reason.
+#   - test_dirty_corpus_no_block_flag_exits_0: validate_riskmap.py exits 0
+#     today because it does not yet run the mirror check at all.

--- a/scripts/hooks/tests/test_controls_components_mirror.py
+++ b/scripts/hooks/tests/test_controls_components_mirror.py
@@ -296,17 +296,16 @@ def _run(cwd: Path, *extra_args: str) -> subprocess.CompletedProcess:
 
 # ===========================================================================
 # 1. Pure-function tests — check_controls_components_mirror()
-#    These tests FAIL today with ImportError (red phase).
 # ===========================================================================
 
 
 class TestCheckControlsComponentsMirror:
     """Pure-function tests for check_controls_components_mirror().
 
-    The function does not exist yet.  Every test in this class requests the
-    `mirror_fn` fixture which raises ImportError when the symbol is absent,
-    causing each test to FAIL (not ERROR at collection time).  This keeps
-    TestBlockToggleCLI collectible and runnable independently.
+    Every test in this class requests the `mirror_fn` fixture which raises
+    ImportError when the symbol is absent, causing each test to FAIL (not
+    ERROR at collection time).  This keeps TestBlockToggleCLI collectible
+    and runnable independently.
 
     Once SWE implements the function in riskmap_validator/validator.py,
     these tests are the green-phase acceptance criteria.
@@ -530,15 +529,11 @@ class TestCheckControlsComponentsMirror:
 
 # ===========================================================================
 # 2. CLI tests — --block toggle on validate_riskmap.py
-#    These tests FAIL today with argparse exit 2 (red phase).
 # ===========================================================================
 
 
 class TestBlockToggleCLI:
     """End-to-end CLI tests for the --block flag on validate_riskmap.py.
-
-    These tests fail in the red phase because --block does not yet exist on
-    validate_riskmap.py's argparse.  argparse exits 2 for unrecognised args.
 
     Live-corpus tests use _REPO_ROOT as cwd.
     Synthesised-corpus tests build a minimal two-file corpus in tmp_path.

--- a/scripts/hooks/tests/test_controls_components_mirror.py
+++ b/scripts/hooks/tests/test_controls_components_mirror.py
@@ -168,22 +168,37 @@ def _make_control(
 # ---------------------------------------------------------------------------
 
 # Minimal components.yaml whose two components reference each other so
-# ComponentEdgeValidator does not fail on missing back-edges.
+# ComponentEdgeValidator does not fail on missing back-edges. The categories
+# block + subcategory fields make this corpus opaque to task 2.3.9's nesting
+# check (after 2.3.9 wires, every component has a valid (category, subcategory)
+# pair so the nesting check stays silent and the mirror behavior remains
+# isolated).
 _MINIMAL_COMPONENTS: dict[str, Any] = {
     "components": [
         {
             "id": "componentAlpha",
             "title": "Alpha",
             "category": "componentsInfrastructure",
+            "subcategory": "componentsData",
             "edges": {"to": ["componentBeta"], "from": []},
         },
         {
             "id": "componentBeta",
             "title": "Beta",
             "category": "componentsInfrastructure",
+            "subcategory": "componentsData",
             "edges": {"to": [], "from": ["componentAlpha"]},
         },
-    ]
+    ],
+    "categories": [
+        {
+            "id": "componentsInfrastructure",
+            "title": "Infrastructure",
+            "subcategory": [
+                {"id": "componentsData", "title": "Data"},
+            ],
+        },
+    ],
 }
 
 # controls.yaml that references only IDs present in _MINIMAL_COMPONENTS.

--- a/scripts/hooks/tests/test_folded_bullet_live_corpus.py
+++ b/scripts/hooks/tests/test_folded_bullet_live_corpus.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+r"""
+Live-corpus regression guards for folded-bullet drift (issue #225, ADR-020 D4).
+
+Background
+----------
+The folded-bullet drift heuristic (INVALID_FOLDED_BULLET, Rule 10 in
+_prose_tokens.py) detects **source-form** drift: whitespace-prefixed "- item"
+lines in raw decoded strings.
+
+The two known issue #225 cases use YAML ``>`` folded scalars instead. When
+PyYAML decodes a ``>`` block it collapses indentation, so embedded list items
+arrive at column 0 in the Python string — triggering INVALID_LIST (Rule 5)
+rather than INVALID_FOLDED_BULLET.
+
+Both drift cases are caught:
+- ``controlModelAndDataExecutionIntegrity.description[1]`` → INVALID_LIST
+- ``riskSensitiveDataDisclosure.longDescription[3]``        → INVALID_LIST
+
+What this file pins:
+1. Live-corpus regression — the two specific entries above continue to
+   produce diagnostics (alarm if the corpus is cleaned without updating
+   issue #225 tracking).
+2. Diagnostic-text contract — the INVALID_LIST reason cross-references
+   ``ADR-020 D4`` so authors who encounter the message find the heuristic's
+   broader documentation.
+
+Test Summary
+============
+Total tests: 8
+
+- Live-corpus controls regression (3 tests): diagnostic exists at the entry,
+  on description[1], with ADR-020 D4 in the reason.
+- Live-corpus risks regression (3 tests): diagnostic exists at the entry,
+  on longDescription[3], with ADR-020 D4 in the reason.
+- INVALID_LIST reason-text contract (2 tests): synthetic input asserts the
+  reason mentions ADR-020 D4 and hints at folded-bullet drift.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Inject scripts/hooks so precommit.* imports work from any working directory.
+_HOOKS_DIR = Path(__file__).resolve().parent.parent
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+try:
+    from precommit._prose_tokens import TokenKind, tokenize  # noqa: E402
+    from precommit.validate_yaml_prose_subset import (  # noqa: E402
+        Diagnostic,
+        check_prose_field,
+        find_prose_fields,
+    )
+
+    _IMPORT_ERROR: Exception | None = None
+except ImportError as _e:
+    _IMPORT_ERROR = _e
+    Diagnostic = None  # type: ignore[assignment,misc]
+    check_prose_field = None  # type: ignore[assignment]
+    find_prose_fields = None  # type: ignore[assignment]
+    TokenKind = None  # type: ignore[assignment]
+    tokenize = None  # type: ignore[assignment]
+
+
+@pytest.fixture(autouse=True)
+def _require_imports():
+    """Skip every test with ImportError if the implementation modules are absent."""
+    if _IMPORT_ERROR is not None:
+        raise _IMPORT_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_SCHEMA_DIR = _REPO_ROOT / "risk-map" / "schemas"
+_CONTROLS_YAML = _REPO_ROOT / "risk-map" / "yaml" / "controls.yaml"
+_RISKS_YAML = _REPO_ROOT / "risk-map" / "yaml" / "risks.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect_entry_diagnostics(yaml_path: Path, entry_id: str) -> list:
+    """Run the prose-subset linter on all fields of a single entry.
+
+    Collects ProseFields for the given entry_id and returns all Diagnostic
+    objects produced by check_prose_field across every matching field.
+
+    Args:
+        yaml_path: Path to the YAML file.
+        entry_id:  The entry's ``id`` value to filter on.
+
+    Returns:
+        List of Diagnostic objects for all fields of that entry.
+    """
+    diagnostics = []
+    for field in find_prose_fields(yaml_path, _SCHEMA_DIR):
+        if field.entry_id == entry_id:
+            diagnostics.extend(check_prose_field(field))
+    return diagnostics
+
+
+# ===========================================================================
+# Scope (a) — live-corpus regression guards: controls.yaml
+# ===========================================================================
+
+
+class TestControlsLiveCorpusDriftRegression:
+    r"""Regression guard for controlModelAndDataExecutionIntegrity (issue #225).
+
+    The ``description[1]`` field contains a YAML ``>`` folded scalar with
+    embedded "- item" bullet lines.  When decoded by PyYAML the items land at
+    column 0 → INVALID_LIST fires.
+
+    These tests pin the specific corpus entry to the diagnostic output so that
+    future content edits that silently fix or regress the drift are caught.
+    """
+
+    def test_controls_drift_entry_produces_diagnostic(self):
+        r"""
+        The known drift entry in controls.yaml produces at least one diagnostic.
+
+        Given: The live controls.yaml corpus file
+        When: find_prose_fields + check_prose_field are run over the file
+        Then: At least one Diagnostic is produced for
+              controlModelAndDataExecutionIntegrity
+
+        Regression guard: if the entry is cleaned up (drift removed) this
+        test will fail. That is the intended behaviour — update or remove
+        this test and close issue #225 when the cleanup lands.
+        """
+        if not _CONTROLS_YAML.is_file():
+            pytest.skip(f"Live corpus not found: {_CONTROLS_YAML}")
+
+        diags = _collect_entry_diagnostics(_CONTROLS_YAML, "controlModelAndDataExecutionIntegrity")
+        assert len(diags) >= 1, (
+            "Expected at least one diagnostic for "
+            "controlModelAndDataExecutionIntegrity; found none. "
+            "If the drift was intentionally removed, update this test and "
+            "close issue #225."
+        )
+
+    def test_controls_drift_entry_is_at_description_index_1(self):
+        r"""
+        The diagnostic for the known controls drift is on description[1].
+
+        Given: The live controls.yaml corpus file
+        When: find_prose_fields + check_prose_field are run
+        Then: At least one Diagnostic has field_name == 'description'
+              AND index == 1 for entry controlModelAndDataExecutionIntegrity
+
+        Regression guard: a failing assertion after content cleanup is the
+        intended behaviour. Update or remove this test and close issue #225
+        when the cleanup lands.
+        """
+        if not _CONTROLS_YAML.is_file():
+            pytest.skip(f"Live corpus not found: {_CONTROLS_YAML}")
+
+        diags = _collect_entry_diagnostics(_CONTROLS_YAML, "controlModelAndDataExecutionIntegrity")
+        matching = [d for d in diags if d.field_name == "description" and d.index == 1]
+        assert len(matching) >= 1, (
+            "Expected a diagnostic at description[1] for "
+            "controlModelAndDataExecutionIntegrity. "
+            f"Got diagnostics: {[(d.field_name, d.index) for d in diags]}"
+        )
+
+    def test_controls_drift_diagnostic_mentions_adr020(self):
+        r"""
+        The controls drift diagnostic reason cross-references ADR-020 D4.
+
+        Given: The live controls.yaml corpus file
+        When: find_prose_fields + check_prose_field are run
+        Then: At least one diagnostic for controlModelAndDataExecutionIntegrity
+              description[1] has a reason that mentions 'ADR-020 D4'
+
+        Contract: the INVALID_LIST reason includes the ADR-020 D4 reference so
+        a reader who hits this diagnostic finds the folded-bullet documentation.
+        """
+        if not _CONTROLS_YAML.is_file():
+            pytest.skip(f"Live corpus not found: {_CONTROLS_YAML}")
+
+        diags = _collect_entry_diagnostics(_CONTROLS_YAML, "controlModelAndDataExecutionIntegrity")
+        description_diags = [d for d in diags if d.field_name == "description" and d.index == 1]
+        assert len(description_diags) >= 1, (
+            "Prerequisite failed: no diagnostic at description[1]; "
+            "check test_controls_drift_entry_is_at_description_index_1."
+        )
+        # The key assertion: at least one reason must mention ADR-020 D4.
+        # Substring containment, not exact match — allows wording flexibility.
+        has_adr_reference = any("ADR-020 D4" in d.reason for d in description_diags)
+        assert has_adr_reference, (
+            "Expected at least one diagnostic reason for "
+            "controlModelAndDataExecutionIntegrity description[1] to contain "
+            "'ADR-020 D4'. This cross-reference directs authors to the correct "
+            "documentation when they encounter the folded-bullet drift message. "
+            f"Actual reasons: {[d.reason for d in description_diags]}"
+        )
+
+
+# ===========================================================================
+# Scope (a) — live-corpus regression guards: risks.yaml
+# ===========================================================================
+
+
+class TestRisksLiveCorpusDriftRegression:
+    r"""Regression guard for riskSensitiveDataDisclosure (issue #225).
+
+    The ``longDescription[3]`` field is a nested-list outer item containing a
+    YAML ``>`` folded scalar with embedded "- Category: explanation" bullet
+    lines.  After PyYAML decoding, the items land at column 0 → INVALID_LIST.
+    The nested structure means ``index == 3`` and ``nested_index == 0`` in the
+    ProseField; the Diagnostic carries ``index == 3``.
+    """
+
+    def test_risks_drift_entry_produces_diagnostic(self):
+        r"""
+        The known drift entry in risks.yaml produces at least one diagnostic.
+
+        Given: The live risks.yaml corpus file
+        When: find_prose_fields + check_prose_field are run over the file
+        Then: At least one Diagnostic is produced for riskSensitiveDataDisclosure
+
+        Regression guard: a failing assertion after content cleanup is the
+        intended behaviour. Update or remove this test and close issue #225
+        when the cleanup lands.
+        """
+        if not _RISKS_YAML.is_file():
+            pytest.skip(f"Live corpus not found: {_RISKS_YAML}")
+
+        diags = _collect_entry_diagnostics(_RISKS_YAML, "riskSensitiveDataDisclosure")
+        assert len(diags) >= 1, (
+            "Expected at least one diagnostic for riskSensitiveDataDisclosure; "
+            "found none.  If the drift was intentionally removed, update this "
+            "test and close issue #225."
+        )
+
+    def test_risks_drift_entry_is_at_long_description_index_3(self):
+        r"""
+        The diagnostic for the known risks drift is on longDescription[3].
+
+        Given: The live risks.yaml corpus file
+        When: find_prose_fields + check_prose_field are run
+        Then: At least one Diagnostic has field_name == 'longDescription'
+              AND index == 3 for entry riskSensitiveDataDisclosure
+
+        Regression guard: a failing assertion after content cleanup is the
+        intended behaviour. Update or remove this test and close issue #225
+        when the cleanup lands.
+        """
+        if not _RISKS_YAML.is_file():
+            pytest.skip(f"Live corpus not found: {_RISKS_YAML}")
+
+        diags = _collect_entry_diagnostics(_RISKS_YAML, "riskSensitiveDataDisclosure")
+        matching = [d for d in diags if d.field_name == "longDescription" and d.index == 3]
+        assert len(matching) >= 1, (
+            "Expected a diagnostic at longDescription[3] for "
+            "riskSensitiveDataDisclosure. "
+            f"Got diagnostics: {[(d.field_name, d.index) for d in diags]}"
+        )
+
+    def test_risks_drift_diagnostic_mentions_adr020(self):
+        r"""
+        The risks drift diagnostic reason cross-references ADR-020 D4.
+
+        Given: The live risks.yaml corpus file
+        When: find_prose_fields + check_prose_field are run
+        Then: At least one diagnostic for riskSensitiveDataDisclosure
+              longDescription[3] has a reason that mentions 'ADR-020 D4'
+
+        Contract: the INVALID_LIST reason includes the ADR-020 D4 reference so
+        a reader who hits this diagnostic finds the folded-bullet documentation.
+        """
+        if not _RISKS_YAML.is_file():
+            pytest.skip(f"Live corpus not found: {_RISKS_YAML}")
+
+        diags = _collect_entry_diagnostics(_RISKS_YAML, "riskSensitiveDataDisclosure")
+        long_desc_diags = [d for d in diags if d.field_name == "longDescription" and d.index == 3]
+        assert len(long_desc_diags) >= 1, (
+            "Prerequisite failed: no diagnostic at longDescription[3]; "
+            "check test_risks_drift_entry_is_at_long_description_index_3."
+        )
+        has_adr_reference = any("ADR-020 D4" in d.reason for d in long_desc_diags)
+        assert has_adr_reference, (
+            "Expected at least one diagnostic reason for "
+            "riskSensitiveDataDisclosure longDescription[3] to contain "
+            "'ADR-020 D4'. "
+            f"Actual reasons: {[d.reason for d in long_desc_diags]}"
+        )
+
+
+# ===========================================================================
+# Scope (b) — INVALID_LIST reason text must cross-reference ADR-020 D4
+# ===========================================================================
+
+
+class TestInvalidListReasonAugmentation:
+    r"""Assert that the INVALID_LIST diagnostic mentions ADR-020 D4.
+
+    Pins the contract on the _REASONS mapping in validate_yaml_prose_subset.py:
+    the INVALID_LIST reason must mention 'ADR-020 D4' and hint at folded-bullet
+    drift, so a reader who encounters the diagnostic finds the heuristic's
+    broader documentation.
+    """
+
+    def _make_list_field(self, raw_text: str):
+        r"""Build a ProseField whose text produces an INVALID_LIST token.
+
+        Args:
+            raw_text: A string that starts with '- ' at column 0.
+
+        Returns:
+            A ProseField with a populated token stream.
+        """
+        from precommit._linter_types import ProseField  # noqa: PLC0415
+
+        return ProseField(
+            file_path=Path("controls.yaml"),
+            entry_id="controlAlpha",
+            field_name="description",
+            index=0,
+            raw_text=raw_text,
+            tokens=tokenize(raw_text),
+        )
+
+    def test_invalid_list_reason_mentions_adr020_d4(self):
+        r"""
+        A column-0 list diagnostic reason includes 'ADR-020 D4'.
+
+        Given: A ProseField with '- item at column zero'
+        When: check_prose_field is called
+        Then: The produced Diagnostic reason contains 'ADR-020 D4'
+        """
+        field = self._make_list_field("- item at column zero")
+        diags = check_prose_field(field)
+
+        assert len(diags) >= 1, "Expected at least one diagnostic for column-0 list item"
+        # Verify the field first produces INVALID_LIST (not some other kind)
+        list_diags = [d for d in diags if "list marker" in d.reason.lower() or "list" in d.reason.lower()]
+        assert len(list_diags) >= 1, f"Expected a list-marker diagnostic; got: {[d.reason for d in diags]}"
+        has_adr_ref = any("ADR-020 D4" in d.reason for d in list_diags)
+        assert has_adr_ref, (
+            "Expected INVALID_LIST diagnostic reason to contain 'ADR-020 D4' "
+            "so authors are directed to the folded-bullet drift documentation. "
+            f"Actual reasons: {[d.reason for d in list_diags]}"
+        )
+
+    def test_invalid_list_reason_distinguishes_folded_scalar_drift(self):
+        r"""
+        The INVALID_LIST reason text hints at folded-bullet drift.
+
+        Given: A ProseField with a column-0 list item (parsed-form drift)
+        When: check_prose_field is called
+        Then: The reason contains either 'folded-bullet' or 'folded' so that
+              authors who encounter this message understand it may originate
+              from a '>' folded scalar in YAML source.
+        """
+        field = self._make_list_field("- another column zero item")
+        diags = check_prose_field(field)
+
+        assert len(diags) >= 1, "Expected at least one diagnostic"
+        list_diags = [d for d in diags if "list" in d.reason.lower()]
+        assert len(list_diags) >= 1
+
+        # Either 'folded' or 'ADR-020' in the reason satisfies the intent.
+        has_drift_hint = any(("folded" in d.reason.lower() or "ADR-020" in d.reason) for d in list_diags)
+        assert has_drift_hint, (
+            "Expected INVALID_LIST reason to mention 'folded' or 'ADR-020' "
+            "to hint that this violation may be folded-scalar drift "
+            "(see issue #225). "
+            f"Actual reasons: {[d.reason for d in list_diags]}"
+        )

--- a/scripts/hooks/tests/test_lifecycle_stage_order_uniqueness.py
+++ b/scripts/hooks/tests/test_lifecycle_stage_order_uniqueness.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""
+Tests for the lifecycleStage.order uniqueness validator check.
+
+Per ADR-022 D4 (line 98): uniqueness across array items is awkward in JSON Schema;
+a small validator check is the cleaner path. This file tests that validator check.
+
+Per ADR-022 D8 (line 271):
+  "D4 lifecycleStage.order uniqueness | recommended: validator extension | validator |
+   Conformance-sweep deliverable"
+
+The validator must:
+- Accept the current lifecycle-stage.yaml corpus (orders 1..8, all unique).
+- Reject any input where two or more stages share an order value.
+- Identify the colliding stage IDs and the duplicated order value in its failure
+  output, so a developer reading CI output can locate the defect.
+- Block immediately (no warn-only path); the corpus is clean at landing.
+
+Coverage:
+- Positive/regression: current lifecycle-stage.yaml passes.
+- Single duplicate pair (two stages with the same order).
+- Triple duplicate (three stages with the same order).
+- All-same-order degenerate case (every stage carries order: 1).
+- Non-canonical order sequence that contains a hidden duplicate
+  (e.g. [3, 11, 4, 11, 5, 9, 2, 6] — duplicated value 11).
+- Output shape: failure result carries the colliding IDs and the duplicated value.
+
+Note: this check assumes each stage carries an `order` key; malformed-structure
+rejection (missing/wrong-type keys) is the schema layer's responsibility — see
+`test_lifecycle_stage_order_range.py` for the schema-side coverage.
+"""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# The import below is expected to fail (ImportError or AttributeError) until
+# SWE adds the uniqueness check to riskmap_validator.validator.  That is the
+# red-phase signal.
+from riskmap_validator.validator import check_lifecycle_stage_order_uniqueness  # noqa: E402, I001
+
+
+# ============================================================================
+# Module-level constants — inline YAML fixture data
+# ============================================================================
+
+# The current corpus: 8 stages, orders 1–8, no duplicates.
+_CORPUS_CLEAN = {
+    "lifecycleStages": [
+        {"id": "planning", "title": "Planning", "order": 1},
+        {"id": "data-preparation", "title": "Data Preparation", "order": 2},
+        {"id": "model-training", "title": "Model Training", "order": 3},
+        {"id": "development", "title": "Development", "order": 4},
+        {"id": "evaluation", "title": "Evaluation", "order": 5},
+        {"id": "deployment", "title": "Deployment", "order": 6},
+        {"id": "runtime", "title": "Runtime", "order": 7},
+        {"id": "maintenance", "title": "Maintenance", "order": 8},
+    ]
+}
+
+# Single duplicate pair: two stages both claim order 3.
+_CORPUS_SINGLE_DUPLICATE = {
+    "lifecycleStages": [
+        {"id": "stage-a", "title": "Stage A", "order": 1},
+        {"id": "stage-b", "title": "Stage B", "order": 2},
+        {"id": "stage-c", "title": "Stage C", "order": 3},
+        {"id": "stage-d", "title": "Stage D", "order": 3},  # duplicate
+        {"id": "stage-e", "title": "Stage E", "order": 5},
+    ]
+}
+
+# Triple duplicate: three stages all carry order 5.
+_CORPUS_TRIPLE_DUPLICATE = {
+    "lifecycleStages": [
+        {"id": "alpha", "title": "Alpha", "order": 1},
+        {"id": "beta", "title": "Beta", "order": 5},
+        {"id": "gamma", "title": "Gamma", "order": 5},
+        {"id": "delta", "title": "Delta", "order": 5},  # third with order 5
+        {"id": "epsilon", "title": "Epsilon", "order": 8},
+    ]
+}
+
+# Degenerate: every stage has order 1.
+_CORPUS_ALL_SAME = {
+    "lifecycleStages": [{"id": f"stage-{i}", "title": f"Stage {i}", "order": 1} for i in range(1, 6)]
+}
+
+# Non-canonical sequence with a hidden duplicate:
+# orders [3, 11, 4, 11, 5, 9, 2, 6] — value 11 appears twice.
+# 11 is a two-digit value that does not appear in any stage ID (s1–s8),
+# making the substring assertion in the output-shape test unambiguous.
+_CORPUS_HIDDEN_DUPLICATE = {
+    "lifecycleStages": [
+        {"id": "s1", "title": "S1", "order": 3},
+        {"id": "s2", "title": "S2", "order": 11},
+        {"id": "s3", "title": "S3", "order": 4},
+        {"id": "s4", "title": "S4", "order": 11},  # duplicate of s2
+        {"id": "s5", "title": "S5", "order": 5},
+        {"id": "s6", "title": "S6", "order": 9},
+        {"id": "s7", "title": "S7", "order": 2},
+        {"id": "s8", "title": "S8", "order": 6},
+    ]
+}
+
+# Minimal clean corpus (two stages, distinct orders) — verify trivially valid input passes.
+_CORPUS_MINIMAL_CLEAN = {
+    "lifecycleStages": [
+        {"id": "first", "title": "First", "order": 1},
+        {"id": "second", "title": "Second", "order": 2},
+    ]
+}
+
+# Single stage — always unique by definition.
+_CORPUS_SINGLE_STAGE = {
+    "lifecycleStages": [
+        {"id": "only", "title": "Only Stage", "order": 1},
+    ]
+}
+
+# Empty stages array — no orders to compare; must pass without error.
+_CORPUS_EMPTY = {"lifecycleStages": []}
+
+
+# ============================================================================
+# Positive / regression tests
+# ============================================================================
+
+
+class TestLifecycleStageOrderUniquenessPassCases:
+    """Inputs that carry no duplicate order values must be accepted."""
+
+    def test_current_corpus_in_memory_passes(self):
+        """
+        Test that the in-memory representation of the current corpus passes uniqueness.
+
+        Given: A dict matching the shape of lifecycle-stage.yaml (orders 1..8)
+        When: the uniqueness check is called
+        Then: The result indicates success (no duplicates)
+        """
+        result = check_lifecycle_stage_order_uniqueness(_CORPUS_CLEAN)
+        assert result.is_valid, f"Current corpus (orders 1..8) must pass uniqueness; got errors: {result.errors}"
+
+    def test_current_yaml_file_passes(self, lifecycle_stage_yaml_path: Path):
+        """
+        Test that the actual lifecycle-stage.yaml on disk passes uniqueness.
+
+        Given: lifecycle-stage.yaml loaded from the repository
+        When: the uniqueness check is called with its parsed content
+        Then: The result indicates success (non-destructive against today's corpus)
+        """
+        with open(lifecycle_stage_yaml_path, encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+        result = check_lifecycle_stage_order_uniqueness(data)
+        assert result.is_valid, (
+            f"lifecycle-stage.yaml on disk must pass order uniqueness; got errors: {result.errors}"
+        )
+
+    def test_minimal_two_stage_corpus_passes(self):
+        """
+        Test that a two-stage corpus with distinct orders passes.
+
+        Given: Two stages with orders 1 and 2
+        When: the uniqueness check is called
+        Then: The result indicates success
+        """
+        result = check_lifecycle_stage_order_uniqueness(_CORPUS_MINIMAL_CLEAN)
+        assert result.is_valid, f"Two distinct orders must pass; got errors: {result.errors}"
+
+    def test_single_stage_corpus_passes(self):
+        """
+        Test that a single-stage corpus passes (uniqueness is vacuously satisfied).
+
+        Given: One stage
+        When: the uniqueness check is called
+        Then: The result indicates success (no pair to collide)
+        """
+        result = check_lifecycle_stage_order_uniqueness(_CORPUS_SINGLE_STAGE)
+        assert result.is_valid, f"Single stage must pass uniqueness; got errors: {result.errors}"
+
+    def test_empty_stages_array_passes(self):
+        """
+        Test that an empty lifecycleStages array passes.
+
+        Given: lifecycleStages: [] (no stages)
+        When: the uniqueness check is called
+        Then: The result indicates success (nothing to be non-unique)
+        """
+        result = check_lifecycle_stage_order_uniqueness(_CORPUS_EMPTY)
+        assert result.is_valid, f"Empty stages array must pass uniqueness; got errors: {result.errors}"
+
+
+# ============================================================================
+# Negative tests — duplicate rejection
+# ============================================================================
+
+
+class TestLifecycleStageOrderUniquenessRejectCases:
+    """Inputs with duplicate order values must be rejected."""
+
+    def test_single_duplicate_pair_is_rejected(self):
+        """
+        Test that two stages sharing order 3 are rejected.
+
+        Given: Five stages where stage-c and stage-d both carry order 3
+        When: the uniqueness check is called
+        Then: The result indicates failure
+        """
+        result = check_lifecycle_stage_order_uniqueness(_CORPUS_SINGLE_DUPLICATE)
+        assert not result.is_valid, "Two stages with the same order value must fail uniqueness validation"
+
+    def test_triple_duplicate_is_rejected(self):
+        """
+        Test that three stages sharing order 5 are rejected.
+
+        Given: Five stages where beta, gamma, and delta all carry order 5
+        When: the uniqueness check is called
+        Then: The result indicates failure
+        """
+        result = check_lifecycle_stage_order_uniqueness(_CORPUS_TRIPLE_DUPLICATE)
+        assert not result.is_valid, "Three stages with the same order value must fail uniqueness validation"
+
+    def test_all_same_order_is_rejected(self):
+        """
+        Test that a corpus where every stage carries order 1 is rejected.
+
+        Given: Five stages each with order: 1
+        When: the uniqueness check is called
+        Then: The result indicates failure (order 1 appears five times)
+        """
+        result = check_lifecycle_stage_order_uniqueness(_CORPUS_ALL_SAME)
+        assert not result.is_valid, "All stages carrying the same order value must fail uniqueness validation"
+
+    def test_non_canonical_sequence_with_hidden_duplicate_is_rejected(self):
+        """
+        Test that orders [3,11,4,11,5,9,2,6] — duplicate value 11 — are rejected.
+
+        Given: Eight stages with non-ascending orders containing a hidden duplicate (11)
+        When: the uniqueness check is called
+        Then: The result indicates failure
+        """
+        result = check_lifecycle_stage_order_uniqueness(_CORPUS_HIDDEN_DUPLICATE)
+        assert not result.is_valid, (
+            "Non-canonical order sequence with a duplicate value (11 appears twice) must fail"
+        )
+
+
+# ============================================================================
+# Output shape tests — failure must identify colliders
+# ============================================================================
+
+
+class TestLifecycleStageOrderUniquenessOutputShape:
+    """
+    On failure the result must carry enough information to identify the defect.
+
+    ADR-022 D4 says "a developer reading CI output can locate the bug".
+    The assertions here verify that the error payload mentions the duplicated
+    order value and the IDs of the stages that collide — without prescribing
+    the exact message format (that is SWE's call).
+    """
+
+    def test_single_duplicate_failure_identifies_duplicated_order_value(self):
+        """
+        Test that the failure result names the duplicated order value.
+
+        Given: stage-c and stage-d both carry order 3
+        When: the uniqueness check is called and fails
+        Then: The error payload mentions the value 3 (the colliding order)
+        """
+        result = check_lifecycle_stage_order_uniqueness(_CORPUS_SINGLE_DUPLICATE)
+        assert not result.is_valid
+
+        # The error representation must contain the duplicated value.
+        # We stringify result.errors to be format-agnostic.
+        errors_repr = str(result.errors)
+        assert "3" in errors_repr, f"Failure output must mention the duplicated order value 3; got: {errors_repr}"
+
+    def test_single_duplicate_failure_identifies_both_colliding_stage_ids(self):
+        """
+        Test that the failure result names both stage IDs that share order 3.
+
+        Given: stage-c and stage-d both carry order 3
+        When: the uniqueness check is called and fails
+        Then: The error payload mentions both 'stage-c' and 'stage-d'
+        """
+        result = check_lifecycle_stage_order_uniqueness(_CORPUS_SINGLE_DUPLICATE)
+        assert not result.is_valid
+
+        errors_repr = str(result.errors)
+        assert "stage-c" in errors_repr, (
+            f"Failure output must mention colliding stage ID 'stage-c'; got: {errors_repr}"
+        )
+        assert "stage-d" in errors_repr, (
+            f"Failure output must mention colliding stage ID 'stage-d'; got: {errors_repr}"
+        )
+
+    def test_triple_duplicate_failure_identifies_all_three_colliding_stage_ids(self):
+        """
+        Test that a triple collision names all three stages in the error payload.
+
+        Given: beta, gamma, and delta all carry order 5
+        When: the uniqueness check is called and fails
+        Then: The error payload mentions beta, gamma, and delta
+        """
+        result = check_lifecycle_stage_order_uniqueness(_CORPUS_TRIPLE_DUPLICATE)
+        assert not result.is_valid
+
+        errors_repr = str(result.errors)
+        for stage_id in ("beta", "gamma", "delta"):
+            assert stage_id in errors_repr, (
+                f"Failure output must mention colliding stage ID '{stage_id}'; got: {errors_repr}"
+            )
+
+    def test_hidden_duplicate_failure_identifies_colliding_ids_and_value(self):
+        """
+        Test that a hidden duplicate in a non-canonical sequence is identified.
+
+        Given: s2 (order 11) and s4 (order 11) in sequence [3,11,4,11,5,9,2,6]
+        When: the uniqueness check is called and fails
+        Then: The error payload mentions both 's2' and 's4', and the value 11
+        """
+        result = check_lifecycle_stage_order_uniqueness(_CORPUS_HIDDEN_DUPLICATE)
+        assert not result.is_valid
+
+        errors_repr = str(result.errors)
+        assert "s2" in errors_repr, f"Failure output must mention colliding stage ID 's2'; got: {errors_repr}"
+        assert "s4" in errors_repr, f"Failure output must mention colliding stage ID 's4'; got: {errors_repr}"
+        assert "11" in errors_repr, (
+            f"Failure output must mention the duplicated order value 11; got: {errors_repr}"
+        )
+
+    def test_result_has_errors_attribute(self):
+        """
+        Test that the result object exposes an errors attribute.
+
+        Given: A corpus with a duplicate order
+        When: the uniqueness check is called and fails
+        Then: result.errors is a non-empty collection
+        """
+        result = check_lifecycle_stage_order_uniqueness(_CORPUS_SINGLE_DUPLICATE)
+        assert not result.is_valid
+        assert result.errors, "result.errors must be non-empty on failure"
+
+    def test_result_has_no_errors_on_clean_corpus(self):
+        """
+        Test that the result object has an empty errors collection on success.
+
+        Given: The clean 8-stage corpus
+        When: the uniqueness check is called and passes
+        Then: result.errors is empty (or falsy)
+        """
+        result = check_lifecycle_stage_order_uniqueness(_CORPUS_CLEAN)
+        assert result.is_valid
+        assert not result.errors, f"result.errors must be empty on success; got: {result.errors}"
+
+
+# ============================================================================
+# Test summary
+# ============================================================================
+"""
+Test Summary
+============
+Test classes: 3
+
+TestLifecycleStageOrderUniquenessPassCases (5 tests)
+  — current corpus in-memory; lifecycle-stage.yaml on disk; minimal 2-stage;
+    single stage; empty array.
+
+TestLifecycleStageOrderUniquenessRejectCases (4 tests)
+  — single duplicate pair (order 3); triple duplicate (order 5); all-same-order;
+    non-canonical hidden duplicate (order 11 in sequence [3,11,4,11,5,9,2,6]).
+
+TestLifecycleStageOrderUniquenessOutputShape (6 tests)
+  — failure names the duplicated value; failure names both colliding IDs (pair);
+    failure names all three colliding IDs (triple); failure names colliding IDs + value
+    for hidden duplicate; result.errors is non-empty on failure; result.errors is
+    empty on success.
+
+Total: 15 tests
+
+Coverage areas:
+  - ADR-022 D4: order uniqueness check, block-mode, validator extension
+  - Regression: current lifecycle-stage.yaml remains valid
+  - Rejection: single, triple, all-same, non-canonical duplicate orderings
+  - Output shape: colliding IDs and duplicated value present in error payload
+  - Result contract: is_valid / errors attributes on returned result object
+"""

--- a/scripts/hooks/tests/test_lifecycle_stage_order_uniqueness.py
+++ b/scripts/hooks/tests/test_lifecycle_stage_order_uniqueness.py
@@ -30,8 +30,10 @@ rejection (missing/wrong-type keys) is the schema layer's responsibility — see
 `test_lifecycle_stage_order_range.py` for the schema-side coverage.
 """
 
+import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -357,12 +359,247 @@ class TestLifecycleStageOrderUniquenessOutputShape:
 
 
 # ============================================================================
+# CLI wiring tests — validate_riskmap.py integration (ADR-022 D4)
+# ============================================================================
+
+# Absolute path to the CLI script under test.
+_SCRIPT = Path(__file__).parent.parent / "validate_riskmap.py"
+
+# Repository root — used as cwd for the live-corpus subprocess test.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+# Minimal corpus shapes required by validate_riskmap.py --force.
+# components.yaml: two components with mutual edges so ComponentEdgeValidator passes.
+# The subcategory field keeps the nesting check silent (valid pair for each component).
+_MINIMAL_COMPONENTS: dict[str, Any] = {
+    "components": [
+        {
+            "id": "componentAlpha",
+            "title": "Alpha",
+            "category": "componentsInfrastructure",
+            "subcategory": "componentsData",
+            "edges": {"to": ["componentBeta"], "from": []},
+        },
+        {
+            "id": "componentBeta",
+            "title": "Beta",
+            "category": "componentsInfrastructure",
+            "subcategory": "componentsData",
+            "edges": {"to": [], "from": ["componentAlpha"]},
+        },
+    ],
+    "categories": [
+        {
+            "id": "componentsInfrastructure",
+            "title": "Infrastructure",
+            "subcategory": [
+                {"id": "componentsData", "title": "Data"},
+            ],
+        },
+    ],
+}
+
+# controls.yaml with no dangling refs (mirror check stays quiet).
+_MINIMAL_CONTROLS: dict[str, Any] = {
+    "controls": [
+        {
+            "id": "controlClean",
+            "title": "Clean Control",
+            "category": "controlsModel",
+            "components": ["componentAlpha"],
+            "risks": [],
+            "personas": [],
+        }
+    ]
+}
+
+# risks.yaml stub — script reads this file; content irrelevant to lifecycle check.
+_MINIMAL_RISKS: dict[str, Any] = {"risks": []}
+
+# lifecycle-stage.yaml with unique orders 1–3 (clean corpus, no duplicates).
+_LIFECYCLE_UNIQUE: dict[str, Any] = {
+    "lifecycleStages": [
+        {"id": "stage-one", "title": "Stage One", "order": 1},
+        {"id": "stage-two", "title": "Stage Two", "order": 2},
+        {"id": "stage-three", "title": "Stage Three", "order": 3},
+    ]
+}
+
+# lifecycle-stage.yaml where stage-b and stage-c both carry order 2 (duplicate).
+_LIFECYCLE_DUPLICATE: dict[str, Any] = {
+    "lifecycleStages": [
+        {"id": "stage-a", "title": "Stage A", "order": 1},
+        {"id": "stage-b", "title": "Stage B", "order": 2},
+        {"id": "stage-c", "title": "Stage C", "order": 2},  # duplicate
+    ]
+}
+
+
+def _write_lifecycle_corpus(
+    base: Path,
+    lifecycle: dict[str, Any] | None,
+) -> Path:
+    """
+    Write a minimal corpus under base/risk-map/yaml/ and return base as cwd.
+
+    Writes components.yaml, controls.yaml, risks.yaml unconditionally.
+    Writes lifecycle-stage.yaml only when lifecycle is not None, simulating
+    the file-absent case for the graceful-skip test.
+
+    Args:
+        base: Temporary directory root (pytest tmp_path).
+        lifecycle: Parsed lifecycle-stage.yaml content, or None to omit the file.
+
+    Returns:
+        base path for use as subprocess cwd.
+    """
+    yaml_dir = base / "risk-map" / "yaml"
+    yaml_dir.mkdir(parents=True)
+    (yaml_dir / "components.yaml").write_text(yaml.dump(_MINIMAL_COMPONENTS), encoding="utf-8")
+    (yaml_dir / "controls.yaml").write_text(yaml.dump(_MINIMAL_CONTROLS), encoding="utf-8")
+    (yaml_dir / "risks.yaml").write_text(yaml.dump(_MINIMAL_RISKS), encoding="utf-8")
+    if lifecycle is not None:
+        (yaml_dir / "lifecycle-stage.yaml").write_text(yaml.dump(lifecycle), encoding="utf-8")
+    return base
+
+
+def _run_lifecycle(cwd: Path) -> subprocess.CompletedProcess:
+    """
+    Run validate_riskmap.py --force --allow-isolated from the given cwd.
+
+    --force: validate regardless of git-staged state.
+    --allow-isolated: skip orphan check so minimal corpora don't fail on that.
+
+    Args:
+        cwd: Working directory for the subprocess.
+
+    Returns:
+        CompletedProcess with returncode, stdout, stderr.
+    """
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), "--force", "--allow-isolated"],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+    )
+
+
+class TestLifecycleUniquenessCLI:
+    """
+    CLI integration tests: validate_riskmap.py must call
+    check_lifecycle_stage_order_uniqueness() and exit 1 on duplicate orders.
+
+    ADR-022 D4 specifies block-mode-immediate (no --block flag required).
+    The --block flag is NOT involved here; the check always fails hard.
+    """
+
+    def test_live_corpus_exits_0(self):
+        """
+        Running against the actual lifecycle-stage.yaml (orders 1..8, all unique) exits 0.
+
+        Given: The real lifecycle-stage.yaml on disk (no duplicate orders)
+        When: validate_riskmap.py --force --allow-isolated (cwd=repo root)
+        Then: Exit code is 0 (no uniqueness violations)
+
+        This is a regression guard: if the wiring lands correctly and the live
+        corpus is clean, this test must pass on every subsequent run.
+        """
+        result = _run_lifecycle(_REPO_ROOT)
+        assert result.returncode == 0, (
+            f"Expected exit 0 against live corpus (orders 1..8 unique); "
+            f"got {result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_synthesised_corpus_with_duplicate_order_exits_1(self, tmp_path):
+        """
+        A synthesised corpus whose lifecycle-stage.yaml has duplicate order values exits 1.
+
+        Given: A corpus where stage-b and stage-c both carry order 2
+        When: validate_riskmap.py --force --allow-isolated
+        Then: Exit code is 1 (duplicate orders detected, block-mode-immediate)
+        """
+        _write_lifecycle_corpus(tmp_path, _LIFECYCLE_DUPLICATE)
+        result = _run_lifecycle(tmp_path)
+        assert result.returncode == 1, (
+            f"Expected exit 1 for corpus with duplicate lifecycle order; "
+            f"got {result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_synthesised_corpus_with_duplicate_order_output_names_value_and_ids(self, tmp_path):
+        """
+        When duplicate orders are found, the output names the duplicated value
+        and the colliding stage IDs so a developer can locate the defect.
+
+        Given: stage-b and stage-c both carry order 2
+        When: validate_riskmap.py --force --allow-isolated
+        Then: Output (stdout or stderr) mentions the duplicated value 2 AND
+              mentions both "stage-b" and "stage-c"
+        """
+        _write_lifecycle_corpus(tmp_path, _LIFECYCLE_DUPLICATE)
+        result = _run_lifecycle(tmp_path)
+        combined = result.stdout + result.stderr
+        # "2" is the duplicated order value in _LIFECYCLE_DUPLICATE.
+        # Stage IDs are "stage-a/b/c" and orders are 1/2/2; no other field
+        # in the corpus produces a bare "2" in the script's output, so the
+        # substring assertion is unambiguous for this corpus.
+        assert "2" in combined, (
+            f"Expected duplicated order value '2' in output; stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+        )
+        # Check that both colliding stage IDs are named.
+        assert "stage-b" in combined, (
+            f"Expected colliding stage ID 'stage-b' in output; "
+            f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+        )
+        assert "stage-c" in combined, (
+            f"Expected colliding stage ID 'stage-c' in output; "
+            f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+        )
+
+    def test_synthesised_corpus_with_unique_orders_exits_0(self, tmp_path):
+        """
+        A synthesised corpus with unique lifecycle orders exits 0.
+
+        Given: A corpus where lifecycle-stage.yaml has orders 1, 2, 3 (all unique)
+        When: validate_riskmap.py --force --allow-isolated
+        Then: Exit code is 0
+
+        Confirms the block-mode-immediate semantic fires only on actual duplicates,
+        not on any lifecycle file presence.
+        """
+        _write_lifecycle_corpus(tmp_path, _LIFECYCLE_UNIQUE)
+        result = _run_lifecycle(tmp_path)
+        assert result.returncode == 0, (
+            f"Expected exit 0 for corpus with unique lifecycle orders; "
+            f"got {result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_synthesised_corpus_without_lifecycle_file_exits_0(self, tmp_path):
+        """
+        A corpus with no lifecycle-stage.yaml exits 0 (graceful skip).
+
+        Given: A corpus directory that does NOT contain lifecycle-stage.yaml
+        When: validate_riskmap.py --force --allow-isolated
+        Then: Exit code is 0 (lifecycle check is skipped, not failed)
+
+        lifecycle-stage.yaml may not be present in every test environment.
+        The check must degrade gracefully when the file is absent, matching
+        the broad-except pattern used by the mirror and nesting checks.
+        """
+        _write_lifecycle_corpus(tmp_path, None)  # None = omit the file
+        result = _run_lifecycle(tmp_path)
+        assert result.returncode == 0, (
+            f"Expected exit 0 when lifecycle-stage.yaml is absent (graceful skip); "
+            f"got {result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+
+# ============================================================================
 # Test summary
 # ============================================================================
 """
 Test Summary
 ============
-Test classes: 3
+Test classes: 4
 
 TestLifecycleStageOrderUniquenessPassCases (5 tests)
   — current corpus in-memory; lifecycle-stage.yaml on disk; minimal 2-stage;
@@ -378,12 +615,20 @@ TestLifecycleStageOrderUniquenessOutputShape (6 tests)
     for hidden duplicate; result.errors is non-empty on failure; result.errors is
     empty on success.
 
-Total: 15 tests
+TestLifecycleUniquenessCLI (5 tests — subprocess CLI integration)
+  — live corpus exits 0 (orders 1..8 unique, regression guard);
+    synthesised corpus with duplicate order exits 1 (block-mode-immediate);
+    synthesised corpus with duplicate order output names value + colliding IDs;
+    synthesised corpus with unique orders exits 0;
+    synthesised corpus missing lifecycle-stage.yaml exits 0 (graceful skip).
+
+Total: 20 tests
 
 Coverage areas:
-  - ADR-022 D4: order uniqueness check, block-mode, validator extension
+  - ADR-022 D4: order uniqueness check, block-mode-immediate, validator extension
   - Regression: current lifecycle-stage.yaml remains valid
   - Rejection: single, triple, all-same, non-canonical duplicate orderings
   - Output shape: colliding IDs and duplicated value present in error payload
   - Result contract: is_valid / errors attributes on returned result object
+  - CLI wiring: validate_riskmap.py calls the check; exit codes; graceful skip
 """

--- a/scripts/hooks/tests/test_lifecycle_stage_order_uniqueness.py
+++ b/scripts/hooks/tests/test_lifecycle_stage_order_uniqueness.py
@@ -37,9 +37,8 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-# The import below is expected to fail (ImportError or AttributeError) until
-# SWE adds the uniqueness check to riskmap_validator.validator.  That is the
-# red-phase signal.
+# noqa I001 retained because ruff's import-sort would re-order this past the
+# sys.path.insert above and break the deferred import pattern.
 from riskmap_validator.validator import check_lifecycle_stage_order_uniqueness  # noqa: E402, I001
 
 

--- a/scripts/hooks/tests/test_mermaid_config_loader.py
+++ b/scripts/hooks/tests/test_mermaid_config_loader.py
@@ -1159,6 +1159,172 @@ class TestMissingCategoryWarnings:
                 pytest.skip("Loader uses return-list API; no emit method to test here")
 
 
+class TestBaseGraphEmitsCategoryWarnings:
+    """
+    Tests that BaseGraph.__init__ calls emit_missing_category_warnings() after
+    binding its config_loader, making missing-category warnings visible at
+    graph-generator-run time (ADR-022 D6a).
+
+    The SWE must:
+      1. Add a cached helper (e.g., _get_schema_categories() in graph_utils.py)
+         that reads risk-map/schemas/components.schema.json once and returns the
+         category enum as set[str].
+      2. Call self.config_loader.emit_missing_category_warnings(<schema_categories>)
+         in BaseGraph.__init__ after self.config_loader is bound (line ~63 of
+         base.py).
+
+    Red-phase: every test in this class FAILS today because BaseGraph.__init__
+    never calls emit_missing_category_warnings(), so no warnings are emitted
+    regardless of the config_loader's styling coverage.
+    """
+
+    # A minimal valid dict of ComponentNode objects accepted by BaseGraph.__init__.
+    # BaseGraph validates that components is a dict[str, ComponentNode]; empty dict
+    # passes the isinstance check but some subclass code may complain, so we provide
+    # one real node.
+    @staticmethod
+    def _one_component() -> dict:
+        """Return a minimal components dict with one ComponentNode."""
+        from riskmap_validator.models import ComponentNode
+
+        return {"compA": ComponentNode(title="A", category="componentsInfrastructure", to_edges=[], from_edges=[])}
+
+    def _loader_with_categories(self, tmp_path: Path, present_category_keys: list[str]) -> MermaidConfigLoader:
+        """
+        Build a MermaidConfigLoader whose componentCategories contains exactly the given keys.
+
+        Reuses the same helper pattern from TestMissingCategoryWarnings so the
+        synthesised loaders are consistent between the two test classes.
+
+        Args:
+            tmp_path: pytest tmp_path fixture value.
+            present_category_keys: category key strings to include in styling config.
+        """
+        import yaml as _yaml
+
+        cat_entries = {k: {"fill": "#aabbcc"} for k in present_category_keys}
+        config = {
+            "version": "1.0.0",
+            "foundation": {"colors": {}},
+            "sharedElements": {
+                "cssClasses": {"hidden": "display: none;"},
+                "componentCategories": cat_entries,
+            },
+            "graphTypes": {
+                "component": {"direction": "TD", "flowchartConfig": {}},
+                "control": {"direction": "LR", "flowchartConfig": {}},
+            },
+        }
+        config_file = tmp_path / "styles.yaml"
+        with open(config_file, "w") as fh:
+            _yaml.dump(config, fh)
+        return MermaidConfigLoader(config_file)
+
+    def test_no_warnings_when_all_schema_categories_covered(self, tmp_path):
+        """
+        No UserWarning emitted when the styling config covers all schema categories.
+
+        Given: A config_loader whose componentCategories contains all three schema
+               categories (componentsInfrastructure, componentsModel, componentsApplication)
+        When: BaseGraph is instantiated with that loader
+        Then: No UserWarning is emitted during __init__
+
+        Red phase: FAILS today because BaseGraph.__init__ never calls
+        emit_missing_category_warnings — warnings.catch_warnings sees nothing,
+        but the assertion that no warning was emitted PASSES (false green). This
+        is handled by the complementary test below that verifies a warning IS
+        emitted when a category IS missing; that test drives the actual red failure.
+        """
+        import warnings
+
+        from riskmap_validator.graphing.base import BaseGraph
+
+        loader = self._loader_with_categories(
+            tmp_path,
+            ["componentsInfrastructure", "componentsModel", "componentsApplication"],
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            BaseGraph(self._one_component(), config_loader=loader)
+
+        category_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(category_warnings) == 0, (
+            f"Expected no UserWarning when all schema categories are styled; "
+            f"got: {[str(w.message) for w in category_warnings]}"
+        )
+
+    def test_warning_emitted_when_schema_category_missing_from_styling(self, tmp_path):
+        """
+        At least one UserWarning is emitted when a schema category has no styling entry.
+
+        Given: A config_loader whose componentCategories is missing componentsApplication
+        When: BaseGraph is instantiated with that loader
+        Then: At least one UserWarning is emitted, and its text names
+              "componentsApplication"
+
+        Red phase: FAILS today because BaseGraph.__init__ does not call
+        emit_missing_category_warnings. No warnings are emitted, so
+        len(category_warnings) == 0 and the assertion fails.
+        """
+        import warnings
+
+        from riskmap_validator.graphing.base import BaseGraph
+
+        loader = self._loader_with_categories(
+            tmp_path,
+            # componentsApplication intentionally absent
+            ["componentsInfrastructure", "componentsModel"],
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            BaseGraph(self._one_component(), config_loader=loader)
+
+        category_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(category_warnings) >= 1, (
+            "Expected at least one UserWarning when styling config is missing "
+            "'componentsApplication'. BaseGraph.__init__ must call "
+            "emit_missing_category_warnings() after binding config_loader."
+        )
+        warning_text = " ".join(str(w.message) for w in category_warnings)
+        assert "componentsApplication" in warning_text, (
+            f"Expected 'componentsApplication' in warning text; got: {warning_text!r}"
+        )
+
+    def test_live_state_regression_no_warnings_with_default_loader(self):
+        """
+        BaseGraph instantiated with the default singleton loader produces no warnings.
+
+        Given: The real mermaid-styles.yaml and the real components.schema.json
+               (live state has all 3 categories present in styling config)
+        When: BaseGraph is instantiated with no explicit config_loader
+              (uses the default singleton, which reads the real styles file)
+        Then: No UserWarning is emitted
+
+        This is a live-state regression guard. If the real mermaid-styles.yaml
+        drifts out of sync with the schema enum, this test will catch it.
+
+        Red phase: FAILS today (no warning emitted) BUT the assertion is that
+        no warning IS emitted, so this test currently PASSES for the wrong reason.
+        It will remain green after wiring as long as the live corpus is in sync —
+        which is the intended long-term behavior. The test above (missing category)
+        is the primary red-failure driver.
+        """
+        import warnings
+
+        from riskmap_validator.graphing.base import BaseGraph
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            BaseGraph(self._one_component())
+
+        category_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(category_warnings) == 0, (
+            "Expected no UserWarning with the default loader against the live corpus. "
+            "If this fails, the live mermaid-styles.yaml is missing a schema category. "
+            f"Got: {[str(w.message) for w in category_warnings]}"
+        )
+
+
 """
 Test Summary
 ============
@@ -1175,4 +1341,15 @@ Coverage Areas:
 - Boundary values: empty schema set, empty styling config, all present
 - Live corpus regression: schema enum vs live YAML in sync
 - Optional operator-visible emission path (skipped if return-list-only API)
+
+Class: TestBaseGraphEmitsCategoryWarnings
+Total Tests: 3
+- Happy Path: 1  (no_warnings_when_all_schema_categories_covered)
+- Error / Missing Condition: 1  (warning_emitted_when_schema_category_missing)
+- Live regression: 1  (no_warnings_with_default_loader)
+
+Coverage Areas:
+- BaseGraph.__init__ wiring: emit_missing_category_warnings called after loader bind
+- Warning emission observable via warnings.catch_warnings
+- Live-state regression: default loader + real corpus → no warnings
 """

--- a/scripts/hooks/tests/test_mermaid_config_loader.py
+++ b/scripts/hooks/tests/test_mermaid_config_loader.py
@@ -852,3 +852,327 @@ class TestMermaidConfigLoaderIntegration:
         custom_loader = MermaidConfigLoader()
         graph_custom = ControlGraph(controls, components, config_loader=custom_loader)
         assert graph_custom.config_loader is custom_loader
+
+
+class TestMissingCategoryWarnings:
+    """
+    Tests for MermaidConfigLoader missing-category warning generation.
+
+    ADR-022 D6a: The loader must emit a warning when
+    sharedElements.componentCategories lacks a styling entry for a category
+    present in components.schema.json.
+
+    These tests pin the observable behavior (return shape and warning content)
+    rather than the internal emission mechanism.
+    """
+
+    @pytest.fixture
+    def temp_config_file(self, tmp_path):
+        """Write a minimal valid config YAML to a temp file and return its path."""
+        config = {
+            "version": "1.0.0",
+            "foundation": {"colors": {}},
+            "sharedElements": {
+                "cssClasses": {"hidden": "display: none;"},
+                "componentCategories": {
+                    "componentsInfrastructure": {"fill": "#e6f3e6"},
+                    "componentsModel": {"fill": "#ffe6e6"},
+                    "componentsApplication": {"fill": "#e6f0ff"},
+                },
+            },
+            "graphTypes": {
+                "component": {"direction": "TD", "flowchartConfig": {}},
+                "control": {"direction": "LR", "flowchartConfig": {}},
+            },
+        }
+        config_file = tmp_path / "mermaid-styles.yaml"
+        import yaml as _yaml
+
+        with open(config_file, "w") as fh:
+            _yaml.dump(config, fh)
+        return config_file
+
+    @pytest.fixture
+    def loader_all_present(self, temp_config_file):
+        """Loader whose styling config contains all three schema categories."""
+        return MermaidConfigLoader(temp_config_file)
+
+    def _loader_with_categories(self, tmp_path, present_category_keys):
+        """
+        Build a loader whose componentCategories contains exactly the given keys.
+
+        Args:
+            tmp_path: pytest tmp_path fixture value.
+            present_category_keys: iterable of category key strings to include.
+        """
+        import yaml as _yaml
+
+        cat_entries = {k: {"fill": "#aabbcc"} for k in present_category_keys}
+        config = {
+            "version": "1.0.0",
+            "foundation": {"colors": {}},
+            "sharedElements": {
+                "cssClasses": {"hidden": "display: none;"},
+                "componentCategories": cat_entries,
+            },
+            "graphTypes": {
+                "component": {"direction": "TD", "flowchartConfig": {}},
+                "control": {"direction": "LR", "flowchartConfig": {}},
+            },
+        }
+        config_file = tmp_path / "styles.yaml"
+        with open(config_file, "w") as fh:
+            _yaml.dump(config, fh)
+        return MermaidConfigLoader(config_file)
+
+    # ------------------------------------------------------------------
+    # Layer 1 — pure-method tests on the warning generator
+    # ------------------------------------------------------------------
+
+    def test_all_schema_categories_present_returns_empty_list(self, loader_all_present):
+        """
+        No warnings when every schema category has a styling entry.
+
+        Given: A loader whose componentCategories contains X, Y, Z
+        When: get_missing_category_warnings({X, Y, Z}) is called
+        Then: Returns an empty list
+        """
+        schema_categories = {
+            "componentsInfrastructure",
+            "componentsModel",
+            "componentsApplication",
+        }
+        result = loader_all_present.get_missing_category_warnings(schema_categories)
+        assert result == []
+
+    def test_one_missing_category_returns_single_warning(self, tmp_path):
+        """
+        One warning when exactly one schema category is absent from styling.
+
+        Given: Styling has X and Y; schema declares X, Y, Z
+        When: get_missing_category_warnings({X, Y, Z}) is called
+        Then: Returns a list with exactly one string that names Z
+        """
+        loader = self._loader_with_categories(
+            tmp_path,
+            ["componentsInfrastructure", "componentsModel"],
+        )
+        schema_categories = {
+            "componentsInfrastructure",
+            "componentsModel",
+            "componentsApplication",
+        }
+        result = loader.get_missing_category_warnings(schema_categories)
+
+        assert len(result) == 1
+        assert isinstance(result[0], str)
+        assert "componentsApplication" in result[0]
+
+    def test_multiple_missing_categories_returns_one_warning_each(self, tmp_path):
+        """
+        Two warnings when two schema categories are absent from styling.
+
+        Given: Styling has only X; schema declares X, Y, Z
+        When: get_missing_category_warnings({X, Y, Z}) is called
+        Then: Returns a list with two strings, each naming the missing category
+        """
+        loader = self._loader_with_categories(tmp_path, ["componentsInfrastructure"])
+        schema_categories = {
+            "componentsInfrastructure",
+            "componentsModel",
+            "componentsApplication",
+        }
+        result = loader.get_missing_category_warnings(schema_categories)
+
+        assert len(result) == 2
+        assert all(isinstance(w, str) for w in result)
+        missing_ids = {"componentsModel", "componentsApplication"}
+        for warning in result:
+            assert any(mid in warning for mid in missing_ids), (
+                f"Warning '{warning}' does not name a missing category"
+            )
+
+    def test_empty_schema_set_returns_empty_list(self, loader_all_present):
+        """
+        No warnings when the schema category set is empty.
+
+        Given: Any loader
+        When: get_missing_category_warnings(set()) is called
+        Then: Returns an empty list (nothing to check)
+        """
+        result = loader_all_present.get_missing_category_warnings(set())
+        assert result == []
+
+    def test_empty_styling_config_all_schema_categories_warn(self, tmp_path):
+        """
+        All schema categories produce warnings when styling config has no entries.
+
+        Given: componentCategories is empty ({}); schema declares X, Y, Z
+        When: get_missing_category_warnings({X, Y, Z}) is called
+        Then: Returns 3 warnings, each naming a missing category
+        """
+        loader = self._loader_with_categories(tmp_path, [])
+        schema_categories = {
+            "componentsInfrastructure",
+            "componentsModel",
+            "componentsApplication",
+        }
+        result = loader.get_missing_category_warnings(schema_categories)
+
+        assert len(result) == 3
+        assert all(isinstance(w, str) for w in result)
+        for cat in schema_categories:
+            assert any(cat in w for w in result), f"Expected warning mentioning '{cat}' but got: {result}"
+
+    def test_return_type_is_always_list(self, loader_all_present, tmp_path):
+        """
+        Return type is always list[str] regardless of input.
+
+        Given: Various inputs including empty set and fully-covered set
+        When: get_missing_category_warnings() is called
+        Then: Return value is always a list (never None, never a generator)
+        """
+        assert isinstance(loader_all_present.get_missing_category_warnings(set()), list)
+        assert isinstance(
+            loader_all_present.get_missing_category_warnings(
+                {"componentsInfrastructure", "componentsModel", "componentsApplication"}
+            ),
+            list,
+        )
+
+        loader_empty = self._loader_with_categories(tmp_path, [])
+        assert isinstance(
+            loader_empty.get_missing_category_warnings({"componentsInfrastructure"}),
+            list,
+        )
+
+    def test_warning_string_mentions_missing_category_id(self, tmp_path):
+        """
+        Each warning string must contain the ID of the missing category.
+
+        Given: Styling lacks componentsModel
+        When: get_missing_category_warnings({"componentsModel"}) is called
+        Then: The single returned string contains "componentsModel"
+        """
+        loader = self._loader_with_categories(tmp_path, [])
+        result = loader.get_missing_category_warnings({"componentsModel"})
+
+        assert len(result) == 1
+        assert "componentsModel" in result[0]
+
+    def test_extra_styling_entry_beyond_schema_produces_no_warning(self, tmp_path):
+        """
+        Over-coverage in styling produces no warning — the check is one-directional.
+
+        ADR-022 D6a enforces schema → styling only: for every category the schema
+        enumerates, a styling entry must exist.  The reverse direction (a styling
+        entry that the schema does not enumerate) is explicitly out of scope; extra
+        styling keys are harmless and must not generate warnings.
+
+        Without this test an implementation that iterates over styling keys instead
+        of schema keys (inverted direction) would pass all other tests in this class
+        but would silently miss the coverage gap the method is supposed to close.
+
+        Given: Styling declares componentsInfrastructure AND componentsModel;
+               schema enumerates only componentsInfrastructure
+        When: get_missing_category_warnings({"componentsInfrastructure"}) is called
+        Then: Returns [] (componentsModel in styling but not in schema is not an error)
+        """
+        loader = self._loader_with_categories(
+            tmp_path,
+            ["componentsInfrastructure", "componentsModel"],
+        )
+        result = loader.get_missing_category_warnings({"componentsInfrastructure"})
+        assert result == []
+
+    # ------------------------------------------------------------------
+    # Live corpus regression
+    # ------------------------------------------------------------------
+
+    def test_live_corpus_produces_zero_warnings(self):
+        """
+        Running against the actual schema + actual mermaid-styles.yaml produces no warnings.
+
+        Given: The real components.schema.json enum and the real mermaid-styles.yaml
+        When: get_missing_category_warnings() is called with the live schema categories
+        Then: Returns an empty list (live corpus is in sync per 2026-05-04 verification)
+        """
+        import json
+
+        schema_path = (
+            Path(__file__).parent.parent.parent.parent / "risk-map" / "schemas" / "components.schema.json"
+        )
+        styles_path = Path(__file__).parent.parent.parent.parent / "risk-map" / "yaml" / "mermaid-styles.yaml"
+
+        with open(schema_path) as fh:
+            schema = json.load(fh)
+
+        schema_categories = set(schema["definitions"]["category"]["properties"]["id"]["enum"])
+
+        loader = MermaidConfigLoader(styles_path)
+        result = loader.get_missing_category_warnings(schema_categories)
+
+        assert result == [], f"Live corpus has {len(result)} unexpected missing-category warning(s): {result}"
+
+    # ------------------------------------------------------------------
+    # Layer 2 — operator-visible emission (optional wiring check)
+    # ------------------------------------------------------------------
+
+    def test_emission_path_surfaces_missing_category(self, tmp_path, capsys):
+        """
+        If the loader emits warnings to stderr, the missing category ID appears there.
+
+        Given: Styling is missing componentsApplication
+        When: The loader emits warnings via print(stderr) or warnings.warn
+        Then: "componentsApplication" is present in stderr output
+
+        NOTE: This test is conditional — it only asserts that IF the loader
+        has an emit method, calling it produces visible output.  If SWE
+        implements a return-list-only API with no emit method this test
+        can be skipped or removed.  The pure-method tests above are the
+        primary contract.
+        """
+        import warnings
+
+        loader = self._loader_with_categories(tmp_path, ["componentsInfrastructure", "componentsModel"])
+        schema_categories = {
+            "componentsInfrastructure",
+            "componentsModel",
+            "componentsApplication",
+        }
+
+        # Capture both stderr output and Python warnings
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter("always")
+
+            # If the loader has an emit-style method, call it
+            if hasattr(loader, "emit_missing_category_warnings"):
+                loader.emit_missing_category_warnings(schema_categories)
+                captured = capsys.readouterr()
+                warned_text = " ".join(str(w.message) for w in caught_warnings)
+                all_output = captured.err + captured.out + warned_text
+                assert "componentsApplication" in all_output, (
+                    "emit_missing_category_warnings() did not surface the missing category"
+                )
+            else:
+                # Return-list API only; emission test does not apply — pass silently
+                pytest.skip("Loader uses return-list API; no emit method to test here")
+
+
+"""
+Test Summary
+============
+Class: TestMissingCategoryWarnings
+Total Tests: 9
+- Happy Path / all-present: 2  (all_schema_categories_present, live_corpus_regression)
+- Edge Cases: 3  (empty_schema_set, empty_styling_config, return_type_always_list)
+- Error / Missing Conditions: 3  (one_missing, multiple_missing, warning_string_mentions_id)
+- Optional Emission Check: 1  (emission_path_surfaces_missing_category)
+
+Coverage Areas:
+- Return shape: always list[str]
+- Warning content: each warning names the missing category ID
+- Boundary values: empty schema set, empty styling config, all present
+- Live corpus regression: schema enum vs live YAML in sync
+- Optional operator-visible emission path (skipped if return-list-only API)
+"""

--- a/scripts/hooks/tests/test_precommit_hook_install.py
+++ b/scripts/hooks/tests/test_precommit_hook_install.py
@@ -112,6 +112,15 @@ _REQUIRED_HOOK_IDS = {
     "validate-component-edges",
     "validate-control-risk-references",
     "validate-framework-references",
+    # Lifecycle uniqueness — dedicated hook so a lifecycle-only commit
+    # (touching only risk-map/yaml/lifecycle-stage.yaml) is reachable.
+    # Replaces the inline lifecycle-uniqueness call previously gated on
+    # validate-component-edges (validate_riskmap.py:184-212), which only
+    # triggers when components.yaml is staged. Architect-recommended Fix B
+    # for PR #277 reviewer feedback (item 2): split into a separate hook
+    # rather than widen validate-component-edges (would force a misleading
+    # hook-name scope).
+    "validate-lifecycle-stage",
     "validate-workflow-uses-pinning",
     # Issue templates:
     "regenerate-issue-templates",
@@ -230,6 +239,99 @@ class TestValidatorHookContracts:
         for token in ("controls", "frameworks", "personas", "risks"):
             assert token in files, f"framework refs files regex missing `{token}`: {files!r}"
         assert hook.get("pass_filenames") is False
+
+    def test_validate_lifecycle_stage_dedicated_hook_present(self):
+        """
+        Test that a dedicated `validate-lifecycle-stage` hook is declared.
+
+        Given: .pre-commit-config.yaml after the Fix B split
+        When:  searching for the lifecycle-stage hook
+        Then:  Exactly one hook with id `validate-lifecycle-stage` exists.
+
+        This pins the architectural intent that lifecycle uniqueness has
+        its own hook entry rather than being bundled into another hook.
+        Lifecycle-only commits (which touch only lifecycle-stage.yaml and
+        not components.yaml) must be able to trigger the check.
+        """
+        hooks = _hooks_by_id("validate-lifecycle-stage")
+        assert len(hooks) == 1, (
+            f"Exactly one validate-lifecycle-stage hook expected; got {len(hooks)}. "
+            f"Architect-recommended Fix B requires a dedicated hook with a narrow "
+            f"`files:` regex that fires on lifecycle-only commits."
+        )
+
+    def test_validate_lifecycle_stage_entry_invokes_validate_riskmap_in_lifecycle_mode(self):
+        """
+        Test that the lifecycle hook entry invokes validate_riskmap.py with
+        the dedicated `--mode lifecycle` flag.
+
+        Given: the `validate-lifecycle-stage` hook in .pre-commit-config.yaml
+        When:  inspecting the `entry:` field
+        Then:  The entry contains both `validate_riskmap.py` and
+               `--mode lifecycle` (substring match keeps the test stable
+               against minor wording changes such as `python3 ` prefix).
+
+        The `--mode lifecycle` flag is the SWE contract: lifecycle mode
+        bypasses get_staged_yaml_files / ComponentEdgeValidator and runs
+        only the uniqueness check. See TestMainLifecycleMode in
+        test_validate_riskmap.py.
+        """
+        hooks = _hooks_by_id("validate-lifecycle-stage")
+        assert len(hooks) == 1, "validate-lifecycle-stage hook missing"
+        entry = hooks[0].get("entry", "")
+        assert "validate_riskmap.py" in entry, (
+            f"validate-lifecycle-stage entry must invoke validate_riskmap.py; got: {entry!r}"
+        )
+        assert "--mode lifecycle" in entry, (
+            f"validate-lifecycle-stage entry must pass --mode lifecycle so the script "
+            f"runs the dedicated short-circuit path; got: {entry!r}"
+        )
+
+    def test_validate_lifecycle_stage_files_regex_anchored_on_lifecycle_yaml(self):
+        """
+        Test that the lifecycle hook's `files:` regex is narrowly scoped to
+        lifecycle-stage.yaml.
+
+        Given: the `validate-lifecycle-stage` hook
+        When:  inspecting the `files:` regex
+        Then:  The regex matches risk-map/yaml/lifecycle-stage.yaml and is
+               anchored. Specifically the regex must be exactly
+               `^risk-map/yaml/lifecycle-stage\\.yaml$` so the hook does not
+               misfire on unrelated yaml writes.
+
+        Anchoring matters: an unanchored `lifecycle-stage` substring would
+        match any future file name containing the phrase. The exact-match
+        requirement also disambiguates the architectural intent —
+        lifecycle mode is single-file scoped.
+        """
+        hooks = _hooks_by_id("validate-lifecycle-stage")
+        assert len(hooks) == 1, "validate-lifecycle-stage hook missing"
+        files_regex = hooks[0].get("files", "")
+        assert files_regex == r"^risk-map/yaml/lifecycle-stage\.yaml$", (
+            f"validate-lifecycle-stage files regex must be "
+            f"`^risk-map/yaml/lifecycle-stage\\.yaml$` (anchored, exact); "
+            f"got: {files_regex!r}"
+        )
+
+    def test_validate_lifecycle_stage_pass_filenames_is_false(self):
+        """
+        Test that the lifecycle hook sets pass_filenames: false.
+
+        Given: the `validate-lifecycle-stage` hook
+        When:  inspecting `pass_filenames`
+        Then:  Value is False.
+
+        The validator self-discovers risk-map/yaml/lifecycle-stage.yaml
+        from a fixed path; passing the staged filename as argv would be
+        redundant and risks the framework batching multiple invocations.
+        Matches the pattern used by validate-component-edges,
+        validate-control-risk-references, and validate-framework-references.
+        """
+        hooks = _hooks_by_id("validate-lifecycle-stage")
+        assert len(hooks) == 1, "validate-lifecycle-stage hook missing"
+        assert hooks[0].get("pass_filenames") is False, (
+            f"validate-lifecycle-stage must set pass_filenames: false; got: {hooks[0].get('pass_filenames')!r}"
+        )
 
     def test_validate_workflow_uses_pinning_targets_workflow_yml_files(self):
         hooks = _hooks_by_id("validate-workflow-uses-pinning")

--- a/scripts/hooks/tests/test_validate_framework_references_block_toggle.py
+++ b/scripts/hooks/tests/test_validate_framework_references_block_toggle.py
@@ -13,17 +13,13 @@ A3 (validate_yaml_prose_subset.py) and A3.7 (lifecycle uniqueness).
 Test structure
 --------------
 1. TestCheckDeprecatedPersonaUsageRegressionGuard
-   Pure-function tests on the already-existing
-   check_deprecated_persona_usage() at line 345 of
-   validate_framework_references.py.  These tests PASS today (red phase for
-   the function is already green) and serve as regression guards so SWE cannot
-   accidentally change the function's semantics while wiring the toggle.
+   Pure-function tests on the existing check_deprecated_persona_usage()
+   at line 345 of validate_framework_references.py.  These guard the
+   function's shape so future wiring cannot accidentally change semantics.
 
 2. TestBlockToggleCLI
-   Subprocess-based end-to-end tests that pin the observable CLI exit codes.
-   These tests FAIL today because --block does not yet exist on the script's
-   argparse, causing argparse to exit 2 ("unrecognized arguments").  That exit-2
-   is the expected red-phase failure mode.
+   Subprocess-based end-to-end tests that pin the observable CLI exit codes
+   for the --block toggle.
 
 Synthesized-corpus harness
 --------------------------
@@ -455,17 +451,11 @@ class TestCheckDeprecatedPersonaUsageRegressionGuard:
 
 # ===========================================================================
 # 2. CLI exit-code tests — --block toggle
-#    These tests FAIL today (red phase): --block not yet in argparse.
 # ===========================================================================
 
 
 class TestBlockToggleCLI:
     """End-to-end CLI tests for the --block toggle.
-
-    These tests fail in the red phase because --block does not yet exist on
-    validate_framework_references.py's argparse.  When argparse encounters an
-    unrecognised argument it exits 2.  After SWE adds --block the tests are
-    expected to pass (green phase).
 
     Live-corpus tests use _REPO_ROOT as cwd; synthesised-corpus tests build a
     minimal four-file corpus in tmp_path.

--- a/scripts/hooks/tests/test_validate_framework_references_block_toggle.py
+++ b/scripts/hooks/tests/test_validate_framework_references_block_toggle.py
@@ -1,0 +1,649 @@
+#!/usr/bin/env python3
+"""
+Tests for the --block toggle on validate_framework_references.py (task 2.3.6).
+
+Per ADR-021 D8: deprecated-persona reference enforcement ships as a
+warn-only-first validator with a block toggle. Default (no --block): warnings
+print, exit 0. With --block and any deprecated-persona warnings: exit 1.
+With --block and a clean corpus (no deprecated refs): exit 0.
+
+These tests follow the warn-only-first / block-toggle pattern established by
+A3 (validate_yaml_prose_subset.py) and A3.7 (lifecycle uniqueness).
+
+Test structure
+--------------
+1. TestCheckDeprecatedPersonaUsageRegressionGuard
+   Pure-function tests on the already-existing
+   check_deprecated_persona_usage() at line 345 of
+   validate_framework_references.py.  These tests PASS today (red phase for
+   the function is already green) and serve as regression guards so SWE cannot
+   accidentally change the function's semantics while wiring the toggle.
+
+2. TestBlockToggleCLI
+   Subprocess-based end-to-end tests that pin the observable CLI exit codes.
+   These tests FAIL today because --block does not yet exist on the script's
+   argparse, causing argparse to exit 2 ("unrecognized arguments").  That exit-2
+   is the expected red-phase failure mode.
+
+Synthesized-corpus harness
+--------------------------
+For the clean-corpus subprocess tests we need to point the script at YAML files
+that have no deprecated-persona references.  The script's get_staged_yaml_files()
+reads files at the paths risk-map/yaml/frameworks.yaml, risks.yaml, controls.yaml,
+personas.yaml relative to cwd.  The cleanest approach is:
+  - create tmp_path / "risk-map" / "yaml"
+  - write minimal valid YAML at each of the four paths
+  - invoke the script via subprocess with cwd=tmp_path and --force
+
+The live-corpus subprocess tests use the actual repo-root as cwd (risk-map/yaml/
+files already exist there); they pin:
+  - no --block -> exit 0  (today's behaviour, must not regress)
+  - --block    -> exit 1  (corpus has 88 deprecated-persona refs; toggle fires)
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# sys.path injection — same pattern as the existing test file
+# ---------------------------------------------------------------------------
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from validate_framework_references import check_deprecated_persona_usage  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Absolute path to the script under test — used in all subprocess invocations.
+_SCRIPT = Path(__file__).parent.parent / "validate_framework_references.py"
+
+# Repository root (worktree root) — used as cwd for live-corpus tests.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+# Minimal frameworks.yaml content: one valid framework so validate_frameworks()
+# does not short-circuit at "no frameworks found".
+_MINIMAL_FRAMEWORKS: dict[str, Any] = {
+    "frameworks": [
+        {
+            "id": "mitre-atlas",
+            "name": "MITRE ATLAS",
+            "fullName": "Adversarial Threat Landscape for AI Systems",
+            "description": "MITRE ATLAS framework",
+            "baseUri": "https://atlas.mitre.org",
+            "applicableTo": ["risks", "controls"],
+        }
+    ]
+}
+
+# Deprecated persona and one current persona.
+_PERSONAS_WITH_DEPRECATED: dict[str, Any] = {
+    "personas": [
+        {
+            "id": "personaModelCreator",
+            "title": "Model Creator",
+            "description": ["Legacy persona, retained for backward compatibility."],
+            "deprecated": True,
+        },
+        {
+            "id": "personaModelProvider",
+            "title": "Model Provider",
+            "description": ["A current persona."],
+            "deprecated": False,
+        },
+    ]
+}
+
+# Personas with NO deprecated members (all current).
+_PERSONAS_ALL_CURRENT: dict[str, Any] = {
+    "personas": [
+        {
+            "id": "personaModelProvider",
+            "title": "Model Provider",
+            "description": ["A current persona."],
+        },
+        {
+            "id": "personaApplicationDeveloper",
+            "title": "Application Developer",
+            "description": ["A current persona."],
+        },
+    ]
+}
+
+# Controls that reference the deprecated persona.
+_CONTROLS_WITH_DEPRECATED_REF: dict[str, Any] = {
+    "controls": [
+        {
+            "id": "controlA",
+            "title": "Control A",
+            "personas": ["personaModelCreator"],  # deprecated
+        },
+        {
+            "id": "controlB",
+            "title": "Control B",
+            "personas": ["personaModelProvider"],  # current — no warning
+        },
+    ]
+}
+
+# Controls that reference only current personas.
+_CONTROLS_CLEAN: dict[str, Any] = {
+    "controls": [
+        {
+            "id": "controlA",
+            "title": "Control A",
+            "personas": ["personaModelProvider"],
+        },
+    ]
+}
+
+# Risks that reference the deprecated persona.
+_RISKS_WITH_DEPRECATED_REF: dict[str, Any] = {
+    "risks": [
+        {
+            "id": "riskAlpha",
+            "title": "Risk Alpha",
+            "personas": ["personaModelCreator"],  # deprecated
+        },
+        {
+            "id": "riskBeta",
+            "title": "Risk Beta",
+            "personas": ["personaModelProvider"],  # current — no warning
+        },
+    ]
+}
+
+# Risks that reference only current personas.
+_RISKS_CLEAN: dict[str, Any] = {
+    "risks": [
+        {
+            "id": "riskAlpha",
+            "title": "Risk Alpha",
+            "personas": ["personaModelProvider"],
+        },
+    ]
+}
+
+# Risks with NO personas field at all.
+_RISKS_NO_PERSONAS: dict[str, Any] = {
+    "risks": [
+        {
+            "id": "riskAlpha",
+            "title": "Risk Alpha",
+        }
+    ]
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_corpus(base: Path, personas: dict, controls: dict, risks: dict) -> Path:
+    """Write a minimal four-file corpus under base/risk-map/yaml/ and return base.
+
+    Args:
+        base: Temporary directory root (passed in from tmp_path).
+        personas: Parsed personas.yaml content.
+        controls: Parsed controls.yaml content.
+        risks: Parsed risks.yaml content.
+
+    Returns:
+        The base path (for use as subprocess cwd).
+    """
+    yaml_dir = base / "risk-map" / "yaml"
+    yaml_dir.mkdir(parents=True)
+    (yaml_dir / "frameworks.yaml").write_text(yaml.dump(_MINIMAL_FRAMEWORKS), encoding="utf-8")
+    (yaml_dir / "personas.yaml").write_text(yaml.dump(personas), encoding="utf-8")
+    (yaml_dir / "controls.yaml").write_text(yaml.dump(controls), encoding="utf-8")
+    (yaml_dir / "risks.yaml").write_text(yaml.dump(risks), encoding="utf-8")
+    return base
+
+
+def _run(cwd: Path, *extra_args: str) -> subprocess.CompletedProcess:
+    """Run the script via subprocess with --force and any extra args.
+
+    Always passes --force so the script validates regardless of git-staged state.
+    cwd is set to the given directory so get_staged_yaml_files() resolves
+    risk-map/yaml/* relative to it.
+
+    Args:
+        cwd: Working directory for the subprocess.
+        *extra_args: Additional CLI arguments (e.g. "--block").
+
+    Returns:
+        CompletedProcess with returncode, stdout, stderr.
+    """
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), "--force", *extra_args],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+    )
+
+
+# ===========================================================================
+# 1. Pure-function regression guard — check_deprecated_persona_usage()
+# ===========================================================================
+
+
+class TestCheckDeprecatedPersonaUsageRegressionGuard:
+    """Regression guard for check_deprecated_persona_usage() — these tests pass today.
+
+    The function already exists at validate_framework_references.py:345.
+    These tests lock its observable behaviour so SWE cannot accidentally change
+    the signature or semantics while wiring the --block toggle.
+    """
+
+    def test_control_referencing_deprecated_persona_returns_warning(self):
+        """
+        A control that references a deprecated persona produces a warning.
+
+        Given: personas_data with personaModelCreator (deprecated: true),
+               controls_data with a control whose personas list includes
+               personaModelCreator, and risks_data with no personas
+        When: check_deprecated_persona_usage is called
+        Then: Returns a non-empty list; warning mentions the control ID and persona ID
+        """
+        result = check_deprecated_persona_usage(
+            _PERSONAS_WITH_DEPRECATED,
+            _CONTROLS_WITH_DEPRECATED_REF,
+            _RISKS_CLEAN,
+        )
+        assert len(result) >= 1
+        combined = " ".join(result)
+        assert "controlA" in combined, f"Expected 'controlA' in warnings; got: {result}"
+        assert "personaModelCreator" in combined, f"Expected 'personaModelCreator' in warnings; got: {result}"
+
+    def test_risk_referencing_deprecated_persona_returns_warning(self):
+        """
+        A risk that references a deprecated persona produces a warning.
+
+        Given: personas_data with personaModelCreator (deprecated: true),
+               risks_data with a risk whose personas list includes personaModelCreator,
+               and controls_data with no deprecated refs
+        When: check_deprecated_persona_usage is called
+        Then: Returns a non-empty list; warning mentions the risk ID and persona ID
+        """
+        result = check_deprecated_persona_usage(
+            _PERSONAS_WITH_DEPRECATED,
+            _CONTROLS_CLEAN,
+            _RISKS_WITH_DEPRECATED_REF,
+        )
+        assert len(result) >= 1
+        combined = " ".join(result)
+        assert "riskAlpha" in combined, f"Expected 'riskAlpha' in warnings; got: {result}"
+        assert "personaModelCreator" in combined, f"Expected 'personaModelCreator' in warnings; got: {result}"
+
+    def test_both_control_and_risk_with_deprecated_ref_returns_two_warnings(self):
+        """
+        Both a control and a risk referencing a deprecated persona produce two warnings.
+
+        Given: personas_data with personaModelCreator (deprecated: true),
+               controls_data with one deprecated ref, risks_data with one deprecated ref
+        When: check_deprecated_persona_usage is called
+        Then: Returns at least 2 warnings (one per deprecated reference found)
+        """
+        result = check_deprecated_persona_usage(
+            _PERSONAS_WITH_DEPRECATED,
+            _CONTROLS_WITH_DEPRECATED_REF,
+            _RISKS_WITH_DEPRECATED_REF,
+        )
+        # controlA + riskAlpha both reference personaModelCreator
+        assert len(result) >= 2
+
+    def test_current_persona_reference_returns_empty_list(self):
+        """
+        References to non-deprecated personas produce no warnings.
+
+        Given: personas_data with all current personas (no deprecated: true),
+               controls_data and risks_data referencing only current personas
+        When: check_deprecated_persona_usage is called
+        Then: Returns empty list
+        """
+        result = check_deprecated_persona_usage(
+            _PERSONAS_ALL_CURRENT,
+            _CONTROLS_CLEAN,
+            _RISKS_CLEAN,
+        )
+        assert result == [], f"Expected no warnings for current-persona refs; got: {result}"
+
+    def test_reference_to_nonexistent_persona_id_returns_empty_list(self):
+        """
+        A reference to a persona ID that does not appear in personas_data at all
+        is silently ignored (no warning; the function only warns on known-deprecated IDs).
+
+        Given: personas_data with only current personas,
+               controls_data referencing an ID that is not in personas_data at all
+        When: check_deprecated_persona_usage is called
+        Then: Returns empty list (no deprecated set to match against)
+        """
+        controls_with_unknown_ref: dict[str, Any] = {
+            "controls": [{"id": "controlX", "title": "X", "personas": ["personaDoesNotExist"]}]
+        }
+        result = check_deprecated_persona_usage(
+            _PERSONAS_ALL_CURRENT,
+            controls_with_unknown_ref,
+            _RISKS_CLEAN,
+        )
+        assert result == [], f"Expected no warnings for unknown persona refs; got: {result}"
+
+    def test_none_personas_data_returns_empty_list(self):
+        """
+        Passing None as personas_data returns empty list (no deprecated set to build).
+
+        Given: personas_data=None
+        When: check_deprecated_persona_usage is called
+        Then: Returns empty list (graceful handling)
+        """
+        result = check_deprecated_persona_usage(None, _CONTROLS_WITH_DEPRECATED_REF, _RISKS_WITH_DEPRECATED_REF)
+        assert result == [], f"Expected empty list when personas_data is None; got: {result}"
+
+    def test_none_controls_data_returns_empty_list_for_controls(self):
+        """
+        Passing None as controls_data does not crash; no control warnings are emitted.
+
+        Given: personas_data with a deprecated persona, controls_data=None,
+               risks_data with no deprecated refs
+        When: check_deprecated_persona_usage is called
+        Then: Returns empty list (no controls to scan)
+        """
+        result = check_deprecated_persona_usage(_PERSONAS_WITH_DEPRECATED, None, _RISKS_CLEAN)
+        assert result == [], f"Expected empty list when controls_data is None; got: {result}"
+
+    def test_none_risks_data_returns_empty_list_for_risks(self):
+        """
+        Passing None as risks_data does not crash; no risk warnings are emitted.
+
+        Given: personas_data with a deprecated persona, controls_data with no deprecated refs,
+               risks_data=None
+        When: check_deprecated_persona_usage is called
+        Then: Returns empty list (no risks to scan)
+        """
+        result = check_deprecated_persona_usage(_PERSONAS_WITH_DEPRECATED, _CONTROLS_CLEAN, None)
+        assert result == [], f"Expected empty list when risks_data is None; got: {result}"
+
+    def test_all_none_returns_empty_list(self):
+        """
+        All-None inputs return empty list without raising.
+
+        Given: personas_data=None, controls_data=None, risks_data=None
+        When: check_deprecated_persona_usage is called
+        Then: Returns empty list
+        """
+        result = check_deprecated_persona_usage(None, None, None)
+        assert result == [], f"Expected empty list for all-None inputs; got: {result}"
+
+    def test_risk_without_personas_field_ignored(self):
+        """
+        A risk entry with no personas field is silently skipped.
+
+        Given: personas_data with a deprecated persona, risks_data whose risks have
+               no personas key
+        When: check_deprecated_persona_usage is called
+        Then: Returns empty list (no refs to check)
+        """
+        result = check_deprecated_persona_usage(
+            _PERSONAS_WITH_DEPRECATED,
+            _CONTROLS_CLEAN,
+            _RISKS_NO_PERSONAS,
+        )
+        assert result == [], f"Expected no warnings for risks without personas field; got: {result}"
+
+    def test_persona_with_no_deprecated_flag_is_not_treated_as_deprecated(self):
+        """
+        A persona with no 'deprecated' key (field absent) is not treated as deprecated.
+
+        Given: personas_data where one persona has no 'deprecated' key at all,
+               controls_data referencing that persona
+        When: check_deprecated_persona_usage is called
+        Then: Returns empty list (absent field defaults to False)
+        """
+        personas_no_flag: dict[str, Any] = {
+            "personas": [
+                {
+                    "id": "personaNoFlag",
+                    "title": "No Flag Persona",
+                    "description": ["No deprecated field at all."],
+                    # No 'deprecated' key
+                }
+            ]
+        }
+        controls_ref_no_flag: dict[str, Any] = {
+            "controls": [{"id": "controlX", "title": "X", "personas": ["personaNoFlag"]}]
+        }
+        result = check_deprecated_persona_usage(personas_no_flag, controls_ref_no_flag, _RISKS_CLEAN)
+        assert result == [], f"Expected no warnings when deprecated flag is absent; got: {result}"
+
+    def test_returns_list_type(self):
+        """
+        The function always returns a list, never None.
+
+        Given: Any valid input combination
+        When: check_deprecated_persona_usage is called
+        Then: Return value is a list instance
+        """
+        result = check_deprecated_persona_usage(
+            _PERSONAS_WITH_DEPRECATED,
+            _CONTROLS_CLEAN,
+            _RISKS_CLEAN,
+        )
+        assert isinstance(result, list), f"Expected list; got {type(result)}"
+
+    def test_each_warning_is_a_string(self):
+        """
+        Every element in the returned list is a string.
+
+        Given: A corpus with at least one deprecated-persona reference
+        When: check_deprecated_persona_usage is called
+        Then: All elements in the returned list are str instances
+        """
+        result = check_deprecated_persona_usage(
+            _PERSONAS_WITH_DEPRECATED,
+            _CONTROLS_WITH_DEPRECATED_REF,
+            _RISKS_WITH_DEPRECATED_REF,
+        )
+        assert len(result) > 0
+        for item in result:
+            assert isinstance(item, str), f"Expected str element; got {type(item)!r}: {item!r}"
+
+
+# ===========================================================================
+# 2. CLI exit-code tests — --block toggle
+#    These tests FAIL today (red phase): --block not yet in argparse.
+# ===========================================================================
+
+
+class TestBlockToggleCLI:
+    """End-to-end CLI tests for the --block toggle.
+
+    These tests fail in the red phase because --block does not yet exist on
+    validate_framework_references.py's argparse.  When argparse encounters an
+    unrecognised argument it exits 2.  After SWE adds --block the tests are
+    expected to pass (green phase).
+
+    Live-corpus tests use _REPO_ROOT as cwd; synthesised-corpus tests build a
+    minimal four-file corpus in tmp_path.
+    """
+
+    # -----------------------------------------------------------------------
+    # Live-corpus: uses the actual risk-map/yaml/ tree in the worktree.
+    # The corpus has 88 deprecated-persona refs (49 controls + 39 risks).
+    # -----------------------------------------------------------------------
+
+    def test_live_corpus_no_block_flag_exits_0(self):
+        """
+        Running without --block against the live corpus exits 0.
+
+        This is today's existing behaviour and must not regress after adding --block.
+
+        Given: The live risk-map/yaml/ corpus (88 deprecated-persona refs)
+        When: validate_framework_references.py --force (no --block)
+        Then: Exit code is 0
+        """
+        result = _run(_REPO_ROOT)
+        assert result.returncode == 0, (
+            f"Expected exit 0 without --block; got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_live_corpus_with_block_flag_exits_1(self):
+        """
+        Running with --block against the live corpus exits 1 (88 deprecated refs).
+
+        Given: The live risk-map/yaml/ corpus (88 deprecated-persona refs)
+        When: validate_framework_references.py --force --block
+        Then: Exit code is 1 (deprecated-persona warnings promoted to failures)
+        """
+        result = _run(_REPO_ROOT, "--block")
+        assert result.returncode == 1, (
+            f"Expected exit 1 with --block on live corpus; got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_live_corpus_with_block_flag_stdout_contains_deprecated_warning(self):
+        """
+        When --block fires, the output contains the deprecated-persona warning text.
+
+        Given: The live corpus and --block flag
+        When: validate_framework_references.py --force --block
+        Then: Output contains the deprecation warning strings (so the developer
+              can see which entries triggered the block)
+        """
+        result = _run(_REPO_ROOT, "--block")
+        # Script already prints deprecation warnings to stdout; they must still appear.
+        combined = result.stdout + result.stderr
+        assert "deprecated" in combined.lower(), (
+            f"Expected 'deprecated' in output; stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+        )
+
+    # -----------------------------------------------------------------------
+    # Synthesised clean corpus: no deprecated refs -> --block does NOT fire.
+    # -----------------------------------------------------------------------
+
+    def test_clean_corpus_with_block_flag_exits_0(self, tmp_path):
+        """
+        Running with --block against a corpus with NO deprecated refs exits 0.
+
+        The --block toggle must only promote warnings to failures when warnings
+        actually exist; a clean corpus must always exit 0 regardless of --block.
+
+        Given: A synthesised corpus where all personas are current (no deprecated: true)
+               and controls/risks reference only current personas
+        When: validate_framework_references.py --force --block (cwd=tmp_path)
+        Then: Exit code is 0 (no deprecated-persona warnings to promote)
+        """
+        _write_corpus(tmp_path, _PERSONAS_ALL_CURRENT, _CONTROLS_CLEAN, _RISKS_CLEAN)
+        result = _run(tmp_path, "--block")
+        assert result.returncode == 0, (
+            f"Expected exit 0 with --block on clean corpus; got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_clean_corpus_no_block_flag_exits_0(self, tmp_path):
+        """
+        Running without --block against a clean corpus exits 0.
+
+        Baseline sanity check: the synthesised corpus harness itself is correct.
+
+        Given: A synthesised clean corpus
+        When: validate_framework_references.py --force (no --block)
+        Then: Exit code is 0
+        """
+        _write_corpus(tmp_path, _PERSONAS_ALL_CURRENT, _CONTROLS_CLEAN, _RISKS_CLEAN)
+        result = _run(tmp_path)
+        assert result.returncode == 0, (
+            f"Expected exit 0 on clean corpus without --block; got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_dirty_synthesised_corpus_with_block_exits_1(self, tmp_path):
+        """
+        Running with --block against a synthesised dirty corpus (deprecated refs) exits 1.
+
+        Cross-checks that the block toggle fires correctly on a synthetic corpus,
+        not just the live one.
+
+        Given: A synthesised corpus with a deprecated persona referenced by a control
+        When: validate_framework_references.py --force --block
+        Then: Exit code is 1
+        """
+        _write_corpus(tmp_path, _PERSONAS_WITH_DEPRECATED, _CONTROLS_WITH_DEPRECATED_REF, _RISKS_CLEAN)
+        result = _run(tmp_path, "--block")
+        assert result.returncode == 1, (
+            f"Expected exit 1 with --block on dirty corpus; got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_dirty_synthesised_corpus_no_block_exits_0(self, tmp_path):
+        """
+        Running WITHOUT --block against a dirty synthesised corpus exits 0.
+
+        Confirms that warn-only (default) behaviour is preserved even when
+        deprecated refs are present.
+
+        Given: A synthesised corpus with a deprecated persona referenced by a control
+        When: validate_framework_references.py --force (no --block)
+        Then: Exit code is 0 (warnings only, no failure)
+        """
+        _write_corpus(tmp_path, _PERSONAS_WITH_DEPRECATED, _CONTROLS_WITH_DEPRECATED_REF, _RISKS_CLEAN)
+        result = _run(tmp_path)
+        assert result.returncode == 0, (
+            f"Expected exit 0 without --block on dirty corpus; got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    # -----------------------------------------------------------------------
+    # Flag discovery: --help must list --block
+    # -----------------------------------------------------------------------
+
+    def test_help_output_contains_block_flag(self):
+        """
+        The --help output documents the --block flag.
+
+        Given: The script is invoked with --help
+        When: validate_framework_references.py --help
+        Then: The --help text contains '--block'
+        """
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT), "--help"],
+            capture_output=True,
+            text=True,
+        )
+        # argparse --help exits 0
+        assert result.returncode == 0, f"--help unexpectedly exited {result.returncode}"
+        assert "--block" in result.stdout, f"Expected '--block' in --help output; got:\n{result.stdout}"
+
+
+# ===========================================================================
+# Test Summary
+# ===========================================================================
+# Total tests: 21
+#
+# TestCheckDeprecatedPersonaUsageRegressionGuard  (13 tests)
+#   — control with deprecated ref produces warning; risk with deprecated ref
+#     produces warning; both produce >=2 warnings; current-only refs produce
+#     empty list; nonexistent persona ID ignored; None personas_data;
+#     None controls_data; None risks_data; all-None inputs; risk without
+#     personas field; absent deprecated flag treated as False; return type
+#     is list; each element is str.
+#
+# TestBlockToggleCLI  (8 tests)
+#   — live corpus + no --block -> exit 0 (regression guard);
+#     live corpus + --block -> exit 1 (88 deprecated refs fire the toggle);
+#     live corpus + --block -> output contains "deprecated" text;
+#     clean synthesised corpus + --block -> exit 0;
+#     clean synthesised corpus + no --block -> exit 0;
+#     dirty synthesised corpus + --block -> exit 1;
+#     dirty synthesised corpus + no --block -> exit 0 (warn-only preserved);
+#     --help output contains '--block'.
+#
+# Red-phase failure mode
+#   - Regression-guard class: PASS today (function already exists).
+#   - Block-toggle CLI class: FAIL today with argparse exit 2
+#     ("unrecognised arguments: --block").

--- a/scripts/hooks/tests/test_validate_riskmap.py
+++ b/scripts/hooks/tests/test_validate_riskmap.py
@@ -8,7 +8,8 @@ graph generation capabilities for component, control, and risk visualizations.
 
 Test Coverage:
 ==============
-Total Tests: 36 across 4 test classes
+Total Tests: 36 across 4 test classes (plus the TestMainLifecycleMode class
+that pins the dedicated `--mode lifecycle` short-circuit hook).
 Coverage Target: 98%+ of validate_riskmap.py (achieved)
 
 1. TestParseArgs - CLI argument parsing (lines 35-113) - 14 tests
@@ -51,11 +52,22 @@ Coverage Target: 98%+ of validate_riskmap.py (achieved)
    - KeyboardInterrupt handling (exit code 2)
    - Unexpected exceptions (exit code 2)
    - Validator initialization errors (exit code 2)
+
+5. TestMainLifecycleMode - `--mode lifecycle` short-circuit hook
+   - Pins the dedicated lifecycle-only entrypoint introduced to fix PR #277
+     reviewer feedback (item 2): the lifecycle uniqueness check must be
+     reachable on lifecycle-only commits without going through the
+     components-validation pipeline.
+   - Architectural intent: lifecycle mode bypasses get_staged_yaml_files,
+     ComponentEdgeValidator, and graph generation entirely.
 """
 
 import sys
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock, mock_open, patch
+
+import yaml
 
 # Add scripts/hooks to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -1077,3 +1089,327 @@ class TestMainErrorHandling:
         captured = capsys.readouterr()
         assert "Unexpected error:" in captured.out
         assert "Invalid validator configuration" in captured.out
+
+
+# ============================================================================
+# TestMainLifecycleMode — `--mode lifecycle` short-circuit hook
+# ============================================================================
+#
+# Background: PR #277 reviewer feedback (item 2) showed that the lifecycle
+# uniqueness check is unreachable on commits that touch only
+# risk-map/yaml/lifecycle-stage.yaml — the validate-component-edges hook
+# only triggers when components.yaml is staged, so a lifecycle-only commit
+# silently bypasses the uniqueness check entirely.
+#
+# Architect-recommended Fix B: split lifecycle uniqueness into its own
+# dedicated `validate-lifecycle-stage` pre-commit hook with a narrow
+# `files: ^risk-map/yaml/lifecycle-stage\.yaml$` regex. Implementation
+# uses a new `--mode lifecycle` flag on validate_riskmap.py so the hook
+# entry stays in the same script.
+#
+# In `--mode lifecycle`, the script must:
+#   1. Skip the components-validation pipeline (no get_staged_yaml_files,
+#      no ComponentEdgeValidator instantiation).
+#   2. Load risk-map/yaml/lifecycle-stage.yaml directly and run
+#      check_lifecycle_stage_order_uniqueness.
+#   3. Skip graph generation (no ComponentGraph / ControlGraph / RiskGraph).
+#   4. Exit 0 on clean corpus, exit 1 on duplicate orders, exit 0 with a
+#      skip message when the file is absent (matches the default-mode
+#      graceful-skip pattern at validate_riskmap.py:210-212).
+#
+# These tests pin the architectural intent. Implementation choices (exact
+# argparse wiring, exit-code disposition for `--mode lifecycle` combined
+# with `--to-graph`, etc.) are documented per-test below.
+# ============================================================================
+
+
+# Reusable in-test fixtures. Re-defined here rather than imported from
+# test_lifecycle_stage_order_uniqueness.py so that file's collection is not
+# perturbed by cross-module imports (no __init__.py in tests/, so cross-file
+# imports go through sys.path manipulation only).
+_LIFECYCLE_CLEAN: dict[str, Any] = {
+    "lifecycleStages": [
+        {"id": "stage-one", "title": "Stage One", "order": 1},
+        {"id": "stage-two", "title": "Stage Two", "order": 2},
+        {"id": "stage-three", "title": "Stage Three", "order": 3},
+    ]
+}
+
+_LIFECYCLE_DUPLICATE: dict[str, Any] = {
+    "lifecycleStages": [
+        {"id": "stage-a", "title": "Stage A", "order": 1},
+        {"id": "stage-b", "title": "Stage B", "order": 2},
+        {"id": "stage-c", "title": "Stage C", "order": 2},  # duplicate
+    ]
+}
+
+
+def _write_lifecycle_only(base: Path, lifecycle: dict[str, Any] | None) -> Path:
+    """
+    Write only risk-map/yaml/lifecycle-stage.yaml under base.
+
+    Lifecycle mode must NOT depend on components.yaml / controls.yaml /
+    risks.yaml being present. Writing only the lifecycle file pins that
+    architectural intent: lifecycle mode is single-file scoped.
+
+    Args:
+        base: Temporary directory root (pytest tmp_path).
+        lifecycle: Parsed lifecycle YAML content, or None to omit the file
+                   (simulating the file-absent case).
+
+    Returns:
+        base path for use as cwd via monkeypatch.chdir.
+    """
+    yaml_dir = base / "risk-map" / "yaml"
+    yaml_dir.mkdir(parents=True)
+    if lifecycle is not None:
+        (yaml_dir / "lifecycle-stage.yaml").write_text(yaml.dump(lifecycle), encoding="utf-8")
+    return base
+
+
+class TestMainLifecycleMode:
+    """
+    Tests for the `--mode lifecycle` short-circuit entrypoint.
+
+    These tests pin the contract that lifecycle mode is a narrow,
+    single-purpose entrypoint that bypasses the components-validation
+    pipeline and graph-generation paths entirely.
+    """
+
+    def test_mode_lifecycle_exits_0_on_clean_corpus(self, tmp_path, monkeypatch, capsys):
+        """
+        Test that --mode lifecycle exits 0 against a clean lifecycle-stage.yaml.
+
+        Given: A tmp cwd containing only a clean risk-map/yaml/lifecycle-stage.yaml
+               (orders 1..3, all unique)
+        When:  validate_riskmap.main() is invoked with argv ["--mode", "lifecycle"]
+        Then:  Exits with code 0 (lifecycle uniqueness check passes)
+        """
+        _write_lifecycle_only(tmp_path, _LIFECYCLE_CLEAN)
+        monkeypatch.chdir(tmp_path)
+
+        with patch("sys.argv", ["script.py", "--mode", "lifecycle"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0, (
+            f"Expected exit 0 on clean lifecycle corpus; got {exc_info.value.code}. "
+            f"Captured output: {capsys.readouterr()!r}"
+        )
+
+    def test_mode_lifecycle_exits_1_on_duplicate_orders(self, tmp_path, monkeypatch, capsys):
+        """
+        Test that --mode lifecycle exits 1 when duplicate orders are present.
+
+        Given: A tmp cwd containing risk-map/yaml/lifecycle-stage.yaml where
+               stage-b and stage-c both carry order 2
+        When:  validate_riskmap.main() is invoked with argv ["--mode", "lifecycle"]
+        Then:  Exits with code 1 and the duplicate is reported on stdout/stderr.
+               Block-mode-immediate semantics — no --block flag required
+               (matches ADR-022 D4 disposition).
+        """
+        _write_lifecycle_only(tmp_path, _LIFECYCLE_DUPLICATE)
+        monkeypatch.chdir(tmp_path)
+
+        with patch("sys.argv", ["script.py", "--mode", "lifecycle"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 1, (
+            f"Expected exit 1 on duplicate lifecycle orders; got {exc_info.value.code}"
+        )
+
+        # Confirm the duplicate is reported. Substring check matches the
+        # output-shape contract from check_lifecycle_stage_order_uniqueness.
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "stage-b" in combined and "stage-c" in combined, (
+            f"Expected duplicate stage IDs in output; got: {combined!r}"
+        )
+
+    def test_mode_lifecycle_does_not_call_get_staged_yaml_files(self, tmp_path, monkeypatch):
+        """
+        Test that --mode lifecycle bypasses get_staged_yaml_files entirely.
+
+        Given: A tmp cwd containing a clean lifecycle-stage.yaml
+        When:  validate_riskmap.main() is invoked with argv ["--mode", "lifecycle"]
+        Then:  validate_riskmap.get_staged_yaml_files is NOT called AND the
+               script exits 0 (lifecycle uniqueness check reached and passed).
+
+        Architectural intent: lifecycle mode is a single-file narrow check;
+        the components-validation pipeline (which uses get_staged_yaml_files
+        to discover components.yaml) is irrelevant and must not run.
+
+        The exit-code assertion guards against false-positive passes: if
+        argparse rejects --mode lifecycle (current state, no flag wired)
+        the script exits with argparse error code 2 before any pipeline
+        runs, which would trivially satisfy a bare assert_not_called.
+        Pinning exit 0 forces the test to validate both the bypass AND
+        the successful lifecycle check on the same run.
+        """
+        _write_lifecycle_only(tmp_path, _LIFECYCLE_CLEAN)
+        monkeypatch.chdir(tmp_path)
+
+        with patch("sys.argv", ["script.py", "--mode", "lifecycle"]):
+            with patch("validate_riskmap.get_staged_yaml_files") as mock_get_files:
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+        assert exc_info.value.code == 0, (
+            f"Expected exit 0 (lifecycle check passed without going through the "
+            f"components pipeline); got {exc_info.value.code}. "
+            f"This test pins both the bypass and the success path."
+        )
+        mock_get_files.assert_not_called()
+
+    def test_mode_lifecycle_does_not_instantiate_component_edge_validator(self, tmp_path, monkeypatch):
+        """
+        Test that --mode lifecycle bypasses ComponentEdgeValidator entirely.
+
+        Given: A tmp cwd containing a clean lifecycle-stage.yaml
+        When:  validate_riskmap.main() is invoked with argv ["--mode", "lifecycle"]
+        Then:  validate_riskmap.ComponentEdgeValidator is NOT instantiated AND
+               the script exits 0.
+
+        Architectural intent: lifecycle mode short-circuits before the
+        components-validation orchestration. Even though
+        ComponentEdgeValidator.components is the gating attribute for the
+        existing inline lifecycle-uniqueness call (validate_riskmap.py:191),
+        in dedicated mode the gating is the file's existence, not validator
+        state.
+
+        Exit-code 0 assertion is the same false-positive guard as the
+        get_staged_yaml_files bypass test above.
+        """
+        _write_lifecycle_only(tmp_path, _LIFECYCLE_CLEAN)
+        monkeypatch.chdir(tmp_path)
+
+        with patch("sys.argv", ["script.py", "--mode", "lifecycle"]):
+            with patch("validate_riskmap.ComponentEdgeValidator") as mock_validator_class:
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+        assert exc_info.value.code == 0, (
+            f"Expected exit 0 (lifecycle check reached without instantiating "
+            f"ComponentEdgeValidator); got {exc_info.value.code}."
+        )
+        mock_validator_class.assert_not_called()
+
+    def test_mode_lifecycle_skips_graph_generation_when_to_graph_also_passed(self, tmp_path, monkeypatch, capsys):
+        """
+        Test that --mode lifecycle does not run graph generation even if
+        --to-graph is also provided.
+
+        Given: A tmp cwd containing a clean lifecycle-stage.yaml
+        When:  validate_riskmap.main() is invoked with argv
+               ["--mode", "lifecycle", "--to-graph", "graph.md"]
+        Then:  ComponentGraph is NOT instantiated, AND the script exits with
+               either:
+                 - exit 0  (graph silently ignored in lifecycle mode), OR
+                 - exit 2  (main() rejects the combination as a misuse with
+                           a clear "incompatible flags" message — also
+                           acceptable per architect intent).
+
+        Disposition note: SWE may choose either disposition. The test
+        intentionally accepts both; it pins only that ComponentGraph is
+        NOT constructed (graph generation is incompatible with lifecycle
+        mode's narrow scope) and that the script does NOT exit 1 (which
+        would mean lifecycle check failed on the clean corpus, the wrong
+        signal).
+
+        False-positive guard: this test must FAIL before --mode lifecycle
+        is implemented. Without the flag, argparse rejects the unknown
+        argument with `error: unrecognized arguments: --mode lifecycle`,
+        which would trivially satisfy the negative assertion on
+        ComponentGraph. Asserting that the argparse "unrecognized arguments"
+        message is NOT in stderr forces the test to fail until SWE wires
+        the flag — at which point either disposition (silent ignore or
+        explicit rejection) is accepted.
+        """
+        _write_lifecycle_only(tmp_path, _LIFECYCLE_CLEAN)
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "sys.argv",
+            ["script.py", "--mode", "lifecycle", "--to-graph", "graph.md"],
+        ):
+            with patch("validate_riskmap.ComponentGraph") as mock_graph_class:
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+        captured = capsys.readouterr()
+
+        # False-positive guard: argparse must have RECOGNIZED --mode lifecycle.
+        # Without this assertion the test passes trivially on the unimplemented
+        # flag, which defeats the red-phase purpose.
+        assert "unrecognized arguments" not in captured.err, (
+            f"argparse rejected --mode lifecycle as unrecognized; the flag must "
+            f"be wired before this test can validate the architectural intent. "
+            f"stderr: {captured.err!r}"
+        )
+
+        # Filter out exit 1 (lifecycle check failed on a clean corpus would
+        # be wrong) and unexpected codes. Both 0 (graph ignored) and 2
+        # (main() rejects the flag combination with a clear message) are
+        # acceptable architectural choices.
+        assert exc_info.value.code in (0, 2), (
+            f"Expected exit 0 (graph ignored) or exit 2 (flag-combo rejected); got {exc_info.value.code}."
+        )
+        mock_graph_class.assert_not_called()
+
+    def test_mode_lifecycle_exits_0_with_skip_message_when_file_absent(self, tmp_path, monkeypatch, capsys):
+        """
+        Test that --mode lifecycle exits 0 with a skip message when
+        lifecycle-stage.yaml is absent.
+
+        Given: A tmp cwd with no risk-map/yaml/lifecycle-stage.yaml
+        When:  validate_riskmap.main() is invoked with argv ["--mode", "lifecycle"]
+        Then:  Exits with code 0 and prints a skip message.
+
+        Disposition: this mirrors the current default-mode graceful-skip
+        behavior at validate_riskmap.py:210-212. lifecycle-stage.yaml may
+        not be present in every test environment; the dedicated mode keeps
+        the same forgiving disposition rather than promoting absence to a
+        hard error. Skip message wording uses the substring "skipped" to
+        stay format-agnostic with the existing line at 212.
+        """
+        _write_lifecycle_only(tmp_path, None)  # Omit the file
+        monkeypatch.chdir(tmp_path)
+
+        with patch("sys.argv", ["script.py", "--mode", "lifecycle"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0, (
+            f"Expected exit 0 (graceful skip) when lifecycle-stage.yaml is absent; got {exc_info.value.code}"
+        )
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "skipped" in combined.lower(), (
+            f"Expected a skip message when lifecycle-stage.yaml is absent; got: {combined!r}"
+        )
+
+    def test_default_mode_unchanged_when_mode_flag_omitted(self):
+        """
+        Test that the default code path is preserved when --mode is omitted.
+
+        Given: argv with no --mode flag and no other arguments
+        When:  parse_args() is called
+        Then:  args.mode either does not exist or has a value that does NOT
+               equal "lifecycle".
+
+        Smoke test guarding against the new flag's argparse default
+        accidentally redirecting the existing entrypoint into lifecycle mode.
+        """
+        with patch("sys.argv", ["script.py"]):
+            args = parse_args()
+
+        # SWE may name the attribute `mode` (most likely) or pick a different
+        # spelling. Either way the default value must not be "lifecycle"; the
+        # existing default code path must be reachable without setting the flag.
+        mode_value = getattr(args, "mode", None)
+        assert mode_value != "lifecycle", (
+            f"Default args.mode must not be 'lifecycle'; got {mode_value!r}. "
+            f"Existing default-mode behavior would otherwise be silently overridden."
+        )

--- a/scripts/hooks/validate_framework_references.py
+++ b/scripts/hooks/validate_framework_references.py
@@ -436,8 +436,14 @@ def validate_framework_consistency(frameworks_data: dict[str, Any]) -> list[str]
     return errors
 
 
-def validate_frameworks(file_paths: list[Path]) -> bool:
-    """Validate framework reference consistency including persona mappings."""
+def validate_frameworks(file_paths: list[Path], block_deprecated_personas: bool = False) -> bool:
+    """Validate framework reference consistency including persona mappings.
+
+    Args:
+        file_paths: Ordered list of YAML file paths: frameworks, risks, controls, personas.
+        block_deprecated_personas: When True, deprecated-persona warnings are promoted to
+            errors and cause this function to return False (exit 1 in main).
+    """
     print(f"   Validating framework references in: {', '.join(map(str, file_paths))}")
 
     # Load YAML files
@@ -524,11 +530,13 @@ def validate_frameworks(file_paths: list[Path]) -> bool:
             print(f"     - {error}")
         success = False
 
-    # Report deprecation warnings (don't fail validation)
+    # Report deprecation warnings; promote to errors when --block is active.
     if deprecation_warnings:
         print(f"   ⚠️  Found {len(deprecation_warnings)} deprecated persona usage warnings:")
         for warning in deprecation_warnings:
             print(f"     - {warning}")
+        if block_deprecated_personas:
+            success = False
 
     if success:
         print("  ✅ Framework references and applicability are consistent")
@@ -561,6 +569,12 @@ Examples:
         action="store_true",
         help="Force validation of framework references even if not staged",
     )
+    parser.add_argument(
+        "--block",
+        action="store_true",
+        default=False,
+        help="Promote deprecated-persona warnings to errors and exit 1.",
+    )
     return parser.parse_args()
 
 
@@ -583,7 +597,7 @@ def main() -> None:
     print("   Found staged framework-related YAML files (frameworks, risks, controls, personas)")
 
     # Validate framework references
-    if not validate_frameworks(yaml_files):
+    if not validate_frameworks(yaml_files, block_deprecated_personas=args.block):
         print("   ❌ Framework reference validation failed!")
         print("   Fix the above errors before committing.")
         sys.exit(1)

--- a/scripts/hooks/validate_riskmap.py
+++ b/scripts/hooks/validate_riskmap.py
@@ -26,6 +26,8 @@ import argparse
 import sys
 from pathlib import Path
 
+import yaml
+
 # Configuration Constants
 from riskmap_validator.config import DEFAULT_COMPONENTS_FILE
 from riskmap_validator.graphing import ComponentGraph, ControlGraph, RiskGraph
@@ -189,10 +191,8 @@ def main() -> None:
         if validator.components:
             if lifecycle_path.exists():
                 try:
-                    import yaml as _yaml  # already installed; local import keeps top-level imports minimal
-
                     with open(lifecycle_path, encoding="utf-8") as _fh:
-                        _lifecycle_data = _yaml.safe_load(_fh)
+                        _lifecycle_data = yaml.safe_load(_fh)
                     lifecycle_result = check_lifecycle_stage_order_uniqueness(_lifecycle_data)
                     if lifecycle_result.is_valid:
                         if not args.quiet:
@@ -224,7 +224,7 @@ def main() -> None:
 
         # Track whether any warn-only check produced output that --block should
         # promote to a hard failure.
-        _warn_block_triggered = False
+        warn_block_triggered = False
 
         if controls_path.exists() and validator.components:
             # Broad except wraps both the parse and the check. Lets malformed
@@ -241,7 +241,7 @@ def main() -> None:
                     for warning in mirror_warnings:
                         print(f"     - {warning}")
                     if args.block:
-                        _warn_block_triggered = True
+                        warn_block_triggered = True
                 elif not args.quiet:
                     print("✅ Controls↔components mirror check passed")
             except SystemExit:
@@ -255,10 +255,8 @@ def main() -> None:
         # of warnings are visible before the exit decision below.
         if components_path.exists() and validator.components:
             try:
-                import yaml as _yaml  # already installed; local import keeps top-level imports minimal
-
                 with open(components_path, encoding="utf-8") as _fh:
-                    _components_data = _yaml.safe_load(_fh)
+                    _components_data = yaml.safe_load(_fh)
                 category_to_subcategories: dict[str, set[str]] = {}
                 for _cat in _components_data.get("categories", []):
                     _cat_id = _cat.get("id")
@@ -276,7 +274,7 @@ def main() -> None:
                     for warning in nesting_warnings:
                         print(f"     - {warning}")
                     if args.block:
-                        _warn_block_triggered = True
+                        warn_block_triggered = True
                 elif not args.quiet:
                     print("✅ Category/subcategory nesting check passed")
             except SystemExit:
@@ -286,7 +284,7 @@ def main() -> None:
                     print(f"   ⚠️  Category/subcategory nesting check skipped: {e}")
 
         # Unified exit for warn-only checks — fires after both checks have printed.
-        if _warn_block_triggered:
+        if warn_block_triggered:
             print("   ❌ Warn-only check failures promoted to errors (--block).")
             sys.exit(1)
 

--- a/scripts/hooks/validate_riskmap.py
+++ b/scripts/hooks/validate_riskmap.py
@@ -16,6 +16,7 @@ Options:
     --force             Force validation regardless of git status
     --file PATH         Custom YAML file path
     --allow-isolated    Allow components with no edges
+    --block             Promote warn-only check warnings to errors and exit 1
     --quiet, -q         Minimal output
     --debug             Include debug annotations in graphs
     --mermaid-format    Save additional .mermaid format files
@@ -33,6 +34,7 @@ from riskmap_validator.validator import (
     ComponentEdgeValidator,
     check_category_subcategory_nesting,
     check_controls_components_mirror,
+    check_lifecycle_stage_order_uniqueness,
 )
 
 
@@ -176,6 +178,38 @@ def main() -> None:
 
         if not args.quiet:
             print("✅ All YAML files passed component edge validation")
+
+        # Lifecycle stage order uniqueness check (ADR-022 D4).
+        # Block-mode-immediate: no --block flag required. If the file is absent,
+        # skip gracefully — lifecycle-stage.yaml may not be present in all test cwds.
+        # Guard on validator.components mirrors the mirror/nesting check pattern:
+        # only run when a real component validation pass populated the validator,
+        # avoiding spurious open() calls in unit tests that mock builtins.open.
+        lifecycle_path = Path("risk-map/yaml/lifecycle-stage.yaml")
+        if validator.components:
+            if lifecycle_path.exists():
+                try:
+                    import yaml as _yaml  # already installed; local import keeps top-level imports minimal
+
+                    with open(lifecycle_path, encoding="utf-8") as _fh:
+                        _lifecycle_data = _yaml.safe_load(_fh)
+                    lifecycle_result = check_lifecycle_stage_order_uniqueness(_lifecycle_data)
+                    if lifecycle_result.is_valid:
+                        if not args.quiet:
+                            print("✅ Lifecycle stage order uniqueness check passed")
+                    else:
+                        print("❌ Lifecycle stage order uniqueness check failed:")
+                        for error in lifecycle_result.errors:
+                            print(f"     - {error}")
+                        sys.exit(1)
+                except SystemExit:
+                    raise
+                except Exception as e:
+                    if not args.quiet:
+                        print(f"   ⚠️  Lifecycle stage order uniqueness check skipped: {e}")
+            else:
+                if not args.quiet:
+                    print("   Lifecycle stage order uniqueness check skipped (lifecycle-stage.yaml not found)")
 
         # Run warn-only checks: controls↔components mirror (ADR-020 D7 / task 2.3.8)
         # and category/subcategory nesting (ADR-018 D6 / task 2.3.9).

--- a/scripts/hooks/validate_riskmap.py
+++ b/scripts/hooks/validate_riskmap.py
@@ -29,7 +29,11 @@ from pathlib import Path
 from riskmap_validator.config import DEFAULT_COMPONENTS_FILE
 from riskmap_validator.graphing import ComponentGraph, ControlGraph, RiskGraph
 from riskmap_validator.utils import get_staged_yaml_files, parse_controls_yaml, parse_risks_yaml
-from riskmap_validator.validator import ComponentEdgeValidator, check_controls_components_mirror
+from riskmap_validator.validator import (
+    ComponentEdgeValidator,
+    check_category_subcategory_nesting,
+    check_controls_components_mirror,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -173,18 +177,26 @@ def main() -> None:
         if not args.quiet:
             print("✅ All YAML files passed component edge validation")
 
-        # Run controls↔components mirror check (ADR-020 D7 / task 2.3.8).
-        # Loads controls.yaml relative to cwd; derives component_ids from the
-        # already-parsed validator.components so no second parse of components.yaml.
-        # Skip mirror check when no components are loaded — avoids a vacuous run
-        # and prevents triggering file I/O in test contexts where open() is mocked.
+        # Run warn-only checks: controls↔components mirror (ADR-020 D7 / task 2.3.8)
+        # and category/subcategory nesting (ADR-018 D6 / task 2.3.9).
+        #
+        # Both checks collect warnings independently. The exit decision is deferred
+        # until after both have run so the user sees all warnings in one pass even
+        # when --block is set.  The guard (controls_path.exists() and components
+        # loaded) stays the same as before to avoid vacuous runs and file I/O in
+        # test contexts where components are unavailable.
         controls_path = Path("risk-map/yaml/controls.yaml")
+        components_path = Path("risk-map/yaml/components.yaml")
+
+        # Track whether any warn-only check produced output that --block should
+        # promote to a hard failure.
+        _warn_block_triggered = False
+
         if controls_path.exists() and validator.components:
-            # Broad except wraps both the parse and the check; mirrors the
-            # surrounding graph-generation blocks (lines 227, 251, 278). Lets
-            # malformed controls.yaml or unexpected mock state in tests degrade
-            # to a skip rather than crashing the script. SystemExit (raised
-            # below for --block) is excluded so the block-mode exit propagates.
+            # Broad except wraps both the parse and the check. Lets malformed
+            # controls.yaml or unexpected mock state in tests degrade to a skip
+            # rather than crashing the script. SystemExit is excluded so the
+            # block-mode exit below propagates correctly.
             try:
                 controls = parse_controls_yaml(controls_path)
                 component_ids = set(validator.components.keys())
@@ -195,8 +207,7 @@ def main() -> None:
                     for warning in mirror_warnings:
                         print(f"     - {warning}")
                     if args.block:
-                        print("   ❌ Mirror check failures promoted to errors (--block).")
-                        sys.exit(1)
+                        _warn_block_triggered = True
                 elif not args.quiet:
                     print("✅ Controls↔components mirror check passed")
             except SystemExit:
@@ -204,6 +215,46 @@ def main() -> None:
             except Exception as e:
                 if not args.quiet:
                     print(f"   ⚠️  Controls↔components mirror check skipped: {e}")
+
+        # Category/subcategory nesting check (ADR-018 D6 / task 2.3.9).
+        # Runs regardless of whether the mirror check found issues so both sets
+        # of warnings are visible before the exit decision below.
+        if components_path.exists() and validator.components:
+            try:
+                import yaml as _yaml  # already installed; local import keeps top-level imports minimal
+
+                with open(components_path, encoding="utf-8") as _fh:
+                    _components_data = _yaml.safe_load(_fh)
+                category_to_subcategories: dict[str, set[str]] = {}
+                for _cat in _components_data.get("categories", []):
+                    _cat_id = _cat.get("id")
+                    if not isinstance(_cat_id, str):
+                        continue
+                    category_to_subcategories[_cat_id] = {
+                        _sub.get("id") for _sub in _cat.get("subcategory", []) if isinstance(_sub.get("id"), str)
+                    }
+                nesting_warnings = check_category_subcategory_nesting(
+                    validator.components, category_to_subcategories
+                )
+                if nesting_warnings:
+                    label = "❌" if args.block else "⚠️"
+                    print(f"   {label} Category/subcategory nesting check found {len(nesting_warnings)} issue(s):")
+                    for warning in nesting_warnings:
+                        print(f"     - {warning}")
+                    if args.block:
+                        _warn_block_triggered = True
+                elif not args.quiet:
+                    print("✅ Category/subcategory nesting check passed")
+            except SystemExit:
+                raise
+            except Exception as e:
+                if not args.quiet:
+                    print(f"   ⚠️  Category/subcategory nesting check skipped: {e}")
+
+        # Unified exit for warn-only checks — fires after both checks have printed.
+        if _warn_block_triggered:
+            print("   ❌ Warn-only check failures promoted to errors (--block).")
+            sys.exit(1)
 
         if args.to_graph:
             graph = ComponentGraph(validator.forward_map, validator.components, debug=args.debug)

--- a/scripts/hooks/validate_riskmap.py
+++ b/scripts/hooks/validate_riskmap.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from riskmap_validator.config import DEFAULT_COMPONENTS_FILE
 from riskmap_validator.graphing import ComponentGraph, ControlGraph, RiskGraph
 from riskmap_validator.utils import get_staged_yaml_files, parse_controls_yaml, parse_risks_yaml
-from riskmap_validator.validator import ComponentEdgeValidator
+from riskmap_validator.validator import ComponentEdgeValidator, check_controls_components_mirror
 
 
 def parse_args() -> argparse.Namespace:
@@ -101,6 +101,13 @@ Exit Codes:
         help="Output risk-to-control-to-component graph visualization to specified file",
     )
 
+    parser.add_argument(
+        "--block",
+        action="store_true",
+        default=False,
+        help="Promote warn-only check warnings to errors and exit 1.",
+    )
+
     parser.add_argument("--debug", action="store_true", help="Include rank comments in graph output")
 
     parser.add_argument(
@@ -165,6 +172,38 @@ def main() -> None:
 
         if not args.quiet:
             print("✅ All YAML files passed component edge validation")
+
+        # Run controls↔components mirror check (ADR-020 D7 / task 2.3.8).
+        # Loads controls.yaml relative to cwd; derives component_ids from the
+        # already-parsed validator.components so no second parse of components.yaml.
+        # Skip mirror check when no components are loaded — avoids a vacuous run
+        # and prevents triggering file I/O in test contexts where open() is mocked.
+        controls_path = Path("risk-map/yaml/controls.yaml")
+        if controls_path.exists() and validator.components:
+            # Broad except wraps both the parse and the check; mirrors the
+            # surrounding graph-generation blocks (lines 227, 251, 278). Lets
+            # malformed controls.yaml or unexpected mock state in tests degrade
+            # to a skip rather than crashing the script. SystemExit (raised
+            # below for --block) is excluded so the block-mode exit propagates.
+            try:
+                controls = parse_controls_yaml(controls_path)
+                component_ids = set(validator.components.keys())
+                mirror_warnings = check_controls_components_mirror(controls, component_ids)
+                if mirror_warnings:
+                    label = "❌" if args.block else "⚠️"
+                    print(f"   {label} Controls↔components mirror check found {len(mirror_warnings)} issue(s):")
+                    for warning in mirror_warnings:
+                        print(f"     - {warning}")
+                    if args.block:
+                        print("   ❌ Mirror check failures promoted to errors (--block).")
+                        sys.exit(1)
+                elif not args.quiet:
+                    print("✅ Controls↔components mirror check passed")
+            except SystemExit:
+                raise
+            except Exception as e:
+                if not args.quiet:
+                    print(f"   ⚠️  Controls↔components mirror check skipped: {e}")
 
         if args.to_graph:
             graph = ComponentGraph(validator.forward_map, validator.components, debug=args.debug)

--- a/scripts/hooks/validate_riskmap.py
+++ b/scripts/hooks/validate_riskmap.py
@@ -125,7 +125,59 @@ Exit Codes:
         help="Save graphs in '.mermaid' format in addition to markdown code block",
     )
 
+    parser.add_argument(
+        "--mode",
+        choices=["default", "lifecycle"],
+        default="default",
+        help=(
+            "Run a specific check mode. 'lifecycle': run only the lifecycle-stage.yaml "
+            "order-uniqueness check (used by validate-lifecycle-stage pre-commit hook). "
+            "'default': run the full component-edges + warn-only check pipeline."
+        ),
+    )
+
     return parser.parse_args()
+
+
+def _run_lifecycle_mode(args: argparse.Namespace) -> int:
+    """
+    Run the dedicated lifecycle-stage order-uniqueness short-circuit.
+
+    Loads risk-map/yaml/lifecycle-stage.yaml and runs only the uniqueness
+    check. Bypasses ComponentEdgeValidator, get_staged_yaml_files, and
+    graph generation. Returns the exit code for sys.exit().
+    """
+    lifecycle_path = Path("risk-map/yaml/lifecycle-stage.yaml")
+    if not lifecycle_path.exists():
+        # Mirror default-mode graceful skip when the file is absent.
+        if not args.quiet:
+            print("   Lifecycle stage order uniqueness check skipped (lifecycle-stage.yaml not found)")
+        return 0
+
+    # Broad except mirrors the default-mode skip pattern: malformed YAML
+    # or unexpected I/O state degrades to a skip rather than crashing
+    # the dedicated hook. SystemExit is excluded so explicit exits below
+    # propagate.
+    try:
+        with open(lifecycle_path, encoding="utf-8") as fh:
+            lifecycle_data = yaml.safe_load(fh)
+        result = check_lifecycle_stage_order_uniqueness(lifecycle_data)
+    except SystemExit:
+        raise
+    except Exception as e:
+        if not args.quiet:
+            print(f"   ⚠️  Lifecycle stage order uniqueness check skipped: {e}")
+        return 0
+
+    if result.is_valid:
+        if not args.quiet:
+            print("✅ Lifecycle stage order uniqueness check passed")
+        return 0
+
+    print("❌ Lifecycle stage order uniqueness check failed:")
+    for error in result.errors:
+        print(f"     - {error}")
+    return 1
 
 
 def main() -> None:
@@ -136,6 +188,13 @@ def main() -> None:
     """
     try:
         args = parse_args()
+
+        # Lifecycle mode short-circuits before ComponentEdgeValidator and
+        # get_staged_yaml_files so a lifecycle-only commit (validate-lifecycle-stage
+        # pre-commit hook) is reachable without depending on components.yaml state.
+        # Graph flags (--to-graph etc.) are silently ignored in this mode.
+        if args.mode == "lifecycle":
+            sys.exit(_run_lifecycle_mode(args))
 
         # Initialize validator
         validator = ComponentEdgeValidator(allow_isolated=args.allow_isolated, verbose=not args.quiet)


### PR DESCRIPTION
## Conformance sweep A4: validator extensions (6 ADR-driven checks)

Closes #268

## Summary

- **6 ADR-driven validator/linter extensions** spanning `scripts/hooks/riskmap_validator/validator.py`, `scripts/hooks/riskmap_validator/graphing/graph_utils.py`, `scripts/hooks/precommit/_prose_tokens.py`, `scripts/hooks/precommit/validate_yaml_prose_subset.py`, `scripts/hooks/validate_framework_references.py`, and `scripts/hooks/validate_riskmap.py`.
- **Mode breakdown** (corrected against live-corpus inspection 2026-05-04):
  - **1 block-mode-immediately** (current corpus already passes): 2.3.7 lifecycle-order uniqueness
  - **4 warn-only-first with `--block` toggle** (current corpus has content debt; flips at sweep-closing commit per plan § 2.7.1): 2.3.5 folded-bullet drift live-corpus pinning, 2.3.6 deprecated-persona reference toggle, 2.3.8 controls↔components mirror, 2.3.9 category/subcategory nesting
  - **1 runtime warning** (operator-visible during generator runs; not a CI gate): 2.3.10 `MermaidConfigLoader` missing-category warning
- **Hybrid scope on 2.3.5** — A3 (PR #262) already shipped the folded-bullet detection heuristic in `_prose_tokens.py`. A4's contribution narrowed to (a) live-corpus regression pinning so issue #225 cases stay caught after future tokenizer edits; (b) augmented `INVALID_LIST` diagnostic message cross-referencing ADR-020 D4 + issue #225 so authors aim the right fix; (c) source/parsed-form documentation in the heuristic docstring. 
- **Live corpus debt surfaced by warn-only-first checks** (verified 2026-05-04; tracked separately for Phase B disposition):
  - 88 deprecated-persona refs (49 controls + 39 risks)
  - 2 dangling control→component refs (`componentInputHandling`/`componentOutputHandling` — likely typos for `componentApplication{Input,Output}Handling`)
  - 7 components missing `subcategory` field
- **Unified `--block` toggle** on `riskmap_validator/validator.py` covers tasks 2.3.8 + 2.3.9 via a shared `_warn_block_triggered` boolean — all warnings print before exit. One flip-point at § 2.7.1, not two.
- **9 commits, 14 files, +3955 / -11**; full hook suite 2268+ passed / 6 skipped / 0 failed; pre-commit clean; code-reviewer APPROVED post-review fix; opportunistic L7+L2+L5 absorption in commit 9 keeps A4-introduced duplication local rather than passing it forward. Branch rebased on `e01f684` 2026-05-07.

## Commit-by-commit

| # | SHA | Subject | Role |
|---|---|---|---|
| 1 | `c6d0025` | `feat(validator): add lifecycleStage.order uniqueness check (ADR-022 D4)` | SWE — 2.3.7 (block-mode-immediately) |
| 2 | `9d3cc14` | `feat(precommit): add --block toggle to deprecated-persona check (ADR-021 D8)` | SWE — 2.3.6 (extends existing `check_deprecated_persona_usage()` at `validate_framework_references.py`) |
| 3 | `2c72add` | `feat(validator): add controls↔components mirror check (ADR-020 D7)` | SWE — 2.3.8 |
| 4 | `c55dcf1` | `feat(validator): add category/subcategory nesting check (ADR-018 D6)` | SWE — 2.3.9 |
| 5 | `5828102` | `test(precommit): pin folded-bullet drift live-corpus regression (ADR-020 D4)` | testing/SWE — 2.3.5 hybrid (live-corpus pinning + diagnostic-message cross-reference + docstring) |
| 6 | `a9d7f2b` | `feat(validator): add MermaidConfigLoader missing-category warning (ADR-022 D6a)` | SWE — 2.3.10 (greenfield; path-corrected from `graphing/base.py` to `graphing/graph_utils.py:9`) |
| 7 | `4bc7003` | `chore(tests): scrub stale red-phase language from A4 test docstrings` | tests — phasing-language scrub |
| 8 | `069c3a4` | `feat(validator): wire lifecycle-uniqueness + missing-category warnings (A4 follow-up)` | SWE — AI reviewer required fixes (M1 + M2 + M3 + L1 + L3 in one consolidation commit) |
| 9 | `2e998bb` | `chore(tests): lift mirror+nesting helpers; tighten validate_riskmap imports` | SWE — opportunistic absorption of L7 (mirror+nesting helpers only — lifecycle helpers stay file-local because the signatures genuinely diverge: 4-file corpus vs 3-file corpus, no extra-args support) + L2 + L5. Decision-bound judgment call; conftest comment documents the divergence. |

## Out of scope (deferred):
- **Content cleanup of the 88 deprecated-persona refs** → tracked at `gh-drafts/draft-content-debt-from-a4-validators-issue.md` for Phase B planning per Option C of the 2026-05-04 audit. The legacy-persona-removal class is also out-of-Phase-2 by ADR-021's design (sequenced strictly after `self-assessment.yaml` archive lands).
- **Content cleanup of the 2 dangling control→component refs + 7 missing subcategories** → same content-debt tracker
- **Block-mode flip on the 4 warn-only-first checks** → sweep-closing sub-PR (plan § 2.7.1)
- **Schema clarification on `subcategory` optionality** → architect call at Phase B planning time (either content-fill the 7 components or schema-relax the validator)

## Test plan

- [x] `pytest scripts/hooks/tests` clean (2268 passed / 6 skipped)
- [x] `ruff check` + `ruff format --check` clean
- [x] `pre-commit run --all-files` clean — warn-only diagnostics from A4's 4 toggles surface live-corpus debt as expected; no new errors
- [x] Manual `--block` exercise on each toggle exits non-zero with clear diagnostics
- [x] Code-reviewer APPROVED
- [ ] Reviewer spot-check — block-mode flip rehearsal will follow at the sweep-closing commit (plan § 2.7.1)
