### PR TITLE
Update dependency packages to reduce vulnerability risk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,10 @@
   "packages": {
     "": {
       "dependencies": {
-        "@mermaid-js/mermaid-cli": "^11.14.0",
-        "playwright": "1.59.1",
+        "@mermaid-js/mermaid-cli": "^11.15.0",
+        "playwright": "1.60.0",
         "prettier": "^3.8.3",
-        "puppeteer": "24.43.0"
+        "puppeteer": "24.43.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -155,6 +155,15 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.2.0.tgz",
+      "integrity": "sha512-3DguDv/oUE+7vjMeTSOjCSG+KeawgVQOHrKRnvUuqYh1mfArrh7s+s8hXW3e4RerBA1+Wh+hBqf8sJNpqNrBWg==",
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@headlessui/react": {
       "version": "2.2.9",
       "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.9.tgz",
@@ -267,24 +276,43 @@
         "mermaid": "^11.0.2"
       }
     },
+    "node_modules/@mermaid-js/layout-tidy-tree": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/layout-tidy-tree/-/layout-tidy-tree-0.2.2.tgz",
+      "integrity": "sha512-8RmjDXjKJBxqTS1mICStm8zWRM45fSzs0SOrkp28+KsOGS2YEMFMVTwwRU8CsC6M1L+pDYZVjf1m9AC1c9Wndg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "d3": "^7.9.0"
+      },
+      "peerDependencies": {
+        "mermaid": "^11.0.2"
+      }
+    },
     "node_modules/@mermaid-js/mermaid-cli": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-cli/-/mermaid-cli-11.14.0.tgz",
-      "integrity": "sha512-8tURXUFVSc1x4i0fmgJOUleT8w3KyW3Jixt9YLJ2zQVfaVArViIXD7DuJLRlYds1tdExsnvSK/qf6pCNdyU+Vw==",
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-cli/-/mermaid-cli-11.15.0.tgz",
+      "integrity": "sha512-rmz9ELKtmKQvRcYJGI2e509FK9yCBvmEVfHeRSYkleGqo6qqh8LFooxRPCqq04uVx3JHMp9g/vmM85gi/QFFlQ==",
       "license": "MIT",
       "dependencies": {
-        "@mermaid-js/layout-elk": "^0.1.2 || ^0.2.0",
+        "@fortawesome/fontawesome-free": "^6.0.0 || ^7.0.1",
+        "@mermaid-js/layout-elk": "^0.1.5 || ^0.2.0",
         "@mermaid-js/mermaid-zenuml": "^0.2.0",
         "chalk": "^5.0.1",
         "commander": "^13.1.0",
         "import-meta-resolve": "^4.1.0",
-        "mermaid": "^11.14.0"
+        "katex": "^0.16.25",
+        "mermaid": "^11.14.0",
+        "p-limit": "^6.2.0"
       },
       "bin": {
         "mmdc": "src/cli.js"
       },
       "engines": {
         "node": "^18.19 || >=20.0"
+      },
+      "optionalDependencies": {
+        "@mermaid-js/layout-tidy-tree": "^0.2.1"
       },
       "peerDependencies": {
         "puppeteer": "^23 || ^24"
@@ -347,9 +375,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.1.tgz",
-      "integrity": "sha512-zmS4RTK9fbrc++WlAJhxYbfz3IjDeOmkK/CwwbLmk7ydfS9e2CiEeRJHEPvjDVElO/bwXbidwGA37Bsm6LzCnQ==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.4.3",
@@ -766,13 +794,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
-      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+      "version": "25.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
+      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~7.21.0"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -2824,6 +2852,21 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-limit": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/pac-proxy-agent": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
@@ -3008,12 +3051,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3026,9 +3069,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -3298,17 +3341,17 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.43.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.43.0.tgz",
-      "integrity": "sha512-DRnMFz+J3s4lFUQcjqKl0/7h0jzlCZuUFU9lNjtKrnMl5WI1RwCaIItpHVu9empuPyUreYueN0sUW3/pnfdqsg==",
+      "version": "24.43.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.43.1.tgz",
+      "integrity": "sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.13.1",
+        "@puppeteer/browsers": "2.13.2",
         "chromium-bidi": "14.0.0",
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1608973",
-        "puppeteer-core": "24.43.0",
+        "puppeteer-core": "24.43.1",
         "typed-query-selector": "^2.12.2"
       },
       "bin": {
@@ -3319,12 +3362,12 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.43.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.0.tgz",
-      "integrity": "sha512-cCRNXsUlhyPoKDz6+TiSpfZpRS3mD6Y1YFKhkdr6ik6TMfuJb7fAtXq9ThUFc4sphxObDk3BuAvdxc1Y6YOnqQ==",
+      "version": "24.43.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
+      "integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.13.1",
+        "@puppeteer/browsers": "2.13.2",
         "chromium-bidi": "14.0.0",
         "debug": "^4.4.3",
         "devtools-protocol": "0.0.1608973",
@@ -3993,9 +4036,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
+      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
       "license": "MIT",
       "optional": true
     },
@@ -4106,9 +4149,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -4170,6 +4213,18 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
+    "@mermaid-js/mermaid-cli": "^11.15.0",
+    "playwright": "1.60.0",
     "prettier": "^3.8.3",
-    "puppeteer": "24.43.0",
-    "playwright": "1.59.1",
-    "@mermaid-js/mermaid-cli": "^11.14.0"
+    "puppeteer": "24.43.1"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ pytest-cov==7.1.0
 pytest-timeout==2.4.0
 PyYAML==6.0.3
 ruff==0.15.12
-pandas==3.0.2
+pandas==3.0.3
 tabulate==0.10.0


### PR DESCRIPTION
## Summary

This PR updates direct dependency pins and the Node lockfile for the repository toolchain:

- Bumps `@mermaid-js/mermaid-cli` from `^11.14.0` to `^11.15.0`
- Bumps `playwright` from `1.59.1` to `1.60.0`
- Bumps `puppeteer` from `24.43.0` to `24.43.1`
- Bumps `pandas` from `3.0.2` to `3.0.3`

## Notes

This is a non-content dependency update, so it targets `main` per `CONTRIBUTING.md`.

`npm audit fix` was not run because it requires sending the repository dependency inventory to the external npm audit endpoint.

## Validation

- `npm install --ignore-scripts --cache /private/tmp/npm-cache --logs-dir /private/tmp/npm-logs`
- `npm audit --json --offline --cache /private/tmp/npm-cache --logs-dir /private/tmp/npm-logs`
- `uvx pip-audit -r requirements.txt --format json --no-deps --disable-pip --progress-spinner off`
- `ruff check .`
- `node --test site/tests/*.test.mjs`
- `prettier --check package.json`
- `git diff --check`

Full pytest result:

- `2479 passed`
- `10 skipped`
- `2 failed`

Known local/environment failures:

- `scripts/hooks/tests/test_install_deps.py::TestSkipChromiumWhenPresent::test_chromium_in_cache_emits_skip`
- `scripts/hooks/tests/test_verify_deps.py::TestAllDepsPresent::test_all_dependencies_present_exit_0`

The second failure is due to the local Python version being `3.12.10` while `scripts/tools/verify-deps.sh` requires Python `>= 3.14`.
