### PR TITLE
Add local generated table drift checking

### DIFF
--- a/risk-map/docs/validation.md
+++ b/risk-map/docs/validation.md
@@ -107,7 +107,8 @@ python3 scripts/hooks/yaml_to_markdown.py components --format summary
 
 This strict mode generates tables in a temporary directory, compares them with
 `risk-map/tables/`, and exits non-zero when drift is found. It does not update
-tracked files or change the git index.
+tracked files or change the git index. Any warnings the generator writes to
+stderr still surface in the output; only generator stdout is suppressed.
 
 **Available formats:**
 

--- a/risk-map/docs/validation.md
+++ b/risk-map/docs/validation.md
@@ -98,6 +98,17 @@ python3 scripts/hooks/yaml_to_markdown.py controls --format xref-risks
 python3 scripts/hooks/yaml_to_markdown.py components --format summary
 ```
 
+**Pre-push drift check:**
+
+```bash
+# Verify committed tables match generated output without modifying the tree
+./scripts/tools/validate-all.sh --check-generation
+```
+
+This strict mode generates tables in a temporary directory, compares them with
+`risk-map/tables/`, and exits non-zero when drift is found. It does not update
+tracked files or change the git index.
+
 **Available formats:**
 
 - `full` - Complete tables with all columns (default)

--- a/risk-map/docs/validation.md
+++ b/risk-map/docs/validation.md
@@ -107,8 +107,8 @@ python3 scripts/hooks/yaml_to_markdown.py components --format summary
 
 This strict mode generates tables in a temporary directory, compares them with
 `risk-map/tables/`, and exits non-zero when drift is found. It does not update
-tracked files or change the git index. Any warnings the generator writes to
-stderr still surface in the output; only generator stdout is suppressed.
+tracked files or change the git index. Generator errors print to stdout
+regardless of `--quiet`; only the generator's progress lines are suppressed.
 
 **Available formats:**
 

--- a/scripts/docs/manual-validation.md
+++ b/scripts/docs/manual-validation.md
@@ -39,6 +39,11 @@ the prior `pre-commit.sh --force` workflow.
 # Validate everything, no commit, no regeneration:
 ./scripts/tools/validate-all.sh
 
+# Validate everything and verify generated markdown tables are current.
+# This writes generated tables only to a temporary directory and does not
+# change tracked files or the git index:
+./scripts/tools/validate-all.sh --check-generation
+
 # Help:
 ./scripts/tools/validate-all.sh --help
 ```

--- a/scripts/hooks/tests/test_validate_all_tool.py
+++ b/scripts/hooks/tests/test_validate_all_tool.py
@@ -230,6 +230,26 @@ def test_check_generation_cleans_tempdir_on_sigint(tmp_path: Path):
     assert not (tmp_path / "git-invocations.log").exists()
 
 
+def test_check_generation_fails_cleanly_when_mktemp_fails(tmp_path: Path):
+    """A failing `mktemp -d` must surface as a clean validator failure, not
+    cascade into a write outside the temp tree (e.g. mkdir -p "/tables").
+    """
+    repo, env = _make_stubbed_repo(tmp_path)
+    before_status = _git_status(repo)
+
+    # Override mktemp on PATH so the script's `mktemp -d` returns non-zero
+    # with no stdout. This simulates a full TMPDIR or permission failure.
+    stub_bin = Path(env["PATH"].split(os.pathsep)[0])
+    _write_executable(stub_bin / "mktemp", "#!/bin/bash\nexit 1\n")
+
+    result = _run_validate_all(repo, env, "--check-generation")
+
+    assert result.returncode == 1
+    assert "Could not create temporary directory" in result.stdout
+    _assert_repo_unchanged(repo, before_status)
+    assert not (tmp_path / "git-invocations.log").exists()
+
+
 def test_help_documents_check_generation_purity_contract(tmp_path: Path):
     repo, env = _make_stubbed_repo(tmp_path)
 

--- a/scripts/hooks/tests/test_validate_all_tool.py
+++ b/scripts/hooks/tests/test_validate_all_tool.py
@@ -14,6 +14,8 @@ import subprocess
 import time
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).parent.parent.parent.parent
 SCRIPT_SOURCE = REPO_ROOT / "scripts" / "tools" / "validate-all.sh"
 REAL_GIT = shutil.which("git")
@@ -92,7 +94,13 @@ def _make_stubbed_repo(tmp_path: Path, table_content: str = "canonical\n") -> tu
         'if [[ "$1" == "scripts/hooks/yaml_to_markdown.py" ]]; then\n'
         '    output_dir=""\n'
         "    while [[ $# -gt 0 ]]; do\n"
-        '        if [[ "$1" == "--output-dir" ]]; then\n'
+        # Tolerate both --output-dir <DIR> and --output-dir=<DIR> forms so a
+        # later refactor of the script invocation doesn't silently capture
+        # an empty path.
+        '        if [[ "$1" == --output-dir=* ]]; then\n'
+        '            output_dir="${1#*=}"\n'
+        "            shift\n"
+        '        elif [[ "$1" == "--output-dir" ]]; then\n'
         '            output_dir="$2"\n'
         "            shift 2\n"
         "        else\n"
@@ -198,7 +206,11 @@ def test_check_generation_cleans_tempdir_when_generator_fails(tmp_path: Path):
     assert not (tmp_path / "git-invocations.log").exists()
 
 
-def test_check_generation_cleans_tempdir_on_sigint(tmp_path: Path):
+@pytest.mark.parametrize("sig", [signal.SIGINT, signal.SIGTERM], ids=["sigint", "sigterm"])
+def test_check_generation_cleans_tempdir_on_signal(tmp_path: Path, sig: signal.Signals):
+    """The trap installed by check_generated_tables covers INT and TERM;
+    both signal paths must clean up the temp directory.
+    """
     repo, env = _make_stubbed_repo(tmp_path)
     before_status = _git_status(repo)
     temp_capture = tmp_path / "tempdir.txt"
@@ -221,12 +233,32 @@ def test_check_generation_cleans_tempdir_on_sigint(tmp_path: Path):
 
     assert temp_capture.exists(), "generator stub did not capture the temporary directory"
     temp_dir = Path(temp_capture.read_text(encoding="utf-8").strip())
-    os.killpg(process.pid, signal.SIGINT)
+    os.killpg(process.pid, sig)
     stdout, stderr = process.communicate(timeout=10)
 
     assert process.returncode != 0, stderr + stdout
     _assert_repo_unchanged(repo, before_status)
     assert not temp_dir.exists()
+    assert not (tmp_path / "git-invocations.log").exists()
+
+
+def test_check_generation_flags_extra_file_in_tables_dir(tmp_path: Path):
+    """`diff -r -q` must report drift when risk-map/tables contains a file
+    that the generator does not produce (e.g. a stale rename leftover).
+    """
+    repo, env = _make_stubbed_repo(tmp_path)
+    stale_file = repo / "risk-map" / "tables" / "stale-leftover.md"
+    stale_file.write_text("orphan\n", encoding="utf-8")
+    _run_git(repo, "add", "risk-map/tables/stale-leftover.md")
+    _run_git(repo, "commit", "-m", "Add stale file to surface file-set drift")
+    before_status = _git_status(repo)
+
+    result = _run_validate_all(repo, env, "--check-generation")
+
+    assert result.returncode == 1
+    assert "Table drift detected:" in result.stderr
+    assert "stale-leftover.md" in result.stderr
+    _assert_repo_unchanged(repo, before_status)
     assert not (tmp_path / "git-invocations.log").exists()
 
 

--- a/scripts/hooks/tests/test_validate_all_tool.py
+++ b/scripts/hooks/tests/test_validate_all_tool.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+Tests for scripts/tools/validate-all.sh.
+
+The --check-generation mode has a strict purity contract: generated artifacts
+must be written only to a temporary directory, tracked files must remain
+unchanged, and the git index must not be touched.
+"""
+
+import os
+import shutil
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+SCRIPT_SOURCE = REPO_ROOT / "scripts" / "tools" / "validate-all.sh"
+REAL_GIT = shutil.which("git")
+
+TABLE_FILES = [
+    "components-full.md",
+    "components-summary.md",
+    "controls-full.md",
+    "controls-summary.md",
+    "controls-xref-components.md",
+    "controls-xref-risks.md",
+    "personas-full.md",
+    "personas-summary.md",
+    "personas-xref-controls.md",
+    "personas-xref-risks.md",
+    "risks-full.md",
+    "risks-summary.md",
+]
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    assert REAL_GIT is not None, "git is required for validate-all.sh purity tests"
+    return subprocess.run(
+        [REAL_GIT, *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git_status(repo: Path) -> str:
+    return _run_git(repo, "status", "--porcelain=v1").stdout
+
+
+def _make_stubbed_repo(tmp_path: Path, table_content: str = "canonical\n") -> tuple[Path, dict[str, str]]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    script_path = repo / "scripts" / "tools" / "validate-all.sh"
+    script_path.parent.mkdir(parents=True)
+    shutil.copy2(SCRIPT_SOURCE, script_path)
+
+    (repo / "scripts" / "hooks").mkdir(parents=True)
+    (repo / "risk-map" / "schemas").mkdir(parents=True)
+    (repo / "risk-map" / "tables").mkdir(parents=True)
+    (repo / "risk-map" / "yaml").mkdir(parents=True)
+    (repo / "risk-map" / "schemas" / "components.schema.json").write_text("{}\n", encoding="utf-8")
+    (repo / "risk-map" / "yaml" / "components.yaml").write_text("components: []\n", encoding="utf-8")
+
+    for table_file in TABLE_FILES:
+        (repo / "risk-map" / "tables" / table_file).write_text(table_content, encoding="utf-8")
+
+    stub_bin = tmp_path / "bin"
+    stub_bin.mkdir()
+    git_log = tmp_path / "git-invocations.log"
+    python_log = tmp_path / "python-invocations.log"
+
+    _write_executable(
+        stub_bin / "check-jsonschema",
+        "#!/bin/bash\nexit 0\n",
+    )
+    _write_executable(
+        stub_bin / "git",
+        '#!/bin/bash\necho "$@" >> "${GIT_STUB_LOG:?}"\nexit 99\n',
+    )
+    _write_executable(
+        stub_bin / "python3",
+        "#!/bin/bash\n"
+        'printf "%s\\n" "$*" >> "${PYTHON_STUB_LOG:?}"\n'
+        'if [[ "$1" == "scripts/hooks/yaml_to_markdown.py" ]]; then\n'
+        '    output_dir=""\n'
+        "    while [[ $# -gt 0 ]]; do\n"
+        '        if [[ "$1" == "--output-dir" ]]; then\n'
+        '            output_dir="$2"\n'
+        "            shift 2\n"
+        "        else\n"
+        "            shift\n"
+        "        fi\n"
+        "    done\n"
+        '    if [[ -n "${TMPDIR_CAPTURE_FILE:-}" ]]; then\n'
+        '        dirname "$output_dir" > "$TMPDIR_CAPTURE_FILE"\n'
+        "    fi\n"
+        '    if [[ "${GENERATOR_MODE:-success}" == "failure" ]]; then\n'
+        "        exit 7\n"
+        "    fi\n"
+        '    if [[ "${GENERATOR_MODE:-success}" == "interrupt" ]]; then\n'
+        "        sleep 30\n"
+        "        exit 0\n"
+        "    fi\n"
+        '    mkdir -p "$output_dir"\n'
+        "    for table_file in " + " ".join(TABLE_FILES) + "; do\n"
+        '        printf "%s" "${GENERATED_CONTENT:-canonical\\n}" > "$output_dir/$table_file"\n'
+        "    done\n"
+        "    exit 0\n"
+        "fi\n"
+        "exit 0\n",
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{stub_bin}{os.pathsep}{env['PATH']}"
+    env["GIT_STUB_LOG"] = str(git_log)
+    env["PYTHON_STUB_LOG"] = str(python_log)
+
+    _run_git(repo, "init")
+    _run_git(repo, "config", "user.email", "tests@example.com")
+    _run_git(repo, "config", "user.name", "Tests")
+    _run_git(repo, "add", ".")
+    _run_git(repo, "commit", "-m", "Initial test fixture")
+
+    return repo, env
+
+
+def _run_validate_all(repo: Path, env: dict[str, str], *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "scripts/tools/validate-all.sh", *args],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+
+def _assert_repo_unchanged(repo: Path, before_status: str) -> None:
+    assert _git_status(repo) == before_status
+    diff = _run_git(repo, "diff", "--name-only").stdout
+    assert diff == ""
+
+
+def test_check_generation_success_leaves_tracked_files_and_index_unchanged(tmp_path: Path):
+    repo, env = _make_stubbed_repo(tmp_path)
+    before_status = _git_status(repo)
+    temp_capture = tmp_path / "tempdir.txt"
+    env["TMPDIR_CAPTURE_FILE"] = str(temp_capture)
+    env["GENERATED_CONTENT"] = "canonical\n"
+
+    result = _run_validate_all(repo, env, "--check-generation")
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "Generated markdown tables match risk-map/tables" in result.stdout
+    _assert_repo_unchanged(repo, before_status)
+    assert not Path(temp_capture.read_text(encoding="utf-8").strip()).exists()
+    assert not (tmp_path / "git-invocations.log").exists()
+
+
+def test_check_generation_drift_fails_without_mutating_tracked_files(tmp_path: Path):
+    repo, env = _make_stubbed_repo(tmp_path, table_content="committed\n")
+    before_status = _git_status(repo)
+    temp_capture = tmp_path / "tempdir.txt"
+    env["TMPDIR_CAPTURE_FILE"] = str(temp_capture)
+    env["GENERATED_CONTENT"] = "generated\n"
+
+    result = _run_validate_all(repo, env, "--check-generation")
+
+    assert result.returncode == 1
+    assert "Table drift detected:" in result.stderr
+    assert "components-full.md" in result.stderr
+    _assert_repo_unchanged(repo, before_status)
+    assert not Path(temp_capture.read_text(encoding="utf-8").strip()).exists()
+    assert not (tmp_path / "git-invocations.log").exists()
+
+
+def test_check_generation_cleans_tempdir_when_generator_fails(tmp_path: Path):
+    repo, env = _make_stubbed_repo(tmp_path)
+    before_status = _git_status(repo)
+    temp_capture = tmp_path / "tempdir.txt"
+    env["TMPDIR_CAPTURE_FILE"] = str(temp_capture)
+    env["GENERATOR_MODE"] = "failure"
+
+    result = _run_validate_all(repo, env, "--check-generation")
+
+    assert result.returncode == 1
+    assert "Markdown table generation check failed" in result.stdout
+    _assert_repo_unchanged(repo, before_status)
+    assert not Path(temp_capture.read_text(encoding="utf-8").strip()).exists()
+    assert not (tmp_path / "git-invocations.log").exists()
+
+
+def test_check_generation_cleans_tempdir_on_sigint(tmp_path: Path):
+    repo, env = _make_stubbed_repo(tmp_path)
+    before_status = _git_status(repo)
+    temp_capture = tmp_path / "tempdir.txt"
+    env["TMPDIR_CAPTURE_FILE"] = str(temp_capture)
+    env["GENERATOR_MODE"] = "interrupt"
+
+    process = subprocess.Popen(
+        ["bash", "scripts/tools/validate-all.sh", "--check-generation"],
+        cwd=repo,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+
+    deadline = time.time() + 10
+    while not temp_capture.exists() and time.time() < deadline:
+        time.sleep(0.05)
+
+    assert temp_capture.exists(), "generator stub did not capture the temporary directory"
+    temp_dir = Path(temp_capture.read_text(encoding="utf-8").strip())
+    os.killpg(process.pid, signal.SIGINT)
+    stdout, stderr = process.communicate(timeout=10)
+
+    assert process.returncode != 0, stderr + stdout
+    _assert_repo_unchanged(repo, before_status)
+    assert not temp_dir.exists()
+    assert not (tmp_path / "git-invocations.log").exists()
+
+
+def test_help_documents_check_generation_purity_contract(tmp_path: Path):
+    repo, env = _make_stubbed_repo(tmp_path)
+
+    result = _run_validate_all(repo, env, "--help")
+
+    assert result.returncode == 0
+    assert "--check-generation" in result.stdout
+    assert "does not write tracked files or change the git" in result.stdout
+
+
+def test_default_mode_does_not_run_generation_check(tmp_path: Path):
+    repo, env = _make_stubbed_repo(tmp_path)
+    before_status = _git_status(repo)
+    env["GENERATOR_MODE"] = "failure"
+
+    result = _run_validate_all(repo, env)
+
+    assert result.returncode == 0
+    _assert_repo_unchanged(repo, before_status)
+    python_log = (tmp_path / "python-invocations.log").read_text(encoding="utf-8")
+    assert "yaml_to_markdown.py" not in python_log
+    assert not (tmp_path / "git-invocations.log").exists()

--- a/scripts/tools/validate-all.sh
+++ b/scripts/tools/validate-all.sh
@@ -3,9 +3,9 @@
 # validate-all.sh - Run every risk-map validator with --force
 # =============================================================================
 # Replacement for the prior `pre-commit.sh --force` workflow. Runs each
-# validator against the full tree (regardless of git staging) without
-# regenerating graphs, tables, or SVGs. Use this while iterating on content
-# to catch issues before you stage for commit.
+# validator against the full tree (regardless of git staging) and, by
+# default, does not regenerate graphs, tables, or SVGs. Use this while
+# iterating on content to catch issues before you stage for commit.
 #
 # Usage:
 #   ./scripts/tools/validate-all.sh                    # run all validators
@@ -23,6 +23,10 @@
 #   2  Bad arguments
 # =============================================================================
 
+# set -u catches unset variables; we deliberately do not set -e because each
+# validator must run even if a prior one fails (failures are counted, not
+# fatal). Any new statement added to check_generated_tables that can return
+# non-zero must therefore be explicitly checked (e.g. wrapped in `if !`).
 set -u
 
 QUIET=false
@@ -86,13 +90,27 @@ cleanup_generation_tmp() {
 }
 
 handle_generation_signal() {
+    # exit 130 re-fires the EXIT trap, which runs cleanup_generation_tmp a
+    # second time; the `-d "$GEN_TMPDIR"` guard in that function makes the
+    # second call a no-op, so net behavior is one cleanup.
     cleanup_generation_tmp
     trap - INT TERM
     exit 130
 }
 
 check_generated_tables() {
-    GEN_TMPDIR="$(mktemp -d)"
+    # mktemp can fail (e.g. full $TMPDIR, permission errors). Without this
+    # guard, $GEN_TMPDIR would be empty and subsequent paths like
+    # "$GEN_TMPDIR/tables" would resolve to "/tables", writing outside the
+    # repo. Fail fast with a clear message instead.
+    if ! GEN_TMPDIR="$(mktemp -d)"; then
+        fail_msg "Could not create temporary directory for generation check"
+        return 1
+    fi
+    # check_generated_tables owns the EXIT trap for the remainder of the
+    # script. The function is the last validator invoked, so this is safe;
+    # any future code added after the CHECK_GENERATION block needs to either
+    # chain into this trap or move it out of the function.
     trap cleanup_generation_tmp EXIT
     trap handle_generation_signal INT TERM
 
@@ -164,9 +182,7 @@ fi
 
 if [[ "$CHECK_GENERATION" == "true" ]]; then
     banner "Generated table parity"
-    if check_generated_tables; then
-        :
-    else
+    if ! check_generated_tables; then
         FAILURES=$((FAILURES + 1))
     fi
 fi

--- a/scripts/tools/validate-all.sh
+++ b/scripts/tools/validate-all.sh
@@ -99,10 +99,8 @@ handle_generation_signal() {
 }
 
 check_generated_tables() {
-    # mktemp can fail (e.g. full $TMPDIR, permission errors). Without this
-    # guard, $GEN_TMPDIR would be empty and subsequent paths like
-    # "$GEN_TMPDIR/tables" would resolve to "/tables", writing outside the
-    # repo. Fail fast with a clear message instead.
+    # Without this guard an empty GEN_TMPDIR turns "$GEN_TMPDIR/tables"
+    # into "/tables", writing outside the repo.
     if ! GEN_TMPDIR="$(mktemp -d)"; then
         fail_msg "Could not create temporary directory for generation check"
         return 1

--- a/scripts/tools/validate-all.sh
+++ b/scripts/tools/validate-all.sh
@@ -8,9 +8,14 @@
 # to catch issues before you stage for commit.
 #
 # Usage:
-#   ./scripts/tools/validate-all.sh          # run all validators
-#   ./scripts/tools/validate-all.sh --quiet  # suppress per-validator banners
-#   ./scripts/tools/validate-all.sh --help   # show this help
+#   ./scripts/tools/validate-all.sh                    # run all validators
+#   ./scripts/tools/validate-all.sh --quiet            # suppress per-validator banners
+#   ./scripts/tools/validate-all.sh --check-generation # also verify generated tables
+#   ./scripts/tools/validate-all.sh --help             # show this help
+#
+# --check-generation regenerates tables into a temporary directory and compares
+# them with risk-map/tables. It does not write tracked files or change the git
+# index. The temporary directory is cleaned up on success, failure, INT, and TERM.
 #
 # Exit codes:
 #   0  All validators passed
@@ -21,6 +26,7 @@
 set -u
 
 QUIET=false
+CHECK_GENERATION=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -28,8 +34,12 @@ while [[ $# -gt 0 ]]; do
             QUIET=true
             shift
             ;;
+        --check-generation)
+            CHECK_GENERATION=true
+            shift
+            ;;
         --help|-h)
-            sed -n '2,19p' "$0"
+            sed -n '2,23p' "$0"
             exit 0
             ;;
         *)
@@ -67,6 +77,45 @@ pass_msg() { echo -e "${GREEN}[PASS]${RESET} $1"; }
 fail_msg() { echo -e "${RED}[FAIL]${RESET} $1"; }
 
 FAILURES=0
+GEN_TMPDIR=""
+
+cleanup_generation_tmp() {
+    if [[ -n "${GEN_TMPDIR:-}" && -d "$GEN_TMPDIR" ]]; then
+        rm -rf "$GEN_TMPDIR"
+    fi
+}
+
+handle_generation_signal() {
+    cleanup_generation_tmp
+    trap - INT TERM
+    exit 130
+}
+
+check_generated_tables() {
+    GEN_TMPDIR="$(mktemp -d)"
+    trap cleanup_generation_tmp EXIT
+    trap handle_generation_signal INT TERM
+
+    local generated_table_dir="$GEN_TMPDIR/tables"
+    local drift_report="$GEN_TMPDIR/table-drift.txt"
+
+    mkdir -p "$generated_table_dir"
+
+    if ! python3 scripts/hooks/yaml_to_markdown.py --all --all-formats --output-dir "$generated_table_dir" --quiet; then
+        fail_msg "Markdown table generation check failed"
+        return 1
+    fi
+
+    if ! diff -r -q risk-map/tables "$generated_table_dir" > "$drift_report"; then
+        fail_msg "Generated markdown tables are out of sync"
+        echo "Table drift detected:" >&2
+        cat "$drift_report" >&2
+        return 1
+    fi
+
+    pass_msg "Generated markdown tables match risk-map/tables"
+    return 0
+}
 
 # Each validator accepts --force to run against the full tree. Output is
 # routed straight to the user's terminal so error messages retain their
@@ -111,6 +160,15 @@ if python3 scripts/hooks/validate_issue_templates.py --force; then
 else
     fail_msg "Issue template validation reported errors"
     FAILURES=$((FAILURES + 1))
+fi
+
+if [[ "$CHECK_GENERATION" == "true" ]]; then
+    banner "Generated table parity"
+    if check_generated_tables; then
+        :
+    else
+        FAILURES=$((FAILURES + 1))
+    fi
 fi
 
 echo


### PR DESCRIPTION
## Summary
- add opt-in validate-all.sh --check-generation for side-effect-free table drift checks
- compare temp-generated markdown tables against risk-map/tables without touching tracked files or the git index
- document the strict local pre-push verification path

Fixes #301

## Validation
- bash -n scripts/tools/validate-all.sh
- ruff check scripts/hooks/tests/test_validate_all_tool.py
- ruff format --check scripts/hooks/tests/test_validate_all_tool.py
- pytest scripts/hooks/tests/test_validate_all_tool.py
- ./scripts/tools/validate-all.sh --check-generation