### PR TITLE
infra: add fork-aware persona pages guards

### DIFF
--- a/.github/workflows/persona-pages.yml
+++ b/.github/workflows/persona-pages.yml
@@ -122,6 +122,9 @@ jobs:
       - name: Summarize pipeline outcome
         run: |
           deploy_result="${{ needs.deploy.result }}"
+          # PR branch is checked first by design: a fork PR reads as
+          # "PRs don't deploy" (the dominant skip reason) rather than the
+          # fork message; the fork branch covers fork pushes to main.
           if [[ "${{ github.event_name }}" == "pull_request" && "$deploy_result" == "skipped" ]]; then
             deploy_display="n/a (PRs don't deploy)"
           elif [[ "${{ github.repository }}" != "cosai-oasis/secure-ai-tooling" && "$deploy_result" == "skipped" ]]; then

--- a/.github/workflows/persona-pages.yml
+++ b/.github/workflows/persona-pages.yml
@@ -80,19 +80,22 @@ jobs:
           test -f _site/generated/persona-site-data.json
 
       - name: Configure GitHub Pages
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.repository == 'cosai-oasis/secure-ai-tooling'
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
         with:
           enablement: true
 
       - name: Upload GitHub Pages artifact
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.repository == 'cosai-oasis/secure-ai-tooling'
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: _site
 
   deploy:
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    if: |
+      github.event_name != 'pull_request'
+      && github.ref == 'refs/heads/main'
+      && github.repository == 'cosai-oasis/secure-ai-tooling'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -121,6 +124,8 @@ jobs:
           deploy_result="${{ needs.deploy.result }}"
           if [[ "${{ github.event_name }}" == "pull_request" && "$deploy_result" == "skipped" ]]; then
             deploy_display="n/a (PRs don't deploy)"
+          elif [[ "${{ github.repository }}" != "cosai-oasis/secure-ai-tooling" && "$deploy_result" == "skipped" ]]; then
+            deploy_display="n/a (fork; Pages deploy not authorized)"
           else
             deploy_display="$deploy_result"
           fi

--- a/scripts/hooks/tests/test_persona_pages_workflow_guards.py
+++ b/scripts/hooks/tests/test_persona_pages_workflow_guards.py
@@ -1,5 +1,6 @@
 """Regression tests for fork-aware persona-pages workflow guards."""
 
+from functools import lru_cache
 from pathlib import Path
 
 import yaml
@@ -10,8 +11,9 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "persona-pages.yml"
 
 
+@lru_cache(maxsize=1)
 def _load_workflow() -> dict:
-    """Load the persona-pages workflow as a mapping."""
+    """Load the persona-pages workflow as a mapping (parsed once per session)."""
     return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
 
 
@@ -54,6 +56,26 @@ def test_pages_build_steps_are_guarded_to_canonical_non_pr_runs():
         assert CANONICAL_REPO_GUARD in step_if
 
 
+def test_build_test_steps_run_on_forks():
+    """
+    Given: Forks must keep getting build and test feedback
+    When: The test and artifact-prep build steps are inspected
+    Then: None carry the canonical-repo guard, so they run on forks
+    """
+    # Negative lock for hard-contract item #3: a refactor that accidentally
+    # adds the canonical guard to these steps would silently kill fork CI
+    # feedback while leaving the positive-guard tests green.
+    build_steps = _load_workflow()["jobs"]["build"]["steps"]
+    fork_visible_steps = (
+        "Run persona site data tests",
+        "Run persona site logic tests",
+        "Prepare Pages artifact",
+    )
+    for step_name in fork_visible_steps:
+        step = next(s for s in build_steps if s.get("name") == step_name)
+        assert CANONICAL_REPO not in (step.get("if") or "")
+
+
 def test_pages_summary_explains_fork_skipped_deploy():
     """
     Given: Fork pushes intentionally skip the Pages deploy job
@@ -62,5 +84,9 @@ def test_pages_summary_explains_fork_skipped_deploy():
     """
     summary_script = _load_workflow()["jobs"]["pages-summary"]["steps"][0]["run"]
 
+    # Lock the structural comparison (canonical-repo literal in the guard),
+    # not the exact prose, so a harmless reword of the display string does
+    # not break the test.
     assert f'"{CANONICAL_REPO}"' in summary_script
-    assert "n/a (fork; Pages deploy not authorized)" in summary_script
+    assert "fork" in summary_script
+    assert "n/a" in summary_script

--- a/scripts/hooks/tests/test_persona_pages_workflow_guards.py
+++ b/scripts/hooks/tests/test_persona_pages_workflow_guards.py
@@ -1,0 +1,66 @@
+"""Regression tests for fork-aware persona-pages workflow guards."""
+
+from pathlib import Path
+
+import yaml
+
+CANONICAL_REPO = "cosai-oasis/secure-ai-tooling"
+CANONICAL_REPO_GUARD = f"github.repository == '{CANONICAL_REPO}'"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "persona-pages.yml"
+
+
+def _load_workflow() -> dict:
+    """Load the persona-pages workflow as a mapping."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _normalized_if(value: str) -> str:
+    """Collapse multiline workflow `if:` expressions for stable assertions."""
+    return " ".join(value.split())
+
+
+def _build_step_if(step_name: str) -> str:
+    """Return the `if:` expression for a named build step."""
+    build_steps = _load_workflow()["jobs"]["build"]["steps"]
+    for step in build_steps:
+        if step.get("name") == step_name:
+            return _normalized_if(step["if"])
+    raise AssertionError(f"build step not found: {step_name}")
+
+
+def test_deploy_job_is_guarded_to_canonical_main_non_pr_runs():
+    """
+    Given: The persona-pages deploy job can publish to GitHub Pages
+    When: The job-level `if:` expression is inspected
+    Then: It requires a non-PR main ref in the canonical repository
+    """
+    deploy_if = _normalized_if(_load_workflow()["jobs"]["deploy"]["if"])
+
+    assert "github.event_name != 'pull_request'" in deploy_if
+    assert "github.ref == 'refs/heads/main'" in deploy_if
+    assert CANONICAL_REPO_GUARD in deploy_if
+
+
+def test_pages_build_steps_are_guarded_to_canonical_non_pr_runs():
+    """
+    Given: The build job must keep running tests on forks
+    When: The Pages-coupled build steps are inspected
+    Then: Only the Pages setup and artifact upload steps require the canonical repo
+    """
+    for step_name in ("Configure GitHub Pages", "Upload GitHub Pages artifact"):
+        step_if = _build_step_if(step_name)
+        assert "github.event_name != 'pull_request'" in step_if
+        assert CANONICAL_REPO_GUARD in step_if
+
+
+def test_pages_summary_explains_fork_skipped_deploy():
+    """
+    Given: Fork pushes intentionally skip the Pages deploy job
+    When: The pages-summary shell script is inspected
+    Then: It reports the skipped deploy as fork-specific n/a status
+    """
+    summary_script = _load_workflow()["jobs"]["pages-summary"]["steps"][0]["run"]
+
+    assert f'"{CANONICAL_REPO}"' in summary_script
+    assert "n/a (fork; Pages deploy not authorized)" in summary_script


### PR DESCRIPTION
## Summary

Closes: #302 

- Guard persona Pages setup/upload steps and the deploy job with the canonical repository check while preserving existing non-PR behavior.
- Keep fork build/test feedback intact and make fork skipped deploys read as `n/a (fork; Pages deploy not authorized)` in the summary.
- Add `scripts/hooks/tests/test_persona_pages_workflow_guards.py` to lock the workflow contract.

## Validation

- `./.venv/bin/pytest scripts/hooks/tests/test_persona_pages_workflow_guards.py` -> 3 passed.
- `PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/pytest scripts/hooks/tests/test_build_persona_site_data.py` -> 36 passed.
- `node --test site/tests/*.test.mjs` -> 39 passed.
- `./.venv/bin/ruff check scripts/hooks/tests/test_persona_pages_workflow_guards.py` -> passed.
- `./.venv/bin/python scripts/hooks/precommit/validate_workflow_uses_pinning.py .github/workflows/persona-pages.yml` -> passed.
- `git diff --check` -> passed.

## act outcomes

- `act -W .github/workflows/persona-pages.yml -j build --env GITHUB_REPOSITORY=davidlabianca/secure-ai-tooling --env GITHUB_EVENT_NAME=push --env GITHUB_REF=refs/heads/main -P ubuntu-latest=catthehacker/ubuntu:act-latest --container-architecture linux/amd64` -> ran dependency install plus both test steps: 36 pytest tests and 39 node tests passed. It then stopped at artifact prep because that medium local image lacks `rsync`.
- `act -n -W .github/workflows/persona-pages.yml -j build --env GITHUB_REPOSITORY=davidlabianca/secure-ai-tooling --env GITHUB_EVENT_NAME=push --env GITHUB_REF=refs/heads/main -P ubuntu-latest=catthehacker/ubuntu:act-latest --container-architecture linux/amd64 --pull=false --no-cache-server` -> succeeded; selected build/test/artifact-prep steps and skipped Pages setup/upload.
- `act -n -W .github/workflows/persona-pages.yml -j deploy --env GITHUB_REPOSITORY=davidlabianca/secure-ai-tooling --env GITHUB_REF=refs/heads/main -P ubuntu-latest=catthehacker/ubuntu:act-latest --container-architecture linux/amd64 --pull=false --no-cache-server` -> succeeded; selected the build dependency and did not select deploy.
- `act -n -W .github/workflows/persona-pages.yml -j deploy --env GITHUB_REPOSITORY=cosai-oasis/secure-ai-tooling --env GITHUB_REF=refs/heads/main -P ubuntu-latest=catthehacker/ubuntu:act-latest --container-architecture linux/amd64 --pull=false --no-cache-server` -> succeeded; selected Pages setup/upload and deploy.
- `act -W .github/workflows/persona-pages.yml -j build --env GITHUB_REPOSITORY=davidlabianca/secure-ai-tooling --env GITHUB_EVENT_NAME=push --env GITHUB_REF=refs/heads/main -P ubuntu-latest=catthehacker/ubuntu:full-latest --container-architecture linux/amd64` -> attempted to reach artifact prep in a fuller runner image, but local Docker image pull produced no progress for several minutes, so no workflow result was available from that attempt.