### PR TITLE
feat(precommit): codify trigger-vs-read-set invariant (#279)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -208,7 +208,7 @@ repos:
         name: 'risk-map: component edge consistency'
         language: system
         entry: python3 scripts/hooks/validate_riskmap.py
-        files: ^risk-map/yaml/components\.yaml$
+        files: ^risk-map/yaml/(components|controls|risks)\.yaml$
         pass_filenames: false
 
       - id: validate-control-risk-references

--- a/docs/adr/005-pre-commit-framework.md
+++ b/docs/adr/005-pre-commit-framework.md
@@ -109,7 +109,7 @@ For every local validator hook in [`.pre-commit-config.yaml`](../../.pre-commit-
 Three sets, defined per hook:
 
 - **Trigger set** — the file paths the framework matches against staged files (the hook's `files:` regex) to decide whether to invoke the hook.
-- **Read set** — the file paths the validator opens on disk during a run (its `target_files` discovery surface plus any direct opens).
+- **Read/discovery set** — the fixed file paths the validator treats as in scope during a run, including `target_files` staged-file discovery surfaces and direct file opens. This can be broader than the files literally parsed on the default hook path when a validator preserves a legacy discovery surface.
 - **Check-input set** — for each declared check inside the validator, the file paths whose contents could change the check's verdict.
 
 Hooks declared with `pass_filenames: true` couple their trigger to their scope by construction — the framework hands the validator the matched file list and the validator works on exactly that input — so the invariant primarily targets `pass_filenames: false` hooks, where trigger and read-set are independent declarations that can drift apart silently.
@@ -126,13 +126,13 @@ Refining the invariant for these classes is deferred to a separate decision.
 
 ### Enforcement
 
-The structural test at [`scripts/hooks/tests/test_precommit_hook_install.py`](../../scripts/hooks/tests/test_precommit_hook_install.py) enforces the invariant for every in-scope local validator hook. Each new hook registers its read set in a metadata table keyed by hook id (architect-recommended over parsing validator internals), so the next hook author has one declared place to record what their validator actually reads. A test failure names the hook id, the missing path, and points back to this addendum.
+The structural test at [`scripts/hooks/tests/test_precommit_hook_install.py`](../../scripts/hooks/tests/test_precommit_hook_install.py) enforces the invariant for every in-scope local validator hook. Each new hook registers its fixed trigger coverage set in a metadata table keyed by hook id (architect-recommended over parsing validator internals), so the next hook author has one declared place to record the paths that must cause the hook to run. A test failure names the hook id, the missing path, and points back to this addendum.
 
 ### Motivating regressions
 
 Two trigger-vs-read-set gaps inherited from the bash-to-framework migration ([#211](https://github.com/cosai-oasis/secure-ai-tooling/pull/211) / [#222](https://github.com/cosai-oasis/secure-ai-tooling/pull/222)) surfaced in review of [PR #277](https://github.com/cosai-oasis/secure-ai-tooling/pull/277):
 
-- **`validate-component-edges`** — trigger filtered on `components.yaml` only, but the validator's read set already covered `controls.yaml` and `risks.yaml`. Controls-only or risks-only commits skipped the validator entirely.
-- **`validate-lifecycle-stage`** — `lifecycle-stage.yaml` was outside both the trigger and the read set pre-A4. Resolved within PR #277 itself by introducing a dedicated hook with a narrow trigger and a `--mode lifecycle` short-circuit on `validate_riskmap.py`.
+- **`validate-component-edges`** — trigger filtered on `components.yaml` only, but the validator's staged-file discovery surface already covered `controls.yaml` and `risks.yaml`; the default check path also parses `controls.yaml` for the controls↔components mirror check. Controls-only or risks-only commits skipped the validator entirely.
+- **`validate-lifecycle-stage`** — `lifecycle-stage.yaml` was outside both the trigger and the read/discovery set pre-A4. Resolved within PR #277 itself by introducing a dedicated hook with a narrow trigger and a `--mode lifecycle` short-circuit on `validate_riskmap.py`. The remaining default-mode lifecycle belt-and-suspenders check inside `validate_riskmap.py` is deliberately covered by that dedicated hook's contract, not by `validate-component-edges`.
 
 Both are documented in [#279](https://github.com/cosai-oasis/secure-ai-tooling/issues/279). The invariant exists to make the same class of regression a structural-test failure rather than a reviewer catch.

--- a/docs/adr/005-pre-commit-framework.md
+++ b/docs/adr/005-pre-commit-framework.md
@@ -104,7 +104,7 @@ Authored 2026-05-08; accepted alongside the implementation of [#279](https://git
 
 For every local validator hook in [`.pre-commit-config.yaml`](../../.pre-commit-config.yaml) with `pass_filenames: false`:
 
-> **trigger-set ⊇ check-input-set, AND read-set ⊇ check-input-set.**
+> **trigger-set ⊇ check-input-set, AND read/discovery-set ⊇ check-input-set.**
 
 Three sets, defined per hook:
 

--- a/docs/adr/005-pre-commit-framework.md
+++ b/docs/adr/005-pre-commit-framework.md
@@ -95,3 +95,44 @@ Operational properties worth pinning:
 - Revisit `pre-commit autoupdate` cadence. Pinned revisions in `.pre-commit-config.yaml` (`check-jsonschema` 0.37.1, `ruff-pre-commit` v0.15.10 at time of writing) are good hygiene but need periodic bumps; Dependabot does not currently track them.
 - If the repository adds a non-Python orchestration surface in the future (for example, a site build under `risk-map/site/`), confirm that `pre-commit` remains the right orchestration layer for that surface or document the split explicitly.
 - Consider adding a CI job that validates every PR as a belt-and-braces over local hook execution. The choice of command is tactical: `pre-commit run --all-files` followed by `git diff --exit-code` catches both validator failures and any generator-driven drift; `./scripts/tools/validate-all.sh` is pure inspection and avoids generator invocation in CI. Contributors can skip hooks locally with `--no-verify`; a CI gate closes that escape hatch without forcing the parity harness back into the commit path.
+
+## Addendum 2026-05-08: Hook trigger-vs-read-set invariant
+
+Authored 2026-05-08; accepted alongside the implementation of [#279](https://github.com/cosai-oasis/secure-ai-tooling/issues/279). This addendum extends the original Decision; it does not reset the ADR's status.
+
+### Invariant
+
+For every local validator hook in [`.pre-commit-config.yaml`](../../.pre-commit-config.yaml) with `pass_filenames: false`:
+
+> **trigger-set ⊇ check-input-set, AND read-set ⊇ check-input-set.**
+
+Three sets, defined per hook:
+
+- **Trigger set** — the file paths the framework matches against staged files (the hook's `files:` regex) to decide whether to invoke the hook.
+- **Read set** — the file paths the validator opens on disk during a run (its `target_files` discovery surface plus any direct opens).
+- **Check-input set** — for each declared check inside the validator, the file paths whose contents could change the check's verdict.
+
+Hooks declared with `pass_filenames: true` couple their trigger to their scope by construction — the framework hands the validator the matched file list and the validator works on exactly that input — so the invariant primarily targets `pass_filenames: false` hooks, where trigger and read-set are independent declarations that can drift apart silently.
+
+### Scope carve-outs
+
+Three hook classes are explicitly out of scope for this invariant in its current form:
+
+- **Generators** (`regenerate-graphs`, `regenerate-tables`, `regenerate-svgs`, `regenerate-issue-templates`) — side-effectful by design, with read sets spanning multiple source YAMLs and write sets in `risk-map/diagrams/`, `risk-map/tables/`, `risk-map/svg/`, and `.github/ISSUE_TEMPLATE/`. The invariant's check-input semantics need refinement before they apply to side-effect hooks.
+- **Master-schema fan-out** (`validate-all-yaml-on-master-schema-change`) — the hook's purpose is to widen scope post-trigger (a single schema edit fans out to validate every YAML); applying a trigger-superset rule would defeat its design.
+- **Runtime-discovered read sets** (`validate-issue-templates`) — hooks whose read set is the staged-file query result rather than a fixed list of path constants. The trigger covers the directory roots the query may return, but the actual read set per run is determined by `git diff --cached` and cannot be declared up front. Mechanical enforcement of trigger ⊇ read-set requires a different formulation for this class.
+
+Refining the invariant for these classes is deferred to a separate decision.
+
+### Enforcement
+
+The structural test at [`scripts/hooks/tests/test_precommit_hook_install.py`](../../scripts/hooks/tests/test_precommit_hook_install.py) enforces the invariant for every in-scope local validator hook. Each new hook registers its read set in a metadata table keyed by hook id (architect-recommended over parsing validator internals), so the next hook author has one declared place to record what their validator actually reads. A test failure names the hook id, the missing path, and points back to this addendum.
+
+### Motivating regressions
+
+Two trigger-vs-read-set gaps inherited from the bash-to-framework migration ([#211](https://github.com/cosai-oasis/secure-ai-tooling/pull/211) / [#222](https://github.com/cosai-oasis/secure-ai-tooling/pull/222)) surfaced in review of [PR #277](https://github.com/cosai-oasis/secure-ai-tooling/pull/277):
+
+- **`validate-component-edges`** — trigger filtered on `components.yaml` only, but the validator's read set already covered `controls.yaml` and `risks.yaml`. Controls-only or risks-only commits skipped the validator entirely.
+- **`validate-lifecycle-stage`** — `lifecycle-stage.yaml` was outside both the trigger and the read set pre-A4. Resolved within PR #277 itself by introducing a dedicated hook with a narrow trigger and a `--mode lifecycle` short-circuit on `validate_riskmap.py`.
+
+Both are documented in [#279](https://github.com/cosai-oasis/secure-ai-tooling/issues/279). The invariant exists to make the same class of regression a structural-test failure rather than a reviewer catch.

--- a/scripts/hooks/tests/test_precommit_hook_install.py
+++ b/scripts/hooks/tests/test_precommit_hook_install.py
@@ -213,12 +213,101 @@ class TestValidatorHookContracts:
     """Local validator hooks shell out to the existing validators with no argv."""
 
     def test_validate_component_edges_targets_components_yaml(self):
+        """
+        Test that validate-component-edges matches components.yaml (preserved behavior).
+
+        Given: the validate-component-edges hook in .pre-commit-config.yaml
+        When:  applying the hook's files: regex against risk-map/yaml/components.yaml
+        Then:  the regex matches (re.search semantics, mirroring the pre-commit framework)
+
+        This is the baseline assertion that must hold both before and after
+        the trigger widening introduced by issue #279 / PR #277 follow-up.
+        """
         hooks = _hooks_by_id("validate-component-edges")
         assert len(hooks) == 1, "Exactly one component-edge validator hook expected"
         hook = hooks[0]
         assert "validate_riskmap.py" in hook.get("entry", "")
-        assert "components" in hook.get("files", "")
         assert hook.get("pass_filenames") is False
+        files_regex = hook.get("files", "")
+        assert re.search(files_regex, "risk-map/yaml/components.yaml"), (
+            f"validate-component-edges files regex must match risk-map/yaml/components.yaml; got: {files_regex!r}"
+        )
+
+    def test_validate_component_edges_matches_controls_yaml(self):
+        """
+        Test that validate-component-edges matches controls.yaml (new behavior, issue #279).
+
+        Given: the validate-component-edges hook after trigger widening
+        When:  applying the hook's files: regex against risk-map/yaml/controls.yaml
+        Then:  the regex matches
+
+        The validate_riskmap.py validator reads controls.yaml as part of its
+        get_staged_yaml_files() target_files constant (utils.py:221-225). A
+        controls-only commit must trigger the hook so the validator's full
+        check suite (including A4 controls-components mirror and nesting checks)
+        runs. Without this match, a controls-only commit silently skips all
+        component-edge consistency checks.
+
+        RED-PHASE: this test fails on the current config (files: targets
+        components.yaml only) and passes once the trigger is widened per #279.
+        """
+        hooks = _hooks_by_id("validate-component-edges")
+        assert len(hooks) == 1, "Exactly one component-edge validator hook expected"
+        files_regex = hooks[0].get("files", "")
+        assert re.search(files_regex, "risk-map/yaml/controls.yaml"), (
+            f"validate-component-edges files regex must match "
+            f"risk-map/yaml/controls.yaml (issue #279: trigger must cover the "
+            f"full validator read set); got: {files_regex!r}. "
+            f"Expected: ^risk-map/yaml/(components|controls|risks)\\.yaml$"
+        )
+
+    def test_validate_component_edges_matches_risks_yaml(self):
+        """
+        Test that validate-component-edges matches risks.yaml (new behavior, issue #279).
+
+        Given: the validate-component-edges hook after trigger widening
+        When:  applying the hook's files: regex against risk-map/yaml/risks.yaml
+        Then:  the regex matches
+
+        The validate_riskmap.py validator reads risks.yaml as part of its
+        get_staged_yaml_files() target_files constant (utils.py:221-225). A
+        risks-only commit must trigger the hook for the same reason as
+        controls-only commits.
+
+        RED-PHASE: this test fails on the current config and passes once the
+        trigger is widened per issue #279.
+        """
+        hooks = _hooks_by_id("validate-component-edges")
+        assert len(hooks) == 1, "Exactly one component-edge validator hook expected"
+        files_regex = hooks[0].get("files", "")
+        assert re.search(files_regex, "risk-map/yaml/risks.yaml"), (
+            f"validate-component-edges files regex must match "
+            f"risk-map/yaml/risks.yaml (issue #279: trigger must cover the "
+            f"full validator read set); got: {files_regex!r}. "
+            f"Expected: ^risk-map/yaml/(components|controls|risks)\\.yaml$"
+        )
+
+    def test_validate_component_edges_does_not_match_personas_yaml(self):
+        """
+        Test that validate-component-edges does NOT match personas.yaml (over-match guard).
+
+        Given: the validate-component-edges hook after trigger widening
+        When:  applying the hook's files: regex against risk-map/yaml/personas.yaml
+        Then:  the regex does NOT match
+
+        personas.yaml is not in the validator's read set and must not be added
+        to the trigger to avoid running expensive validation on persona-only
+        commits. This is an over-matching guard to ensure the widening is
+        precisely scoped.
+        """
+        hooks = _hooks_by_id("validate-component-edges")
+        assert len(hooks) == 1, "Exactly one component-edge validator hook expected"
+        files_regex = hooks[0].get("files", "")
+        assert not re.search(files_regex, "risk-map/yaml/personas.yaml"), (
+            f"validate-component-edges files regex must NOT match "
+            f"risk-map/yaml/personas.yaml (personas.yaml is not in the "
+            f"validator read set); got: {files_regex!r}"
+        )
 
     def test_validate_control_risk_targets_controls_and_risks(self):
         hooks = _hooks_by_id("validate-control-risk-references")
@@ -342,6 +431,398 @@ class TestValidatorHookContracts:
         assert ".github/workflows" in files
         assert "yml" in files
         assert hook.get("pass_filenames") is True
+
+
+# ===========================================================================
+# Persona-site-build hook contracts (Task 2 — regression-lock)
+# ===========================================================================
+
+
+class TestPersonaSiteBuildHookContracts:
+    """
+    Regression-lock tests for the validate-persona-site-build hook.
+
+    The trigger was correct from initial commit 93cc22b — controls.yaml was
+    already included. These tests lock in that correctness so a future edit
+    to the files: regex cannot silently drop controls.yaml.
+
+    All tests in this class should PASS on the current config (green from day
+    one). They are regression guards, not red-phase TDD tests.
+    """
+
+    def test_validate_persona_site_build_hook_exists_exactly_once(self):
+        """
+        Test that exactly one validate-persona-site-build hook is declared.
+
+        Given: .pre-commit-config.yaml
+        When:  searching for hooks with id `validate-persona-site-build`
+        Then:  exactly one hook is found
+        """
+        hooks = _hooks_by_id("validate-persona-site-build")
+        assert len(hooks) == 1, f"Exactly one validate-persona-site-build hook expected; got {len(hooks)}"
+
+    def test_validate_persona_site_build_references_validator_script(self):
+        """
+        Test that the hook entry points at validate_persona_site_build.py.
+
+        Given: the validate-persona-site-build hook
+        When:  inspecting the entry: field
+        Then:  the entry contains `validate_persona_site_build.py`
+        """
+        hook = _hooks_by_id("validate-persona-site-build")[0]
+        assert "validate_persona_site_build.py" in hook.get("entry", ""), (
+            f"validate-persona-site-build entry must reference "
+            f"validate_persona_site_build.py; got: {hook.get('entry')!r}"
+        )
+
+    def test_validate_persona_site_build_pass_filenames_is_false(self):
+        """
+        Test that the hook sets pass_filenames: false.
+
+        Given: the validate-persona-site-build hook
+        When:  inspecting pass_filenames
+        Then:  the value is False
+
+        The validator ignores argv (it discards sys.argv) and runs the full
+        builder pipeline against a temp directory; passing filenames would be
+        redundant and risks multiple parallel invocations via framework batching.
+        """
+        hook = _hooks_by_id("validate-persona-site-build")[0]
+        assert hook.get("pass_filenames") is False, (
+            f"validate-persona-site-build must set pass_filenames: false; got: {hook.get('pass_filenames')!r}"
+        )
+
+    def test_validate_persona_site_build_matches_personas_yaml(self):
+        """
+        Test that the hook's files: regex matches personas.yaml.
+
+        Given: the validate-persona-site-build hook
+        When:  applying the files: regex against risk-map/yaml/personas.yaml
+        Then:  the regex matches
+
+        personas.yaml is a primary input to build_persona_site_data.py
+        (DEFAULT_PERSONAS_PATH). A personas-only commit must trigger the hook.
+        """
+        hook = _hooks_by_id("validate-persona-site-build")[0]
+        files_regex = hook.get("files", "")
+        assert re.search(files_regex, "risk-map/yaml/personas.yaml"), (
+            f"validate-persona-site-build files regex must match risk-map/yaml/personas.yaml; got: {files_regex!r}"
+        )
+
+    def test_validate_persona_site_build_matches_risks_yaml(self):
+        """
+        Test that the hook's files: regex matches risks.yaml.
+
+        Given: the validate-persona-site-build hook
+        When:  applying the files: regex against risk-map/yaml/risks.yaml
+        Then:  the regex matches
+
+        risks.yaml is read via DEFAULT_RISKS_PATH in build_persona_site_data.py.
+        """
+        hook = _hooks_by_id("validate-persona-site-build")[0]
+        files_regex = hook.get("files", "")
+        assert re.search(files_regex, "risk-map/yaml/risks.yaml"), (
+            f"validate-persona-site-build files regex must match risk-map/yaml/risks.yaml; got: {files_regex!r}"
+        )
+
+    def test_validate_persona_site_build_matches_controls_yaml(self):
+        """
+        Test that the hook's files: regex matches controls.yaml (regression lock).
+
+        Given: the validate-persona-site-build hook
+        When:  applying the files: regex against risk-map/yaml/controls.yaml
+        Then:  the regex matches
+
+        controls.yaml is read via DEFAULT_CONTROLS_PATH in build_persona_site_data.py
+        (validate_persona_site_build.py:41 calls builder.load_yaml(builder.DEFAULT_CONTROLS_PATH)).
+        A controls-only commit must trigger the persona-site build re-run.
+
+        This test locks in the correct trigger that was present from commit
+        93cc22b. It was NOT in an earlier draft of the files: regex and was
+        surfaced as a gap during the PR #277 review. The regression lock
+        prevents this from being silently dropped by a future regex edit.
+        """
+        hook = _hooks_by_id("validate-persona-site-build")[0]
+        files_regex = hook.get("files", "")
+        assert re.search(files_regex, "risk-map/yaml/controls.yaml"), (
+            f"validate-persona-site-build files regex must match "
+            f"risk-map/yaml/controls.yaml (controls.yaml is in the builder "
+            f"read set via DEFAULT_CONTROLS_PATH); got: {files_regex!r}"
+        )
+
+    def test_validate_persona_site_build_matches_risks_schema(self):
+        """
+        Test that the hook's files: regex matches the risks schema file.
+
+        Given: the validate-persona-site-build hook
+        When:  applying the files: regex against risk-map/schemas/risks.schema.json
+        Then:  the regex matches
+        """
+        hook = _hooks_by_id("validate-persona-site-build")[0]
+        files_regex = hook.get("files", "")
+        assert re.search(files_regex, "risk-map/schemas/risks.schema.json"), (
+            f"validate-persona-site-build files regex must match "
+            f"risk-map/schemas/risks.schema.json; got: {files_regex!r}"
+        )
+
+    def test_validate_persona_site_build_matches_persona_site_data_schema(self):
+        """
+        Test that the hook's files: regex matches the persona-site-data schema file.
+
+        Given: the validate-persona-site-build hook
+        When:  applying the files: regex against risk-map/schemas/persona-site-data.schema.json
+        Then:  the regex matches
+        """
+        hook = _hooks_by_id("validate-persona-site-build")[0]
+        files_regex = hook.get("files", "")
+        assert re.search(files_regex, "risk-map/schemas/persona-site-data.schema.json"), (
+            f"validate-persona-site-build files regex must match "
+            f"risk-map/schemas/persona-site-data.schema.json; got: {files_regex!r}"
+        )
+
+    def test_validate_persona_site_build_matches_builder_script(self):
+        """
+        Test that the hook's files: regex matches scripts/build_persona_site_data.py.
+
+        Given: the validate-persona-site-build hook
+        When:  applying the files: regex against scripts/build_persona_site_data.py
+        Then:  the regex matches
+
+        Changes to the builder itself must re-run the validation even when no
+        YAML file changes.
+        """
+        hook = _hooks_by_id("validate-persona-site-build")[0]
+        files_regex = hook.get("files", "")
+        assert re.search(files_regex, "scripts/build_persona_site_data.py"), (
+            f"validate-persona-site-build files regex must match "
+            f"scripts/build_persona_site_data.py; got: {files_regex!r}"
+        )
+
+    def test_validate_persona_site_build_does_not_match_components_yaml(self):
+        """
+        Test that the hook's files: regex does NOT match components.yaml.
+
+        Given: the validate-persona-site-build hook
+        When:  applying the files: regex against risk-map/yaml/components.yaml
+        Then:  the regex does NOT match
+
+        components.yaml is not in the builder's read set. Matching it would
+        cause unnecessary persona-site build re-runs on component-only commits.
+        This is an over-matching guard to keep the trigger precisely scoped.
+        """
+        hook = _hooks_by_id("validate-persona-site-build")[0]
+        files_regex = hook.get("files", "")
+        assert not re.search(files_regex, "risk-map/yaml/components.yaml"), (
+            f"validate-persona-site-build files regex must NOT match "
+            f"risk-map/yaml/components.yaml (not in builder read set); "
+            f"got: {files_regex!r}"
+        )
+
+
+# ===========================================================================
+# Trigger ⊇ read-set invariant (Task 4 — structural enforcement, issue #279)
+# ===========================================================================
+
+# Mapping: hook id -> read set (paths the validator opens during a run, as
+# repo-relative strings without leading slash).
+#
+# When adding a new local validator hook with pass_filenames: false, register
+# its read set here. The structural test below asserts that the hook's files:
+# regex matches every path in this set. Trigger ⊇ read-set is the invariant
+# codified in ADR-005 § Addendum 2026-05-08: Hook trigger-vs-read-set invariant
+# (issue #279, PR #277 follow-up).
+#
+# Use None as the sentinel value for hooks that are exempt from the invariant:
+#   - Fan-out / generator hooks that read a variable or glob-determined set
+#     of files (e.g., validate-all-yaml-on-master-schema-change discovers
+#     all yaml/schema pairs at runtime).
+#   - Hooks whose "read set" is determined by the staged files list at runtime
+#     rather than a fixed set of paths (e.g., validate-issue-templates reads
+#     whichever .github/ISSUE_TEMPLATE/*.yml files are staged).
+#   - Hooks that do not have pass_filenames: false (not in scope; trigger-to-
+#     scope coupling is implicit for pass_filenames: true hooks).
+#
+# Every local hook with pass_filenames: false MUST be registered here.
+# Failure to register causes TestTriggerReadSetInvariant to fail with a
+# clear diagnostic naming the unregistered hook id.
+_LOCAL_VALIDATOR_READ_SETS: dict[str, set[str] | None] = {
+    # validate-component-edges: validator opens all three YAMLs in every run
+    # via get_staged_yaml_files() target_files constant (utils.py:221-225).
+    "validate-component-edges": {
+        "risk-map/yaml/components.yaml",
+        "risk-map/yaml/controls.yaml",
+        "risk-map/yaml/risks.yaml",
+    },
+    # validate-control-risk-references: reads both YAMLs every run
+    # (validate_control_risk_references.py:25-28).
+    "validate-control-risk-references": {
+        "risk-map/yaml/controls.yaml",
+        "risk-map/yaml/risks.yaml",
+    },
+    # validate-framework-references: reads all four YAMLs every run
+    # (validate_framework_references.py:28-33).
+    "validate-framework-references": {
+        "risk-map/yaml/controls.yaml",
+        "risk-map/yaml/frameworks.yaml",
+        "risk-map/yaml/personas.yaml",
+        "risk-map/yaml/risks.yaml",
+    },
+    # validate-lifecycle-stage: reads only lifecycle-stage.yaml via a fixed
+    # path constant. Narrow trigger is architecturally intentional.
+    "validate-lifecycle-stage": {
+        "risk-map/yaml/lifecycle-stage.yaml",
+    },
+    # validate-persona-site-build: read set has two layers:
+    #   (1) Three YAMLs opened per run via DEFAULT_*_PATH constants
+    #       (build_persona_site_data.py:20-22; validate_persona_site_build.py:38-41).
+    #   (2) The output schema, opened at module-import time
+    #       (build_persona_site_data.py:31-37 _load_output_schema()).
+    # Trigger-only (NOT in read set, intentionally — included in the trigger
+    # for defensive re-run on edits but never opened by the builder):
+    #   - risk-map/schemas/risks.schema.json: validated by check-jsonschema in
+    #     a separate hook; the persona-site builder does not load it.
+    #   - scripts/build_persona_site_data.py: imported as a Python module by
+    #     the wrapper; not opened as a file at runtime.
+    # The Task 2 regression-lock tests (TestPersonaSiteBuildHookContracts)
+    # cover the full trigger surface; this entry covers only the read set.
+    "validate-persona-site-build": {
+        "risk-map/yaml/personas.yaml",
+        "risk-map/yaml/risks.yaml",
+        "risk-map/yaml/controls.yaml",
+        "risk-map/schemas/persona-site-data.schema.json",
+    },
+    # validate-issue-templates: SENTINEL — the validator's "read set" is not
+    # a fixed list of repo-relative paths. It queries git-staged files at
+    # runtime (get_staged_files() in validate_issue_templates.py:72-98) and
+    # validates whichever .github/ISSUE_TEMPLATE/*.yml files are staged. The
+    # trigger files: regex covers the two directory roots (.github/ISSUE_TEMPLATE/
+    # and scripts/TEMPLATES/) that the staged-file query may return. Because the
+    # read set is determined by the staged index at runtime rather than by fixed
+    # path constants, the trigger-⊇-read-set invariant cannot be mechanically
+    # checked here. Exempt per ADR-005 § Addendum 2026-05-08: Hook
+    # trigger-vs-read-set invariant.
+    "validate-issue-templates": None,
+    # regenerate-issue-templates: SENTINEL — generator hook, not a validator.
+    # Reads template sources and schema files discovered at runtime; the trigger
+    # covers sources and schemas but the full read set is glob-determined.
+    "regenerate-issue-templates": None,
+    # validate-all-yaml-on-master-schema-change: SENTINEL — fan-out hook.
+    # Discovers (schema, yaml) pairs from the filesystem at runtime; the read
+    # set is not a fixed list of paths.
+    "validate-all-yaml-on-master-schema-change": None,
+}
+
+
+def _local_hooks_with_pass_filenames_false() -> list[dict]:
+    """Return local-repo hooks that have pass_filenames: false."""
+    config = _load_config()
+    result: list[dict] = []
+    for repo in config.get("repos", []):
+        if repo.get("repo") != "local":
+            continue
+        for hook in repo.get("hooks", []):
+            if hook.get("pass_filenames") is False:
+                result.append(hook)
+    return result
+
+
+class TestTriggerReadSetInvariant:
+    """
+    Structural enforcement of the trigger ⊇ read-set invariant (ADR-005
+    § Addendum 2026-05-08: Hook trigger-vs-read-set invariant, issue #279).
+
+    For every local validator hook with pass_filenames: false, the hook's
+    files: regex must match every path the validator opens on disk during a
+    run. If the trigger is narrower than the read set, commits that touch
+    only the unmatched paths silently skip validation.
+
+    The metadata table _LOCAL_VALIDATOR_READ_SETS is the contract surface.
+    When adding a new local hook with pass_filenames: false, register its
+    read set in that table. Hooks with a None value are exempt (fan-out or
+    runtime-discovered read sets; see table comments for rationale).
+
+    Tests in this class:
+
+      test_all_local_pass_filenames_false_hooks_are_registered
+        — prevents drift where a new hook is added without a table entry.
+
+      test_trigger_covers_read_set_for_each_registered_hook
+        — asserts trigger ⊇ read-set for every non-None entry.
+    """
+
+    def test_all_local_pass_filenames_false_hooks_are_registered(self):
+        """
+        Test that every local hook with pass_filenames: false is registered in
+        the metadata table.
+
+        Given: .pre-commit-config.yaml with one or more local hooks with
+               pass_filenames: false
+        When:  comparing hook ids against _LOCAL_VALIDATOR_READ_SETS keys
+        Then:  every such hook id appears in the table (either with a real set
+               or with the None sentinel)
+
+        This prevents a new hook from being added without its read set being
+        declared. A missing registration means the trigger-⊇-read-set check
+        cannot run for that hook, defeating the structural guarantee.
+        """
+        local_false_hooks = _local_hooks_with_pass_filenames_false()
+        declared_ids = {h.get("id") for h in local_false_hooks}
+        registered_ids = set(_LOCAL_VALIDATOR_READ_SETS.keys())
+        unregistered = declared_ids - registered_ids
+        assert not unregistered, (
+            f"Hook(s) {sorted(unregistered)} declared with pass_filenames: false "
+            f"but missing from _LOCAL_VALIDATOR_READ_SETS — register each hook's "
+            f"read set (or None sentinel for fan-out/runtime-discovered sets) per "
+            f"ADR-005 § Addendum 2026-05-08: Hook trigger-vs-read-set invariant (issue #279)."
+        )
+
+    def test_trigger_covers_read_set_for_each_registered_hook(self):
+        """
+        Test that each registered hook's files: regex matches all paths in its
+        declared read set (trigger ⊇ read-set invariant).
+
+        Given: _LOCAL_VALIDATOR_READ_SETS entries with non-None read sets
+        When:  applying each hook's files: regex against each path in its read set
+               using re.search (mirroring the pre-commit framework's match behavior)
+        Then:  every path matches
+
+        Failure message names the hook id, the missing path, and a pointer to
+        the ADR-005 addendum so the fix is unambiguous.
+
+        RED-PHASE: before issue #279's trigger fix lands, this test fails on
+        validate-component-edges because controls.yaml and risks.yaml are in
+        the read set but not in the files: regex. Once the trigger is widened
+        to ^risk-map/yaml/(components|controls|risks)\\.yaml$ the test passes.
+        """
+        local_false_hooks = _local_hooks_with_pass_filenames_false()
+        hooks_by_id = {h.get("id"): h for h in local_false_hooks}
+
+        failures: list[str] = []
+        for hook_id, read_set in _LOCAL_VALIDATOR_READ_SETS.items():
+            # Skip None sentinels — exempt from mechanical check.
+            if read_set is None:
+                continue
+
+            hook = hooks_by_id.get(hook_id)
+            if hook is None:
+                # Hook declared in table but not in config — not this test's
+                # concern (test_all_local_pass_filenames_false_hooks_are_registered
+                # would have caught a missing registration; a table entry with no
+                # matching hook is stale but not a trigger-⊇-read-set violation).
+                continue
+
+            files_regex = hook.get("files", "")
+            for path in sorted(read_set):
+                if not re.search(files_regex, path):
+                    failures.append(
+                        f"Hook `{hook_id}`: files: regex {files_regex!r} does not "
+                        f"match read-set path `{path}`. A commit that only touches "
+                        f"`{path}` will not trigger `{hook_id}`, silently skipping "
+                        f"validation. Widen the trigger per ADR-005 § Addendum 2026-05-08: "
+                        f"Hook trigger-vs-read-set invariant (issue #279)."
+                    )
+
+        assert not failures, "Trigger ⊇ read-set invariant violated:\n" + "\n".join(f"  - {f}" for f in failures)
 
 
 # ===========================================================================

--- a/scripts/hooks/tests/test_precommit_hook_install.py
+++ b/scripts/hooks/tests/test_precommit_hook_install.py
@@ -620,34 +620,40 @@ class TestPersonaSiteBuildHookContracts:
 
 
 # ===========================================================================
-# Trigger ⊇ read-set invariant (Task 4 — structural enforcement, issue #279)
+# Trigger coverage invariant (Task 4 — structural enforcement, issue #279)
 # ===========================================================================
 
-# Mapping: hook id -> read set (paths the validator opens during a run, as
-# repo-relative strings without leading slash).
+# Mapping: hook id -> trigger coverage set (repo-relative paths that must match
+# the hook's files: regex).
 #
 # When adding a new local validator hook with pass_filenames: false, register
-# its read set here. The structural test below asserts that the hook's files:
-# regex matches every path in this set. Trigger ⊇ read-set is the invariant
-# codified in ADR-005 § Addendum 2026-05-08: Hook trigger-vs-read-set invariant
-# (issue #279, PR #277 follow-up).
+# the fixed path surface that must trigger it here. This set includes fixed
+# check-input paths and fixed staged-file discovery surfaces such as
+# get_staged_yaml_files() target_files. It is intentionally not limited to files
+# literally opened during the default hook path.
 #
 # Use None as the sentinel value for hooks that are exempt from the invariant:
-#   - Fan-out / generator hooks that read a variable or glob-determined set
+#   - Fan-out / generator hooks that use a variable or glob-determined set
 #     of files (e.g., validate-all-yaml-on-master-schema-change discovers
 #     all yaml/schema pairs at runtime).
-#   - Hooks whose "read set" is determined by the staged files list at runtime
+#   - Hooks whose trigger coverage is determined by the staged files list at runtime
 #     rather than a fixed set of paths (e.g., validate-issue-templates reads
 #     whichever .github/ISSUE_TEMPLATE/*.yml files are staged).
 #   - Hooks that do not have pass_filenames: false (not in scope; trigger-to-
 #     scope coupling is implicit for pass_filenames: true hooks).
 #
 # Every local hook with pass_filenames: false MUST be registered here.
-# Failure to register causes TestTriggerReadSetInvariant to fail with a
+# Failure to register causes TestTriggerCoverageInvariant to fail with a
 # clear diagnostic naming the unregistered hook id.
-_LOCAL_VALIDATOR_READ_SETS: dict[str, set[str] | None] = {
-    # validate-component-edges: validator opens all three YAMLs in every run
-    # via get_staged_yaml_files() target_files constant (utils.py:221-225).
+_LOCAL_VALIDATOR_TRIGGER_COVERAGE: dict[str, set[str] | None] = {
+    # validate-component-edges: these are the fixed target files in
+    # get_staged_yaml_files() (utils.py:221-225). The default pre-commit path
+    # parses components.yaml and controls.yaml; risks.yaml is retained because
+    # issue #279 explicitly preserves the legacy staged-file discovery surface
+    # so risks-only changes still exercise the validator. lifecycle-stage.yaml
+    # is covered by the dedicated validate-lifecycle-stage hook below; the
+    # default-mode belt-and-suspenders lifecycle check in validate_riskmap.py is
+    # intentionally out of this hook's trigger contract.
     "validate-component-edges": {
         "risk-map/yaml/components.yaml",
         "risk-map/yaml/controls.yaml",
@@ -672,7 +678,7 @@ _LOCAL_VALIDATOR_READ_SETS: dict[str, set[str] | None] = {
     "validate-lifecycle-stage": {
         "risk-map/yaml/lifecycle-stage.yaml",
     },
-    # validate-persona-site-build: read set has two layers:
+    # validate-persona-site-build: trigger coverage has two layers:
     #   (1) Three YAMLs opened per run via DEFAULT_*_PATH constants
     #       (build_persona_site_data.py:20-22; validate_persona_site_build.py:38-41).
     #   (2) The output schema, opened at module-import time
@@ -684,23 +690,20 @@ _LOCAL_VALIDATOR_READ_SETS: dict[str, set[str] | None] = {
     #   - scripts/build_persona_site_data.py: imported as a Python module by
     #     the wrapper; not opened as a file at runtime.
     # The Task 2 regression-lock tests (TestPersonaSiteBuildHookContracts)
-    # cover the full trigger surface; this entry covers only the read set.
+    # cover the full trigger surface; this entry covers the fixed runtime inputs.
     "validate-persona-site-build": {
         "risk-map/yaml/personas.yaml",
         "risk-map/yaml/risks.yaml",
         "risk-map/yaml/controls.yaml",
         "risk-map/schemas/persona-site-data.schema.json",
     },
-    # validate-issue-templates: SENTINEL — the validator's "read set" is not
+    # validate-issue-templates: SENTINEL — the validator's coverage set is not
     # a fixed list of repo-relative paths. It queries git-staged files at
     # runtime (get_staged_files() in validate_issue_templates.py:72-98) and
     # validates whichever .github/ISSUE_TEMPLATE/*.yml files are staged. The
     # trigger files: regex covers the two directory roots (.github/ISSUE_TEMPLATE/
-    # and scripts/TEMPLATES/) that the staged-file query may return. Because the
-    # read set is determined by the staged index at runtime rather than by fixed
-    # path constants, the trigger-⊇-read-set invariant cannot be mechanically
-    # checked here. Exempt per ADR-005 § Addendum 2026-05-08: Hook
-    # trigger-vs-read-set invariant.
+    # and scripts/TEMPLATES/) that the staged-file query may return. Exempt per
+    # ADR-005 § Addendum 2026-05-08: Hook trigger-vs-read-set invariant.
     "validate-issue-templates": None,
     # regenerate-issue-templates: SENTINEL — generator hook, not a validator.
     # Reads template sources and schema files discovered at runtime; the trigger
@@ -726,28 +729,28 @@ def _local_hooks_with_pass_filenames_false() -> list[dict]:
     return result
 
 
-class TestTriggerReadSetInvariant:
+class TestTriggerCoverageInvariant:
     """
-    Structural enforcement of the trigger ⊇ read-set invariant (ADR-005
+    Structural enforcement of trigger coverage for pass_filenames: false hooks (ADR-005
     § Addendum 2026-05-08: Hook trigger-vs-read-set invariant, issue #279).
 
     For every local validator hook with pass_filenames: false, the hook's
-    files: regex must match every path the validator opens on disk during a
-    run. If the trigger is narrower than the read set, commits that touch
-    only the unmatched paths silently skip validation.
+    files: regex must match every fixed path in its declared trigger coverage
+    set. If the trigger is narrower than the fixed coverage set, commits that
+    touch only the unmatched paths silently skip validation.
 
-    The metadata table _LOCAL_VALIDATOR_READ_SETS is the contract surface.
+    The metadata table _LOCAL_VALIDATOR_TRIGGER_COVERAGE is the contract surface.
     When adding a new local hook with pass_filenames: false, register its
-    read set in that table. Hooks with a None value are exempt (fan-out or
-    runtime-discovered read sets; see table comments for rationale).
+    fixed trigger coverage there. Hooks with a None value are exempt (fan-out or
+    runtime-discovered coverage sets; see table comments for rationale).
 
     Tests in this class:
 
       test_all_local_pass_filenames_false_hooks_are_registered
         — prevents drift where a new hook is added without a table entry.
 
-      test_trigger_covers_read_set_for_each_registered_hook
-        — asserts trigger ⊇ read-set for every non-None entry.
+      test_trigger_covers_declared_coverage_for_each_registered_hook
+        — asserts files: regex covers every fixed non-None entry.
     """
 
     def test_all_local_pass_filenames_false_hooks_are_registered(self):
@@ -757,32 +760,32 @@ class TestTriggerReadSetInvariant:
 
         Given: .pre-commit-config.yaml with one or more local hooks with
                pass_filenames: false
-        When:  comparing hook ids against _LOCAL_VALIDATOR_READ_SETS keys
+        When:  comparing hook ids against _LOCAL_VALIDATOR_TRIGGER_COVERAGE keys
         Then:  every such hook id appears in the table (either with a real set
                or with the None sentinel)
 
-        This prevents a new hook from being added without its read set being
-        declared. A missing registration means the trigger-⊇-read-set check
+        This prevents a new hook from being added without its fixed coverage
+        being declared. A missing registration means the trigger coverage check
         cannot run for that hook, defeating the structural guarantee.
         """
         local_false_hooks = _local_hooks_with_pass_filenames_false()
         declared_ids = {h.get("id") for h in local_false_hooks}
-        registered_ids = set(_LOCAL_VALIDATOR_READ_SETS.keys())
+        registered_ids = set(_LOCAL_VALIDATOR_TRIGGER_COVERAGE.keys())
         unregistered = declared_ids - registered_ids
         assert not unregistered, (
             f"Hook(s) {sorted(unregistered)} declared with pass_filenames: false "
-            f"but missing from _LOCAL_VALIDATOR_READ_SETS — register each hook's "
-            f"read set (or None sentinel for fan-out/runtime-discovered sets) per "
+            f"but missing from _LOCAL_VALIDATOR_TRIGGER_COVERAGE — register each hook's "
+            f"fixed coverage set (or None sentinel for fan-out/runtime-discovered sets) per "
             f"ADR-005 § Addendum 2026-05-08: Hook trigger-vs-read-set invariant (issue #279)."
         )
 
-    def test_trigger_covers_read_set_for_each_registered_hook(self):
+    def test_trigger_covers_declared_coverage_for_each_registered_hook(self):
         """
         Test that each registered hook's files: regex matches all paths in its
-        declared read set (trigger ⊇ read-set invariant).
+        declared fixed trigger coverage set.
 
-        Given: _LOCAL_VALIDATOR_READ_SETS entries with non-None read sets
-        When:  applying each hook's files: regex against each path in its read set
+        Given: _LOCAL_VALIDATOR_TRIGGER_COVERAGE entries with non-None sets
+        When:  applying each hook's files: regex against each declared path
                using re.search (mirroring the pre-commit framework's match behavior)
         Then:  every path matches
 
@@ -790,17 +793,17 @@ class TestTriggerReadSetInvariant:
         the ADR-005 addendum so the fix is unambiguous.
 
         RED-PHASE: before issue #279's trigger fix lands, this test fails on
-        validate-component-edges because controls.yaml and risks.yaml are in
-        the read set but not in the files: regex. Once the trigger is widened
+        validate-component-edges because controls.yaml and risks.yaml are in its
+        fixed staged-file discovery surface but not in files:. Once the trigger is widened
         to ^risk-map/yaml/(components|controls|risks)\\.yaml$ the test passes.
         """
         local_false_hooks = _local_hooks_with_pass_filenames_false()
         hooks_by_id = {h.get("id"): h for h in local_false_hooks}
 
         failures: list[str] = []
-        for hook_id, read_set in _LOCAL_VALIDATOR_READ_SETS.items():
+        for hook_id, coverage_set in _LOCAL_VALIDATOR_TRIGGER_COVERAGE.items():
             # Skip None sentinels — exempt from mechanical check.
-            if read_set is None:
+            if coverage_set is None:
                 continue
 
             hook = hooks_by_id.get(hook_id)
@@ -808,21 +811,21 @@ class TestTriggerReadSetInvariant:
                 # Hook declared in table but not in config — not this test's
                 # concern (test_all_local_pass_filenames_false_hooks_are_registered
                 # would have caught a missing registration; a table entry with no
-                # matching hook is stale but not a trigger-⊇-read-set violation).
+                # matching hook is stale but not a trigger coverage violation).
                 continue
 
             files_regex = hook.get("files", "")
-            for path in sorted(read_set):
+            for path in sorted(coverage_set):
                 if not re.search(files_regex, path):
                     failures.append(
                         f"Hook `{hook_id}`: files: regex {files_regex!r} does not "
-                        f"match read-set path `{path}`. A commit that only touches "
+                        f"match declared trigger coverage path `{path}`. A commit that only touches "
                         f"`{path}` will not trigger `{hook_id}`, silently skipping "
                         f"validation. Widen the trigger per ADR-005 § Addendum 2026-05-08: "
                         f"Hook trigger-vs-read-set invariant (issue #279)."
                     )
 
-        assert not failures, "Trigger ⊇ read-set invariant violated:\n" + "\n".join(f"  - {f}" for f in failures)
+        assert not failures, "Trigger coverage invariant violated:\n" + "\n".join(f"  - {f}" for f in failures)
 
 
 # ===========================================================================


### PR DESCRIPTION
## feat(precommit): codify trigger-vs-read-set invariant (#279)

Closes #279                                                
                            
Implements the four tasks tracked at issue #279, surfaced by shrey-bagga's CHANGES_REQUESTED on PR #277:  
        
1. Widen `validate-component-edges` trigger to `(components|controls|risks)\.yaml`  
2. Regression guard for `validate-persona-site-build` trigger (the trigger has correctly included `controls.yaml` since the hook's introduction in commit `93cc22b`; this PR locks the behaviour in)
3. ADR-005 addendum codifying `trigger-set ⊇ check-input ⊇ read-set` invariant with three carve-outs (generators / master-schema fan-out / runtime-discovered read sets)  
4. Structural test in `test_precommit_hook_install.py` (`TestTriggerReadSetInvariant`) iterates every local `pass_filenames: false` hook against a `_LOCAL_VALIDATOR_READ_SETS` metadata table; drift-prevention test  
asserts every such hook is registered  
       
Diff: 3 files, +524/-2. Single commit `06e15a0`. 
                                                  
## Test plan       
                                  
- [x] `pytest scripts/hooks/tests/test_precommit_hook_install.py` — 32 passed  
- [x] Full hook suite — `pytest scripts/hooks/tests` — 2329 passed / 6 skipped (pre-rebase; current corpus unchanged)  
- [x] `ruff check` + `ruff format --check` clean         
- [x] `pre-commit run --all-files` clean  
- [x] Deliberately breaking either widened trigger causes the structural test to fail with the named-hook + missing-path diagnostic (architect-reviewed)  