### PR TITLE
This commit does fix CodeQL #20 + #21 (redos in diagnostic-format regex)

### DIFF
--- a/scripts/hooks/tests/test_validate_prose_references.py
+++ b/scripts/hooks/tests/test_validate_prose_references.py
@@ -150,7 +150,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 # The references linter embeds the token value directly in reason strings
 # (e.g. "... at 'riskBaz'"); the regex matches any non-empty reason.
 # ---------------------------------------------------------------------------
-_DIAG_PATTERN = re.compile(r"^validate-prose-references: [^:]+:[^:]+:[^:\[]+(?:\.[^:\[]+)*\[\d+\]: .+$")
+_DIAG_PATTERN = re.compile(r"^validate-prose-references: [^:]+:[^:]+:[^:\[.]+(?:\.[^:\[.]+)*\[\d+\]: .+$")
 
 # ---------------------------------------------------------------------------
 # Helpers for building synthetic YAML and schema fixtures
@@ -1658,3 +1658,39 @@ class TestEdgeCases:
         assert len(camel_diags) >= 1
         assert "at '" in camel_diags[0].reason
         assert "riskAlpha" in camel_diags[0].reason
+
+
+# ===========================================================================
+# TestDiagnosticPatternRedosResistance
+# ===========================================================================
+
+
+class TestDiagnosticPatternRedosResistance:
+    r"""CodeQL #21 regression guard for the diagnostic-format regex."""
+
+    def test_diagnostic_pattern_resists_redos(self):
+        r"""
+        _DIAG_PATTERN must match in bounded time on a many-dotted-segments adversarial
+        input.
+
+        Given: An input shaped like 'validate-prose-references: 9:9:9' + '.9' * N + ':NO_BRACKET'
+        When: _DIAG_PATTERN.match(input) runs against N=50 dotted segments
+        Then: The match completes in well under 1 second AND returns None (input is malformed)
+
+        Pre-fix, the ambiguous quantifier [^:\[]+(?:\.[^:\[]+)* admitted exponential
+        backtracking when the [<digit>] suffix failed: ~53s on N=30 segments.  The fix
+        adds the dot to the inner negated character class — [^:\[.]+(?:\.[^:\[.]+)* —
+        making the dot exclusively the segment separator and eliminating the ambiguity.
+        Linear-time guaranteed.
+        """
+        import time as _time  # local import keeps top-level imports minimal
+
+        redos_seed = "validate-prose-references: 9:9:9" + ".9" * 50 + ":NO_BRACKET"
+        t0 = _time.monotonic()
+        result = _DIAG_PATTERN.match(redos_seed)
+        elapsed = _time.monotonic() - t0
+        assert result is None, "malformed redos seed must not match the diagnostic format"
+        assert elapsed < 1.0, (
+            f"diagnostic regex took {elapsed:.3f}s on redos seed; "
+            f"should be linear-time (sub-millisecond).  CodeQL #21 may have regressed."
+        )

--- a/scripts/hooks/tests/test_validate_prose_references.py
+++ b/scripts/hooks/tests/test_validate_prose_references.py
@@ -1668,6 +1668,7 @@ class TestEdgeCases:
 class TestDiagnosticPatternRedosResistance:
     r"""CodeQL #21 regression guard for the diagnostic-format regex."""
 
+    @pytest.mark.timeout(2)
     def test_diagnostic_pattern_resists_redos(self):
         r"""
         _DIAG_PATTERN must match in bounded time on a many-dotted-segments adversarial

--- a/scripts/hooks/tests/test_validate_yaml_prose_subset.py
+++ b/scripts/hooks/tests/test_validate_yaml_prose_subset.py
@@ -198,7 +198,7 @@ def _make_control(control_id: str, description: list[str] | None = None) -> dict
 # permitted but no additional colons.  The reason segment now requires the
 # ADR-017 D4 "at '<snippet>'" suffix.
 # ---------------------------------------------------------------------------
-_DIAG_PATTERN = re.compile(r"^validate-yaml-prose-subset: [^:]+:[^:]+:[^:\[]+(?:\.[^:\[]+)*\[\d+\]: .+ at '.*'$")
+_DIAG_PATTERN = re.compile(r"^validate-yaml-prose-subset: [^:]+:[^:]+:[^:\[.]+(?:\.[^:\[.]+)*\[\d+\]: .+ at '.*'$")
 
 
 # ===========================================================================
@@ -1159,6 +1159,33 @@ class TestDiagnosticFormat:
         diag = tour_diags[0]
         line = self._diag_to_line(diag)
         assert _DIAG_PATTERN.match(line), f"Diagnostic line does not match pattern: {line!r}"
+
+    def test_diagnostic_pattern_resists_redos(self):
+        r"""
+        CodeQL #20 regression guard: _DIAG_PATTERN must match in bounded time on a
+        many-dotted-segments adversarial input.
+
+        Given: An input shaped like 'validate-yaml-prose-subset: 9:9:9' + '.9' * N + ':NO_BRACKET'
+        When: _DIAG_PATTERN.match(input) runs against N=50 dotted segments
+        Then: The match completes in well under 1 second AND returns None (input is malformed)
+
+        Pre-fix, the ambiguous quantifier [^:\[]+(?:\.[^:\[]+)* admitted exponential
+        backtracking when the [<digit>] suffix failed: ~53s on N=30 segments.  The fix
+        adds the dot to the inner negated character class — [^:\[.]+(?:\.[^:\[.]+)* —
+        making the dot exclusively the segment separator and eliminating the ambiguity.
+        Linear-time guaranteed.
+        """
+        import time as _time  # local import keeps top-level imports minimal
+
+        redos_seed = "validate-yaml-prose-subset: 9:9:9" + ".9" * 50 + ":NO_BRACKET"
+        t0 = _time.monotonic()
+        result = _DIAG_PATTERN.match(redos_seed)
+        elapsed = _time.monotonic() - t0
+        assert result is None, "malformed redos seed must not match the diagnostic format"
+        assert elapsed < 1.0, (
+            f"diagnostic regex took {elapsed:.3f}s on redos seed; "
+            f"should be linear-time (sub-millisecond).  CodeQL #20 may have regressed."
+        )
 
 
 # ===========================================================================

--- a/scripts/hooks/tests/test_validate_yaml_prose_subset.py
+++ b/scripts/hooks/tests/test_validate_yaml_prose_subset.py
@@ -1160,6 +1160,7 @@ class TestDiagnosticFormat:
         line = self._diag_to_line(diag)
         assert _DIAG_PATTERN.match(line), f"Diagnostic line does not match pattern: {line!r}"
 
+    @pytest.mark.timeout(2)
     def test_diagnostic_pattern_resists_redos(self):
         r"""
         CodeQL #20 regression guard: _DIAG_PATTERN must match in bounded time on a


### PR DESCRIPTION
## This commit does fix CodeQL 20 + 21 (redos in diagnostic-format regex)

Adds the dot to the inner negated character class in _DIAG_PATTERN across both prose-linter test files.  

The fragment `[^:\[]+(?:\.[^:\[]+)*` admitted exponential backtracking on inputs with many dotted segments when the trailing [<digit>] match failed (~53s on N=30 segments). The fix `[^:\`[.]+(?:\.[^:\[.]+)*` makes the dot exclusively the segment separator, eliminating the matching ambiguity.  

Adds a regression test in each file asserting bounded match time on the redos seed.

__Note: the production linters only emit the diagnostic string via f-string — they never parse it with a regex. _DIAG_PATTERN exists only in the test suites as a format-contract assertion, so the issues are correctly scoped to the test files and nothing else needs fixing.__