### PR TITLE
precommit: surface nested_index in prose-linter diagnostic output

### DIFF
--- a/docs/adr/017-yaml-prose-authoring-subset.md
+++ b/docs/adr/017-yaml-prose-authoring-subset.md
@@ -78,7 +78,7 @@ A new local hook lands under `.pre-commit-config.yaml` per [ADR-013](013-site-pr
 - **Pass filenames:** true.
 - **Walks every prose field** identified by the schemas as a string or `definitions/prose` reference (`description`, `shortDescription`, `longDescription`, `examples`, `responsibilities`, `tourContent.*`, and equivalents). The list of prose fields is read from the schemas, not hardcoded, to prevent drift when a sibling ADR adds a field.
 - **Tokenizer:** hand-rolled, regex-driven, covering the three allowed forms. Vanilla Python, no markdown library — consistent with [ADR-015](015-site-content-sanitization-invariants.md)'s zero-dep posture for the matching site-side sanitizer.
-- **Rejection format:** stderr line per offending paragraph: `validate-yaml-prose-subset: <file>:<entry-id>:<field>[<index>]: <reason> at <token-snippet>`. Exit non-zero on any rejection.
+- **Rejection format:** stderr line per offending paragraph: `validate-yaml-prose-subset: <file>:<entry-id>:<field>[<index>]: <reason> at <token-snippet>`. A paragraph nested one level inside an inner list (the `oneOf: [string, array<string>]` shape the `utils/text` definition admits) carries a second segment — `<field>[<outer>][<inner>]` — so each inner string is individually addressable. Exit non-zero on any rejection.
 - **Rule list (block-mode end state):**
   1. Accept `**bold**` (one nesting level), `*italic*`, `_italic_`, and the sentinel forms decided in [ADR-016](016-reference-strategy.md).
   2. **Reject any prose carrying a URI scheme inline.** The rule is categorical, not an enumeration. The tokenizer applies two patterns:

--- a/scripts/hooks/precommit/_linter_types.py
+++ b/scripts/hooks/precommit/_linter_types.py
@@ -9,6 +9,13 @@ import sys
 from pathlib import Path
 from typing import NamedTuple
 
+__all__ = [
+    "ProseField",
+    "Diagnostic",
+    "IdIndex",
+    "format_diagnostic_line",
+]
+
 # Ensure the scripts/hooks directory is on sys.path so ``precommit.*`` imports
 # work when this file is executed or imported directly without the package on path.
 _HOOKS_DIR = Path(__file__).resolve().parent.parent
@@ -50,13 +57,19 @@ class Diagnostic(NamedTuple):
     """A single lint finding from a prose wrapper linter.
 
     Attributes:
-        hook_id:    Pre-commit hook identifier (e.g. 'validate-yaml-prose-subset').
-        file_path:  Path to the YAML file that contains the violation.
-        entry_id:   ID of the YAML entry where the violation was found.
-        field_name: Schema property name of the violating prose field.
-        index:      Paragraph index within the array (0-based); None only if
-                    field is a bare scalar.
-        reason:     Human-readable description of the violation.
+        hook_id:      Pre-commit hook identifier (e.g. 'validate-yaml-prose-subset').
+        file_path:    Path to the YAML file that contains the violation.
+        entry_id:     ID of the YAML entry where the violation was found.
+        field_name:   Schema property name of the violating prose field.
+        index:        Paragraph index within the array (0-based); None only if
+                      field is a bare scalar.
+        reason:       Human-readable description of the violation.
+        nested_index: When the violating string came from an inner-list item
+                      (``items: oneOf [string, array<string>]`` field shape),
+                      this is the position of that string within the inner list
+                      (0-based); ``index`` then holds the outer position.
+                      ``None`` for outer / flat-array violations where no inner
+                      list is involved.
     """
 
     hook_id: str
@@ -65,6 +78,7 @@ class Diagnostic(NamedTuple):
     field_name: str
     index: int | None
     reason: str
+    nested_index: int | None = None
 
 
 class IdIndex(NamedTuple):
@@ -91,3 +105,28 @@ class IdIndex(NamedTuple):
     # Not wrapped in MappingProxyType to keep the type signature simple; if this becomes a bug
     # source, wrap at the build_id_index return boundary.
     ext_refs: dict[str, frozenset[str]]
+
+
+def format_diagnostic_line(diag: "Diagnostic") -> str:
+    """Format a Diagnostic as its committed stderr string.
+
+    Format when ``nested_index`` is None (flat-array / outer violation):
+        ``<hook_id>: <file>:<entry_id>:<field>[<index>]: <reason>``
+
+    Format when ``nested_index`` is not None (inner-list violation):
+        ``<hook_id>: <file>:<entry_id>:<field>[<outer>][<inner>]: <reason>``
+
+    The optional ``[<nested_index>]`` segment is appended only when
+    ``diag.nested_index is not None``; flat-array diagnostics are emitted
+    byte-for-byte in the original ``[<index>]:`` form.
+
+    Args:
+        diag: The Diagnostic to format.
+
+    Returns:
+        The formatted diagnostic string (without a trailing newline).
+    """
+    idx_str = f"[{diag.index}]" if diag.index is not None else "[0]"
+    nested_str = f"[{diag.nested_index}]" if diag.nested_index is not None else ""
+    location = f"{diag.file_path}:{diag.entry_id}:{diag.field_name}{idx_str}{nested_str}"
+    return f"{diag.hook_id}: {location}: {diag.reason}"

--- a/scripts/hooks/precommit/validate_prose_references.py
+++ b/scripts/hooks/precommit/validate_prose_references.py
@@ -28,7 +28,7 @@ _HOOKS_DIR = Path(__file__).resolve().parent.parent
 if str(_HOOKS_DIR) not in sys.path:
     sys.path.insert(0, str(_HOOKS_DIR))
 
-from precommit._linter_types import Diagnostic, IdIndex, ProseField  # noqa: E402
+from precommit._linter_types import Diagnostic, IdIndex, ProseField, format_diagnostic_line  # noqa: E402
 from precommit._prose_fields import find_prose_fields  # noqa: E402
 from precommit._prose_tokens import TokenKind  # noqa: E402
 
@@ -189,6 +189,7 @@ def check_references(field: ProseField, id_index: IdIndex) -> list[Diagnostic]:
             field_name=field.field_name,
             index=field.index,
             reason=reason,
+            nested_index=field.nested_index,
         )
 
     for token in field.tokens:
@@ -244,14 +245,19 @@ def check_references(field: ProseField, id_index: IdIndex) -> list[Diagnostic]:
 def _emit_diagnostic(diag: Diagnostic) -> None:
     """Print a single Diagnostic to stderr in the committed format.
 
-    Format: ``<hook_id>: <file>:<entry_id>:<field>[<index>]: <reason>``
+    Format when ``diag.nested_index`` is None (flat-array violation):
+        ``<hook_id>: <file>:<entry_id>:<field>[<index>]: <reason>``
+
+    Format when ``diag.nested_index`` is not None (inner-list violation):
+        ``<hook_id>: <file>:<entry_id>:<field>[<outer>][<inner>]: <reason>``
+
+    The optional ``[<nested_index>]`` segment is appended only for inner-list
+    violations; flat-array output is byte-for-byte unchanged.
 
     Args:
         diag: The Diagnostic to emit.
     """
-    idx_str = f"[{diag.index}]" if diag.index is not None else "[0]"
-    line = f"{diag.hook_id}: {diag.file_path}:{diag.entry_id}:{diag.field_name}{idx_str}: {diag.reason}"
-    print(line, file=sys.stderr)
+    print(format_diagnostic_line(diag), file=sys.stderr)
 
 
 def main(argv: list[str] | None = None) -> NoReturn:

--- a/scripts/hooks/precommit/validate_yaml_prose_subset.py
+++ b/scripts/hooks/precommit/validate_yaml_prose_subset.py
@@ -27,7 +27,7 @@ _HOOKS_DIR = Path(__file__).resolve().parent.parent
 if str(_HOOKS_DIR) not in sys.path:
     sys.path.insert(0, str(_HOOKS_DIR))
 
-from precommit._linter_types import Diagnostic, ProseField  # noqa: E402
+from precommit._linter_types import Diagnostic, ProseField, format_diagnostic_line  # noqa: E402
 from precommit._prose_fields import find_prose_fields  # noqa: E402
 from precommit._prose_tokens import TokenKind  # noqa: E402
 
@@ -118,6 +118,7 @@ def check_prose_field(field: ProseField) -> list[Diagnostic]:
                 field_name=field.field_name,
                 index=field.index,
                 reason=reason,
+                nested_index=field.nested_index,
             )
         )
     return diagnostics
@@ -126,14 +127,19 @@ def check_prose_field(field: ProseField) -> list[Diagnostic]:
 def _emit_diagnostic(diag: Diagnostic) -> None:
     """Print a single Diagnostic to stderr in the committed format.
 
-    Format: ``<hook_id>: <file>:<entry_id>:<field>[<index>]: <reason>``
+    Format when ``diag.nested_index`` is None (flat-array violation):
+        ``<hook_id>: <file>:<entry_id>:<field>[<index>]: <reason>``
+
+    Format when ``diag.nested_index`` is not None (inner-list violation):
+        ``<hook_id>: <file>:<entry_id>:<field>[<outer>][<inner>]: <reason>``
+
+    The optional ``[<nested_index>]`` segment is appended only for inner-list
+    violations; flat-array output is byte-for-byte unchanged.
 
     Args:
         diag: The Diagnostic to emit.
     """
-    idx_str = f"[{diag.index}]" if diag.index is not None else "[0]"
-    line = f"{diag.hook_id}: {diag.file_path}:{diag.entry_id}:{diag.field_name}{idx_str}: {diag.reason}"
-    print(line, file=sys.stderr)
+    print(format_diagnostic_line(diag), file=sys.stderr)
 
 
 def main(argv: list[str] | None = None) -> NoReturn:

--- a/scripts/hooks/tests/fixtures/wrapper_linters/reference_violations/nested_list_bare_camelcase.yaml
+++ b/scripts/hooks/tests/fixtures/wrapper_linters/reference_violations/nested_list_bare_camelcase.yaml
@@ -1,0 +1,13 @@
+risks:
+  - id: riskAlpha
+    title: Alpha Risk
+    # shortDescription uses a nested-array shape:
+    #   outer index 0 → flat string (clean)
+    #   outer index 1 → inner list; inner index 0 is clean,
+    #                               inner index 1 contains a bare camelCase ID
+    # The references linter should emit a diagnostic at shortDescription[1][1]
+    # for the bare camelCase identifier riskBeta (must be wrapped in {{...}}).
+    shortDescription:
+      - "Clean introductory paragraph."
+      - - "First nested bullet — clean prose."
+        - "Second nested bullet mentions riskBeta without a sentinel wrapper."

--- a/scripts/hooks/tests/fixtures/wrapper_linters/subset_violations/nested_list_html_violation.yaml
+++ b/scripts/hooks/tests/fixtures/wrapper_linters/subset_violations/nested_list_html_violation.yaml
@@ -1,0 +1,11 @@
+risks:
+  - id: riskAlpha
+    title: Alpha Risk
+    # shortDescription uses a nested-array shape:
+    #   outer index 0 → flat string (clean)
+    #   outer index 1 → inner list; inner index 0 is clean, inner index 1 contains HTML
+    # The linter should emit a diagnostic at shortDescription[1][1] for the HTML tag.
+    shortDescription:
+      - "Clean introductory paragraph."
+      - - "First bullet of nested list — no violation here."
+        - "Second bullet contains <strong>forbidden HTML</strong> at inner index 1."

--- a/scripts/hooks/tests/test_validate_prose_references.py
+++ b/scripts/hooks/tests/test_validate_prose_references.py
@@ -149,8 +149,15 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 # Field segment allows dotted paths (e.g. "tourContent.introduced").
 # The references linter embeds the token value directly in reason strings
 # (e.g. "... at 'riskBaz'"); the regex matches any non-empty reason.
+#
+# The optional second bracket group ``(?:\[\d+\])?`` accommodates the
+# nested-index extension (issue #285): when a violating token lives inside an
+# inner-list string the location becomes ``<field>[<outer>][<inner>]: <reason>``.
+# Flat-array diagnostics still emit the bare ``<field>[<outer>]:`` form.
 # ---------------------------------------------------------------------------
-_DIAG_PATTERN = re.compile(r"^validate-prose-references: [^:]+:[^:]+:[^:\[.]+(?:\.[^:\[.]+)*\[\d+\]: .+$")
+_DIAG_PATTERN = re.compile(
+    r"^validate-prose-references: [^:]+:[^:]+:[^:\[.]+(?:\.[^:\[.]+)*\[\d+\](?:\[\d+\])?: .+$"
+)
 
 # ---------------------------------------------------------------------------
 # Helpers for building synthetic YAML and schema fixtures
@@ -1695,3 +1702,278 @@ class TestDiagnosticPatternRedosResistance:
             f"diagnostic regex took {elapsed:.3f}s on redos seed; "
             f"should be linear-time (sub-millisecond).  CodeQL #21 may have regressed."
         )
+
+
+# ===========================================================================
+# TestNestedIndexDiagnostic
+# ===========================================================================
+
+
+class TestNestedIndexDiagnostic:
+    r"""Diagnostics on inner-list strings carry nested_index and emit [outer][inner].
+
+    Issue #285: when a prose-field value uses the nested-array shape
+    (``items: oneOf [string, array<string>]``), the references linter must
+    surface both the outer index and the inner index so the exact string can be
+    located.
+
+    Three behavioural contracts are verified here:
+
+    1. ``Diagnostic.nested_index`` is populated from ``ProseField.nested_index``
+       when the violating string came from an inner list.
+    2. The emitted stderr location string uses the ``[outer][inner]:`` form for
+       inner-list violations (not the ambiguous bare ``[outer]:`` form).
+    3. For flat-array violations (``nested_index is None``), the emitted line
+       is unchanged — the bare ``[outer]:`` form without a second bracket pair.
+    """
+
+    def _make_nested_field(
+        self,
+        raw_text: str,
+        index: int,
+        nested_index: int | None,
+        entry_id: str = "riskAlpha",
+        field_name: str = "shortDescription",
+    ) -> "ProseField":
+        r"""Build a ProseField that simulates an inner-list source string.
+
+        The ``nested_index`` argument is forwarded to ``ProseField`` so callers
+        can exercise both the nested (``nested_index=<int>``) and flat-array
+        (``nested_index=None``) paths without going through the full YAML
+        discovery pipeline.
+        """
+        from precommit._prose_tokens import tokenize  # noqa: PLC0415
+
+        return ProseField(
+            file_path=Path("risks.yaml"),
+            entry_id=entry_id,
+            field_name=field_name,
+            index=index,
+            raw_text=raw_text,
+            tokens=tokenize(raw_text),
+            nested_index=nested_index,
+        )
+
+    # ------------------------------------------------------------------
+    # 1. Diagnostic carries nested_index from ProseField
+    # ------------------------------------------------------------------
+
+    def test_diagnostic_nested_index_populated_from_prose_field(self):
+        r"""
+        Diagnostic.nested_index reflects the inner-list position from ProseField.
+
+        Given: A ProseField with index=3 and nested_index=1, containing a bare
+               camelCase identifier riskBeta (reference violation)
+        When: check_references is called with an empty IdIndex
+        Then: Every returned Diagnostic has .index == 3 and .nested_index == 1
+        """
+        idx = _make_index()
+        field = self._make_nested_field(
+            raw_text="The riskBeta attack is relevant here.",
+            index=3,
+            nested_index=1,
+        )
+        diags = check_references(field, idx)
+        assert len(diags) >= 1, "Expected at least one diagnostic for the bare camelCase ID"
+        for diag in diags:
+            assert diag.index == 3, f"Expected index=3, got {diag.index}"
+            assert diag.nested_index == 1, (
+                f"Expected nested_index=1 on Diagnostic; got {diag.nested_index!r}. "
+                "Diagnostic.nested_index must mirror ProseField.nested_index (issue #285)."
+            )
+
+    def test_diagnostic_nested_index_is_none_for_flat_array_field(self):
+        r"""
+        Diagnostic.nested_index is None when the source ProseField is a flat-array item.
+
+        Given: A ProseField with nested_index=None (flat-array shape), containing
+               a bare camelCase identifier violation
+        When: check_references is called
+        Then: Every returned Diagnostic has .nested_index is None
+        """
+        idx = _make_index()
+        field = self._make_nested_field(
+            raw_text="The riskBeta is mentioned in a flat array.",
+            index=2,
+            nested_index=None,
+        )
+        diags = check_references(field, idx)
+        assert len(diags) >= 1, "Expected at least one diagnostic for the bare camelCase ID"
+        for diag in diags:
+            assert diag.nested_index is None, (
+                f"Expected nested_index=None for flat-array ProseField; got {diag.nested_index!r}."
+            )
+
+    def test_diagnostic_nested_index_preserved_for_url_violation(self):
+        r"""
+        Diagnostic.nested_index is populated for inline-URL violations in inner-list strings.
+
+        Given: A ProseField with index=1 and nested_index=0, containing an inline URL
+        When: check_references is called
+        Then: The URL Diagnostic has .index == 1 and .nested_index == 0
+        """
+        idx = _make_index()
+        field = self._make_nested_field(
+            raw_text="See https://example.com for details.",
+            index=1,
+            nested_index=0,
+        )
+        diags = check_references(field, idx)
+        url_diags = [d for d in diags if "inline URL" in d.reason]
+        assert len(url_diags) >= 1, "Expected at least one URL diagnostic"
+        for diag in url_diags:
+            assert diag.index == 1
+            assert diag.nested_index == 0, f"Expected nested_index=0 on URL Diagnostic; got {diag.nested_index!r}."
+
+    # ------------------------------------------------------------------
+    # 2. Emitted location string uses [outer][inner] for nested violations
+    # ------------------------------------------------------------------
+
+    def test_emitted_stderr_contains_double_bracket_for_nested_violation(self, tmp_path, capsys):
+        r"""
+        main() emits ``<field>[<outer>][<inner>]:`` for inner-list violations.
+
+        Given: The reference_violations/nested_list_bare_camelcase.yaml fixture —
+               riskAlpha.shortDescription is a mixed array where outer index 1 is
+               a nested list; inner index 1 contains the bare camelCase ID 'riskBeta'
+        When: main() is called with the fixture file and an id-sources list that
+              does not contain riskBeta (so the bare ID is not a known entity)
+        Then: At least one stderr line contains 'shortDescription[1][1]:' exactly
+        """
+        schema_dir = _SCHEMA_DIR
+        yaml_path = _REF_VIOL_DIR / "nested_list_bare_camelcase.yaml"
+        # Build an ID index from the fixture itself (riskAlpha is declared there).
+        # riskBeta is NOT declared, so the bare identifier remains a violation.
+        idx_yaml = _write_yaml(tmp_path, "idx.yaml", {"risks": []})
+        with pytest.raises(SystemExit):
+            main(
+                [
+                    str(yaml_path),
+                    "--schema-dir",
+                    str(schema_dir),
+                    "--id-sources",
+                    str(idx_yaml),
+                ]
+            )
+        captured = capsys.readouterr()
+        lines = [ln for ln in captured.err.splitlines() if ln.strip()]
+        assert len(lines) >= 1, "Expected at least one diagnostic line"
+        double_bracket_lines = [ln for ln in lines if "shortDescription[1][1]:" in ln]
+        assert len(double_bracket_lines) >= 1, (
+            "Expected a line containing 'shortDescription[1][1]:' for the inner-index "
+            "diagnostic (issue #285). Got stderr lines:\n" + "\n".join(f"  {ln}" for ln in lines)
+        )
+
+    def test_emitted_location_uses_outer_inner_bracket_not_bare_outer(self, tmp_path, capsys):
+        r"""
+        The inner-list violation line does NOT collapse to the bare [outer]: form.
+
+        Given: The reference_violations/nested_list_bare_camelcase.yaml fixture
+        When: main() is called
+        Then: No stderr line for the inner-list violation contains
+              'shortDescription[1]:' without the second bracket pair
+        """
+        schema_dir = _SCHEMA_DIR
+        yaml_path = _REF_VIOL_DIR / "nested_list_bare_camelcase.yaml"
+        idx_yaml = _write_yaml(tmp_path, "idx.yaml", {"risks": []})
+        with pytest.raises(SystemExit):
+            main(
+                [
+                    str(yaml_path),
+                    "--schema-dir",
+                    str(schema_dir),
+                    "--id-sources",
+                    str(idx_yaml),
+                ]
+            )
+        captured = capsys.readouterr()
+        lines = [ln for ln in captured.err.splitlines() if ln.strip()]
+        bare_outer_lines = [
+            ln for ln in lines if "shortDescription[1]:" in ln and "shortDescription[1][" not in ln
+        ]
+        assert len(bare_outer_lines) == 0, (
+            f"Expected NO bare 'shortDescription[1]:' lines for an inner-list violation; "
+            f"found {len(bare_outer_lines)} line(s):\n"
+            + "\n".join(f"  {ln}" for ln in bare_outer_lines)
+            + "\nAll lines:\n"
+            + "\n".join(f"  {ln}" for ln in lines)
+        )
+
+    def test_all_nested_diagnostic_lines_match_extended_format_regex(self, tmp_path, capsys):
+        r"""
+        Every stderr line from the nested-violation fixture matches _DIAG_PATTERN.
+
+        Given: The reference_violations/nested_list_bare_camelcase.yaml fixture
+        When: main() is called
+        Then: All non-empty stderr lines match the updated _DIAG_PATTERN, which
+              accepts the optional second bracket pair ``(?:\[\d+\])?``
+        """
+        schema_dir = _SCHEMA_DIR
+        yaml_path = _REF_VIOL_DIR / "nested_list_bare_camelcase.yaml"
+        idx_yaml = _write_yaml(tmp_path, "idx.yaml", {"risks": []})
+        with pytest.raises(SystemExit):
+            main(
+                [
+                    str(yaml_path),
+                    "--schema-dir",
+                    str(schema_dir),
+                    "--id-sources",
+                    str(idx_yaml),
+                ]
+            )
+        captured = capsys.readouterr()
+        lines = [ln for ln in captured.err.splitlines() if ln.strip()]
+        assert len(lines) >= 1
+        for line in lines:
+            assert _DIAG_PATTERN.match(line), f"Diagnostic line does not match extended _DIAG_PATTERN: {line!r}"
+
+    # ------------------------------------------------------------------
+    # 3. Flat-array format is unchanged (nested_index is None path)
+    # ------------------------------------------------------------------
+
+    def test_flat_array_diagnostic_emits_single_bracket_only(self, tmp_path, capsys):
+        r"""
+        A flat-array violation still emits only [outer]: with no second bracket pair.
+
+        Given: A YAML with a flat-array shortDescription containing a URL violation
+               at outer index 1 (nested_index=None)
+        When: main() is called
+        Then: The stderr line contains '[1]:' and does NOT contain '[1][':
+              confirming the flat-array format is byte-for-byte unchanged
+        """
+        schema_dir = tmp_path / "schemas"
+        schema_dir.mkdir()
+        _write_mock_schema(schema_dir, "risk", ["riskAlpha"])
+        yaml_path = _write_yaml(
+            tmp_path,
+            "risks.yaml",
+            {
+                "risks": [
+                    _make_risk(
+                        "riskAlpha",
+                        description=["Clean first paragraph.", "See https://example.com here."],
+                    )
+                ]
+            },
+        )
+        idx_yaml = _write_yaml(tmp_path, "idx.yaml", {"risks": []})
+        with pytest.raises(SystemExit):
+            main(
+                [
+                    str(yaml_path),
+                    "--schema-dir",
+                    str(schema_dir),
+                    "--id-sources",
+                    str(idx_yaml),
+                ]
+            )
+        captured = capsys.readouterr()
+        lines = [ln for ln in captured.err.splitlines() if ln.strip()]
+        assert len(lines) >= 1, "Expected at least one diagnostic for the URL"
+        desc_lines = [ln for ln in lines if "description" in ln]
+        assert len(desc_lines) >= 1
+        for line in desc_lines:
+            assert re.search(r"description\[\d+\]:", line), f"Expected single-bracket form in: {line!r}"
+            assert not re.search(r"description\[\d+\]\[\d+\]:", line), (
+                f"Flat-array line must not contain double brackets: {line!r}"
+            )

--- a/scripts/hooks/tests/test_validate_yaml_prose_subset.py
+++ b/scripts/hooks/tests/test_validate_yaml_prose_subset.py
@@ -197,8 +197,15 @@ def _make_control(control_id: str, description: list[str] | None = None) -> dict
 # Field segment allows dotted paths (e.g. "tourContent.introduced") — dots are
 # permitted but no additional colons.  The reason segment now requires the
 # ADR-017 D4 "at '<snippet>'" suffix.
+#
+# The optional second bracket group ``(?:\[\d+\])?`` accommodates the
+# nested-index extension (issue #285): when a violating token lives inside an
+# inner-list string the location becomes ``<field>[<outer>][<inner>]: <reason>``.
+# Flat-array diagnostics still emit the bare ``<field>[<outer>]:`` form.
 # ---------------------------------------------------------------------------
-_DIAG_PATTERN = re.compile(r"^validate-yaml-prose-subset: [^:]+:[^:]+:[^:\[.]+(?:\.[^:\[.]+)*\[\d+\]: .+ at '.*'$")
+_DIAG_PATTERN = re.compile(
+    r"^validate-yaml-prose-subset: [^:]+:[^:]+:[^:\[.]+(?:\.[^:\[.]+)*\[\d+\](?:\[\d+\])?: .+ at '.*'$"
+)
 
 
 # ===========================================================================
@@ -974,9 +981,20 @@ class TestDiagnosticFormat:
         return check_prose_field(field)
 
     def _diag_to_line(self, diag: "Diagnostic") -> str:
-        r"""Convert a Diagnostic to its string representation."""
-        idx_str = f"[{diag.index}]" if diag.index is not None else ""
-        return f"{diag.hook_id}: {diag.file_path}:{diag.entry_id}:{diag.field_name}{idx_str}: {diag.reason}"
+        r"""Convert a Diagnostic to its string representation.
+
+        Matches the ``_emit_diagnostic`` format:
+        ``<hook_id>: <file>:<entry_id>:<field>[<index>][<nested_index>]: <reason>``
+
+        The optional ``[<nested_index>]`` segment is appended only when
+        ``diag.nested_index is not None`` (issue #285 extension).
+        """
+        idx_str = f"[{diag.index}]" if diag.index is not None else "[0]"
+        nested_str = f"[{diag.nested_index}]" if getattr(diag, "nested_index", None) is not None else ""
+        return (
+            f"{diag.hook_id}: {diag.file_path}:{diag.entry_id}:"
+            f"{diag.field_name}{idx_str}{nested_str}: {diag.reason}"
+        )
 
     def test_diagnostic_hook_id_is_correct(self):
         r"""
@@ -1771,3 +1789,237 @@ class TestFoldedBulletVsListAtColumn0:
             tokens=tokens,
         )
         assert len(check_prose_field(field)) >= 1
+
+
+# ===========================================================================
+# TestNestedIndexDiagnostic
+# ===========================================================================
+
+
+class TestNestedIndexDiagnostic:
+    r"""Diagnostics on inner-list strings carry nested_index and emit [outer][inner].
+
+    Issue #285: when a prose-field value uses the nested-array shape
+    (``items: oneOf [string, array<string>]``), the linter must surface both
+    the outer index and the inner index so the exact string can be located.
+
+    Three behavioural contracts are verified here:
+
+    1. ``Diagnostic.nested_index`` is populated from ``ProseField.nested_index``
+       when the violating string came from an inner list.
+    2. The emitted stderr location string uses the ``[outer][inner]:`` form for
+       inner-list violations (not the ambiguous bare ``[outer]:`` form).
+    3. For flat-array violations (``nested_index is None``), the emitted line
+       is unchanged — the bare ``[outer]:`` form without a second bracket pair.
+    """
+
+    def _make_nested_field(
+        self,
+        raw_text: str,
+        index: int,
+        nested_index: int | None,
+        field_name: str = "shortDescription",
+        entry_id: str = "riskAlpha",
+    ) -> "ProseField":
+        r"""Build a ProseField that simulates an inner-list source string.
+
+        The ``nested_index`` argument is forwarded to ``ProseField`` so callers
+        can exercise both the nested (``nested_index=<int>``) and flat-array
+        (``nested_index=None``) paths without going through the full YAML
+        discovery pipeline.
+        """
+        from precommit._prose_tokens import tokenize  # noqa: PLC0415
+
+        return ProseField(
+            file_path=Path("risks.yaml"),
+            entry_id=entry_id,
+            field_name=field_name,
+            index=index,
+            raw_text=raw_text,
+            tokens=tokenize(raw_text),
+            nested_index=nested_index,
+        )
+
+    # ------------------------------------------------------------------
+    # 1. Diagnostic carries nested_index from ProseField
+    # ------------------------------------------------------------------
+
+    def test_diagnostic_nested_index_populated_from_prose_field(self):
+        r"""
+        Diagnostic.nested_index reflects the inner-list position from ProseField.
+
+        Given: A ProseField with index=3 and nested_index=1, containing an HTML
+               tag violation
+        When: check_prose_field is called
+        Then: Every returned Diagnostic has .index == 3 and .nested_index == 1
+        """
+        field = self._make_nested_field(
+            raw_text="See <br/> in an inner-list string.",
+            index=3,
+            nested_index=1,
+        )
+        diags = check_prose_field(field)
+        assert len(diags) >= 1, "Expected at least one diagnostic for the HTML tag"
+        for diag in diags:
+            assert diag.index == 3, f"Expected index=3, got {diag.index}"
+            assert diag.nested_index == 1, (
+                f"Expected nested_index=1 on Diagnostic; got {diag.nested_index!r}. "
+                "Diagnostic.nested_index must mirror ProseField.nested_index (issue #285)."
+            )
+
+    def test_diagnostic_nested_index_is_none_for_flat_array_field(self):
+        r"""
+        Diagnostic.nested_index is None when the source ProseField is a flat-array item.
+
+        Given: A ProseField with nested_index=None (flat-array shape), containing
+               an HTML tag violation
+        When: check_prose_field is called
+        Then: Every returned Diagnostic has .nested_index is None
+        """
+        field = self._make_nested_field(
+            raw_text="See <br/> in a flat-array string.",
+            index=2,
+            nested_index=None,
+        )
+        diags = check_prose_field(field)
+        assert len(diags) >= 1, "Expected at least one diagnostic for the HTML tag"
+        for diag in diags:
+            assert diag.nested_index is None, (
+                f"Expected nested_index=None for flat-array ProseField; got {diag.nested_index!r}."
+            )
+
+    def test_diagnostic_nested_index_preserved_across_multiple_violations(self):
+        r"""
+        All Diagnostics from one inner-list ProseField share the same nested_index.
+
+        Given: A ProseField with nested_index=0 containing two HTML tags
+               (<strong>...</strong>)
+        When: check_prose_field is called
+        Then: At least two Diagnostics are returned and all have nested_index == 0
+        """
+        field = self._make_nested_field(
+            raw_text="The <strong>critical</strong> path.",
+            index=1,
+            nested_index=0,
+        )
+        diags = check_prose_field(field)
+        assert len(diags) >= 2, "Expected diagnostics for both <strong> and </strong> tags"
+        for diag in diags:
+            assert diag.nested_index == 0, (
+                f"All Diagnostics from one inner-list field must share nested_index=0; got {diag.nested_index!r}."
+            )
+
+    # ------------------------------------------------------------------
+    # 2. Emitted location string uses [outer][inner] for nested violations
+    # ------------------------------------------------------------------
+
+    def test_emitted_stderr_contains_double_bracket_for_nested_violation(self, tmp_path, capsys):
+        r"""
+        main() emits ``<field>[<outer>][<inner>]:`` for inner-list violations.
+
+        Given: The subset_violations/nested_list_html_violation.yaml fixture —
+               riskAlpha.shortDescription is a mixed array where outer index 1 is
+               a nested list; inner index 1 contains ``<strong>forbidden HTML</strong>``
+        When: main() is called with the fixture file
+        Then: At least one stderr line contains 'shortDescription[1][1]:' exactly
+              (confirming both the outer and inner index are surfaced)
+        """
+        schema_dir = _SCHEMA_DIR
+        yaml_path = _SUBSET_VIOL_DIR / "nested_list_html_violation.yaml"
+        with pytest.raises(SystemExit):
+            main([str(yaml_path), "--schema-dir", str(schema_dir)])
+        captured = capsys.readouterr()
+        lines = [ln for ln in captured.err.splitlines() if ln.strip()]
+        assert len(lines) >= 1, "Expected at least one diagnostic line"
+        double_bracket_lines = [ln for ln in lines if "shortDescription[1][1]:" in ln]
+        assert len(double_bracket_lines) >= 1, (
+            "Expected a line containing 'shortDescription[1][1]:' for the inner-index "
+            "diagnostic (issue #285). Got stderr lines:\n" + "\n".join(f"  {ln}" for ln in lines)
+        )
+
+    def test_emitted_location_uses_outer_inner_bracket_not_bare_outer(self, tmp_path, capsys):
+        r"""
+        The inner-list violation line does NOT collapse to the bare [outer]: form.
+
+        Given: The subset_violations/nested_list_html_violation.yaml fixture
+        When: main() is called
+        Then: No stderr line for the inner-list violation contains
+              'shortDescription[1]:' without the second bracket pair
+              (i.e., the bare [outer]: form is NOT emitted for inner-list strings)
+        """
+        schema_dir = _SCHEMA_DIR
+        yaml_path = _SUBSET_VIOL_DIR / "nested_list_html_violation.yaml"
+        with pytest.raises(SystemExit):
+            main([str(yaml_path), "--schema-dir", str(schema_dir)])
+        captured = capsys.readouterr()
+        lines = [ln for ln in captured.err.splitlines() if ln.strip()]
+        # A bare [1]: would look like "shortDescription[1]: " (no second bracket).
+        # We verify no diagnostic line matches the ambiguous-collapse form.
+        bare_outer_lines = [
+            ln for ln in lines if "shortDescription[1]:" in ln and "shortDescription[1][" not in ln
+        ]
+        assert len(bare_outer_lines) == 0, (
+            f"Expected NO bare 'shortDescription[1]:' lines for an inner-list violation; "
+            f"found {len(bare_outer_lines)} line(s):\n"
+            + "\n".join(f"  {ln}" for ln in bare_outer_lines)
+            + "\nAll lines:\n"
+            + "\n".join(f"  {ln}" for ln in lines)
+        )
+
+    def test_all_nested_diagnostic_lines_match_extended_format_regex(self, tmp_path, capsys):
+        r"""
+        Every stderr line from the nested-violation fixture matches _DIAG_PATTERN.
+
+        Given: The subset_violations/nested_list_html_violation.yaml fixture
+        When: main() is called
+        Then: All non-empty stderr lines match the updated _DIAG_PATTERN, which
+              accepts the optional second bracket pair ``(?:\[\d+\])?``
+        """
+        schema_dir = _SCHEMA_DIR
+        yaml_path = _SUBSET_VIOL_DIR / "nested_list_html_violation.yaml"
+        with pytest.raises(SystemExit):
+            main([str(yaml_path), "--schema-dir", str(schema_dir)])
+        captured = capsys.readouterr()
+        lines = [ln for ln in captured.err.splitlines() if ln.strip()]
+        assert len(lines) >= 1
+        for line in lines:
+            assert _DIAG_PATTERN.match(line), f"Diagnostic line does not match extended _DIAG_PATTERN: {line!r}"
+
+    # ------------------------------------------------------------------
+    # 3. Flat-array format is unchanged (nested_index is None path)
+    # ------------------------------------------------------------------
+
+    def test_flat_array_diagnostic_emits_single_bracket_only(self, tmp_path, capsys):
+        r"""
+        A flat-array violation still emits only [outer]: with no second bracket pair.
+
+        Given: A YAML with a flat-array shortDescription containing one HTML violation
+               at outer index 0 (nested_index=None)
+        When: main() is called
+        Then: The stderr line contains '[0]:' and does NOT contain '[0][':
+              confirming the flat-array format is byte-for-byte unchanged
+        """
+        schema_dir = tmp_path / "schemas"
+        schema_dir.mkdir()
+        prose_ref = {"$ref": "riskmap.schema.json#/definitions/utils/text"}
+        _write_mock_schema(schema_dir, "risk", ["riskAlpha"], extra_props={"shortDescription": prose_ref})
+        yaml_path = _write_yaml(
+            tmp_path,
+            "risks.yaml",
+            {"risks": [_make_risk("riskAlpha", short=["Clean.", "See <br/> in flat array."])]},
+        )
+        with pytest.raises(SystemExit):
+            main([str(yaml_path), "--schema-dir", str(schema_dir)])
+        captured = capsys.readouterr()
+        lines = [ln for ln in captured.err.splitlines() if ln.strip()]
+        assert len(lines) >= 1, "Expected at least one diagnostic for the HTML tag"
+        # All lines for shortDescription must have single-bracket only.
+        desc_lines = [ln for ln in lines if "shortDescription" in ln]
+        assert len(desc_lines) >= 1
+        for line in desc_lines:
+            # Must contain single-bracket form.
+            assert re.search(r"shortDescription\[\d+\]:", line), f"Expected single-bracket form in: {line!r}"
+            # Must NOT contain double-bracket form.
+            assert not re.search(r"shortDescription\[\d+\]\[\d+\]:", line), (
+                f"Flat-array line must not contain double brackets: {line!r}"
+            )


### PR DESCRIPTION
## precommit: surface nested_index in prose-linter diagnostic output

Closes #285

## Summary

- The prose-field schema (`riskmap.schema.json#/definitions/utils/text`) admits one level of nesting (`items: oneOf [string, array<string>]`). PR #262 taught `_prose_fields.py` to yield one `ProseField` per inner string with a `nested_index: int | None`, but the linters' diagnostic emitters never surfaced it — so every violation on the inner strings of a nested list collapsed to the same `<field>[<outer>]:` location, indistinguishable from each other.
- This PR threads `nested_index` through to `Diagnostic` and emits it as a second segment: a violation on an inner-list string now reads `<field>[<outer>][<inner>]:`. Flat-array and bare-scalar diagnostics are **byte-for-byte unchanged** (`nested_index is None` keeps the existing format, including the `[0]` fallback).
- The location-string formatter — previously duplicated across both linters' `_emit_diagnostic()` and a test helper — is lifted into a single shared `format_diagnostic_line(diag)` in `_linter_types.py` (the module that owns `Diagnostic`; `_prose_fields.py` doesn't import `Diagnostic`, so hosting it there would have added a dependency edge). Both `_emit_diagnostic()` are now thin delegations — zero format drift possible between the two linters.
- ADR-017 D4's documented "Rejection format" line is amended to spell out the `[<outer>][<inner>]` form (scope-by-decision: the change moves the documented contract, so the contract doc moves with it). ADR-016 has no analogous format declaration — nothing owed there.

## What changed

- **`scripts/hooks/precommit/_linter_types.py`** — `Diagnostic` NamedTuple gains `nested_index: int | None = None` (appended last, defaulted — additive, no positional-construction breakage); new `format_diagnostic_line(diag) -> str`; new `__all__`.
- **`scripts/hooks/precommit/validate_yaml_prose_subset.py`** — `check_prose_field()` passes `nested_index=field.nested_index`; `_emit_diagnostic()` delegates to `format_diagnostic_line`.
- **`scripts/hooks/precommit/validate_prose_references.py`** — `check_references()`'s `_diag()` helper passes `nested_index=field.nested_index`; `_emit_diagnostic()` delegates.
- **`docs/adr/017-yaml-prose-authoring-subset.md`** — D4 "Rejection format" bullet documents the `<field>[<outer>][<inner>]` form for inner-list paragraphs.
- **`scripts/hooks/tests/test_validate_yaml_prose_subset.py`**, **`scripts/hooks/tests/test_validate_prose_references.py`** — `_DIAG_PATTERN` widened (`\[\d+\]` → `\[\d+\](?:\[\d+\])?`); new `TestNestedIndexDiagnostic` class (7 tests each) asserting the `Diagnostic.nested_index` value, the `[outer][inner]:` stderr form, and the unchanged flat-array form.
- **New fixtures:** `scripts/hooks/tests/fixtures/wrapper_linters/subset_violations/nested_list_html_violation.yaml`, `scripts/hooks/tests/fixtures/wrapper_linters/reference_violations/nested_list_bare_camelcase.yaml` — minimal mixed-shape prose fields with a single deterministic violation at `[1][1]`.

## Scope boundaries

In scope:
- Both prose-aware linter emitters (the only two that produce a `<file>:<entry-id>:<field>[<index>]` location string — verified by repo-wide grep of `Diagnostic(`, `_emit_diagnostic`, and the `validate-*-prose-*:` literals; no third emitter, no parser/consumer of the diagnostic line, no positional `Diagnostic(*args)` construction).
- The shared `Diagnostic` shape (one additive defaulted field).
- ADR-017 D4's documented format string.

Out of scope:
- Block-mode flip on the warn-only prose linters → sweep-closing sub-PR (ADR-017 plan § 2.7.1). That PR is the consumer that makes this format operator-facing in CI logs; it should cite #285.
- Operator-side tooling that parses the diagnostic line (none exists today).
- Non-prose validators (component-edge, control-risk-reference, etc.) — different domain, not subject to the `<field>[<index>]` format.

## Live-corpus effect (`risk-map/yaml/*.yaml`)

| | before | after |
|---|---:|---:|
| `validate-yaml-prose-subset` diagnostics (total) | 177 | 177 |
| `validate-prose-references` diagnostics (total) | 170 | 170 |
| subset lines now carrying `[<outer>][<inner>]` | 0 | 19 |
| references lines now carrying `[<outer>][<inner>]` | 0 | 16 |

Totals are unchanged — the same tokens are reported; only the location string disambiguates inner-list strings. The new double-bracket lines land on the 3 nested-list sites in `risks.yaml` (`riskInsecureIntegratedComponent.longDescription[3]` → `[3][0]`/`[3][1]`; `riskSensitiveDataDisclosure.longDescription[3]`; `riskRogueActions.longDescription[2]`).

## Review

TDD chain (testing → code-reviewer → swe → code-reviewer) plus a full-branch Opus review. Verdict: **APPROVE-WITH-NITS**, both nits fixed before commit and folded into `e42b248`:
- A stale pre-implementation parenthetical (`"... field not yet added to Diagnostic NamedTuple"`) in two test assertion messages — removed (the field *is* added).
- ADR-017 D4's format line didn't reflect the new `[<outer>][<inner>]` form — amended.

Remaining nits judged not-worth-churn: a defensive `getattr(diag, "nested_index", None)` in the `_diag_to_line` test helper (always present now); `__all__` placement above the `sys.path` shim in `_linter_types.py`.

## Test plan

- [x] `pytest scripts/hooks/tests/test_validate_yaml_prose_subset.py scripts/hooks/tests/test_validate_prose_references.py scripts/hooks/tests/test_prose_field_shape_coverage.py` → 197 passed
- [x] `pytest` (full repo) → 2491 passed / 6 skipped / 0 failed
- [x] `ruff check` + `ruff format --check` on all 5 modified `.py` files → clean
- [x] Live corpus: `validate_yaml_prose_subset.py` / `validate_prose_references.py` on `risk-map/yaml/*.yaml` → 177 / 170 totals unchanged; `[outer][inner]` form present on the 3 nested-list sites
- [x] No phasing / orchestration leakage in tracked code (no `gh-drafts/`, `working-plans/`, `.worktree/`, branch-name, or RED/GREEN-phase references)

