### PR TITLE
Phase C - C1: schema tightenings (additionalProperties, prose-strict, title.maxLength, relevantQuestions removal)

### DIFF
--- a/risk-map/schemas/actor-access.schema.json
+++ b/risk-map/schemas/actor-access.schema.json
@@ -46,7 +46,8 @@
           "description": "Whether this is a traditional or modern/AI-specific access level"
         }
       },
-      "required": ["id", "title", "description"]
+      "required": ["id", "title", "description"],
+      "additionalProperties": false
     }
   }
 }

--- a/risk-map/schemas/components.schema.json
+++ b/risk-map/schemas/components.schema.json
@@ -36,7 +36,8 @@
         },
         "description": { "$ref": "riskmap.schema.json#/definitions/utils/text" }
       },
-      "required": ["id", "title"]
+      "required": ["id", "title"],
+      "additionalProperties": false
     },
     "subcategory": {
       "type": "object",
@@ -56,7 +57,8 @@
         "title": { "type": "string" },
         "description": { "$ref": "riskmap.schema.json#/definitions/utils/text" }
       },
-      "required": ["id", "title"]
+      "required": ["id", "title"],
+      "additionalProperties": false
     },
     "component": {
       "type": "object",
@@ -131,7 +133,8 @@
           "$ref": "external-references.schema.json#/definitions/externalReferences"
         }
       },
-      "required": ["id", "title", "category", "edges"]
+      "required": ["id", "title", "category", "edges"],
+      "additionalProperties": false
     },
     "edges": {
       "type": "object",
@@ -145,7 +148,8 @@
           "items": { "$ref": "#/definitions/component/properties/id" }
         }
       },
-      "anyOf": [{ "required": ["to"] }, { "required": ["from"] }]
+      "anyOf": [{ "required": ["to"] }, { "required": ["from"] }],
+      "additionalProperties": false
     }
   }
 }

--- a/risk-map/schemas/components.schema.json
+++ b/risk-map/schemas/components.schema.json
@@ -6,7 +6,7 @@
   "type": "object",
   "properties": {
     "title": { "type": "string" },
-    "description": { "$ref": "riskmap.schema.json#/definitions/utils/text" },
+    "description": { "$ref": "riskmap.schema.json#/definitions/utils/prose-strict" },
     "categories": {
       "type": "array",
       "items": { "$ref": "#/definitions/category" }
@@ -34,7 +34,7 @@
           "type": "array",
           "items": { "$ref": "#/definitions/subcategory" }
         },
-        "description": { "$ref": "riskmap.schema.json#/definitions/utils/text" }
+        "description": { "$ref": "riskmap.schema.json#/definitions/utils/prose-strict" }
       },
       "required": ["id", "title"],
       "additionalProperties": false
@@ -55,7 +55,7 @@
           ]
         },
         "title": { "type": "string" },
-        "description": { "$ref": "riskmap.schema.json#/definitions/utils/text" }
+        "description": { "$ref": "riskmap.schema.json#/definitions/utils/prose-strict" }
       },
       "required": ["id", "title"],
       "additionalProperties": false
@@ -96,7 +96,7 @@
           ]
         },
         "title": { "type": "string" },
-        "description": { "$ref": "riskmap.schema.json#/definitions/utils/text" },
+        "description": { "$ref": "riskmap.schema.json#/definitions/utils/prose-strict" },
         "category": {
           "$ref": "#/definitions/category/properties/id"
         },

--- a/risk-map/schemas/controls.schema.json
+++ b/risk-map/schemas/controls.schema.json
@@ -34,7 +34,8 @@
         },
         "title": { "type": "string" }
       },
-      "required": ["id", "title"]
+      "required": ["id", "title"],
+      "additionalProperties": false
     },
     "control": {
       "type": "object",
@@ -184,7 +185,8 @@
           "$ref": "external-references.schema.json#/definitions/externalReferences"
         }
       },
-      "required": ["title", "description", "category", "personas", "components", "risks"]
+      "required": ["title", "description", "category", "personas", "components", "risks"],
+      "additionalProperties": false
     }
   }
 }

--- a/risk-map/schemas/controls.schema.json
+++ b/risk-map/schemas/controls.schema.json
@@ -80,7 +80,7 @@
             "controlInterComponentTransportSecurity"
           ]
         },
-        "title": { "type": "string" },
+        "title": { "type": "string", "maxLength": 100 },
         "description": { "$ref": "riskmap.schema.json#/definitions/utils/text" },
         "category": { "$ref": "#/definitions/category/properties/id" },
         "personas": {

--- a/risk-map/schemas/controls.schema.json
+++ b/risk-map/schemas/controls.schema.json
@@ -6,7 +6,7 @@
   "type": "object",
   "properties": {
     "title": { "type": "string" },
-    "description": { "$ref": "riskmap.schema.json#/definitions/utils/text" },
+    "description": { "$ref": "riskmap.schema.json#/definitions/utils/prose-strict" },
     "categories": {
       "type": "array",
       "items": { "$ref": "#/definitions/category" }
@@ -81,7 +81,7 @@
           ]
         },
         "title": { "type": "string", "maxLength": 100 },
-        "description": { "$ref": "riskmap.schema.json#/definitions/utils/text" },
+        "description": { "$ref": "riskmap.schema.json#/definitions/utils/prose-strict" },
         "category": { "$ref": "#/definitions/category/properties/id" },
         "personas": {
           "type": "array",

--- a/risk-map/schemas/frameworks.schema.json
+++ b/risk-map/schemas/frameworks.schema.json
@@ -74,7 +74,8 @@
           "minItems": 1
         }
       },
-      "required": ["id", "name", "fullName", "description", "baseUri", "applicableTo"]
+      "required": ["id", "name", "fullName", "description", "baseUri", "applicableTo"],
+      "additionalProperties": false
     },
     "framework-mapping-patterns": {
       "type": "object",

--- a/risk-map/schemas/impact-type.schema.json
+++ b/risk-map/schemas/impact-type.schema.json
@@ -47,7 +47,8 @@
           "description": "Whether this is a traditional security concern or AI-specific"
         }
       },
-      "required": ["id", "title", "description"]
+      "required": ["id", "title", "description"],
+      "additionalProperties": false
     }
   }
 }

--- a/risk-map/schemas/lifecycle-stage.schema.json
+++ b/risk-map/schemas/lifecycle-stage.schema.json
@@ -46,7 +46,8 @@
           "maximum": 8
         }
       },
-      "required": ["id", "title", "description"]
+      "required": ["id", "title", "description"],
+      "additionalProperties": false
     }
   }
 }

--- a/risk-map/schemas/personas.schema.json
+++ b/risk-map/schemas/personas.schema.json
@@ -72,7 +72,8 @@
           "$ref": "external-references.schema.json#/definitions/externalReferences"
         }
       },
-      "required": ["id", "title", "description"]
+      "required": ["id", "title", "description"],
+      "additionalProperties": false
     }
   }
 }

--- a/risk-map/schemas/personas.schema.json
+++ b/risk-map/schemas/personas.schema.json
@@ -6,7 +6,7 @@
   "type": "object",
   "properties": {
     "title": { "type": "string" },
-    "description": { "$ref": "riskmap.schema.json#/definitions/utils/text" },
+    "description": { "$ref": "riskmap.schema.json#/definitions/utils/prose-strict" },
     "personas": {
       "type": "array",
       "items": { "$ref": "#/definitions/persona" }
@@ -33,7 +33,7 @@
           ]
         },
         "title": { "type": "string" },
-        "description": { "$ref": "riskmap.schema.json#/definitions/utils/text" },
+        "description": { "$ref": "riskmap.schema.json#/definitions/utils/prose-strict" },
         "deprecated": {
           "type": "boolean",
           "description": "Indicates if this persona is deprecated and superseded by newer personas",

--- a/risk-map/schemas/risks.schema.json
+++ b/risk-map/schemas/risks.schema.json
@@ -58,7 +58,7 @@
             "riskZombieShadowMCPServers"
           ]
         },
-        "title": { "type": "string" },
+        "title": { "type": "string", "maxLength": 120 },
         "shortDescription": { "$ref": "riskmap.schema.json#/definitions/utils/text" },
         "longDescription": { "$ref": "riskmap.schema.json#/definitions/utils/text" },
         "category": {

--- a/risk-map/schemas/risks.schema.json
+++ b/risk-map/schemas/risks.schema.json
@@ -88,10 +88,6 @@
           "items": { "$ref": "controls.schema.json#/definitions/control/properties/id" }
         },
         "examples": { "$ref": "riskmap.schema.json#/definitions/utils/text" },
-        "relevantQuestions": {
-          "type": "array",
-          "items": { "type": "string" }
-        },
         "mappings": {
           "type": "object",
           "description": "Cross-references to external security frameworks. Per ADR-019 D5 + ADR-022 D5b: mitre-atlas, iso-22989, and eu-ai-act receive per-framework strict patterns from frameworks.schema.json; stride, nist-ai-rmf, and owasp-top10-llm fall through to the loose catch-all because their current entries use non-canonical forms. Keys must match valid framework IDs in frameworks.schema.json.",

--- a/risk-map/schemas/risks.schema.json
+++ b/risk-map/schemas/risks.schema.json
@@ -162,7 +162,8 @@
           "$ref": "external-references.schema.json#/definitions/externalReferences"
         }
       },
-      "required": ["id", "title", "shortDescription", "longDescription", "category", "personas", "controls"]
+      "required": ["id", "title", "shortDescription", "longDescription", "category", "personas", "controls"],
+      "additionalProperties": false
     }
   }
 }

--- a/risk-map/schemas/risks.schema.json
+++ b/risk-map/schemas/risks.schema.json
@@ -6,7 +6,7 @@
   "type": "object",
   "properties": {
     "title": { "type": "string" },
-    "description": { "$ref": "riskmap.schema.json#/definitions/utils/text" },
+    "description": { "$ref": "riskmap.schema.json#/definitions/utils/prose-strict" },
     "risks": {
       "type": "array",
       "items": { "$ref": "#/definitions/risk" }
@@ -59,8 +59,8 @@
           ]
         },
         "title": { "type": "string", "maxLength": 120 },
-        "shortDescription": { "$ref": "riskmap.schema.json#/definitions/utils/text" },
-        "longDescription": { "$ref": "riskmap.schema.json#/definitions/utils/text" },
+        "shortDescription": { "$ref": "riskmap.schema.json#/definitions/utils/prose-strict" },
+        "longDescription": { "$ref": "riskmap.schema.json#/definitions/utils/prose-strict" },
         "category": {
           "type": "string",
           "enum": [
@@ -78,16 +78,16 @@
         "tourContent": {
           "type": "object",
           "properties": {
-            "introduced": { "$ref": "riskmap.schema.json#/definitions/utils/text" },
-            "exposed": { "$ref": "riskmap.schema.json#/definitions/utils/text" },
-            "mitigated": { "$ref": "riskmap.schema.json#/definitions/utils/text" }
+            "introduced": { "$ref": "riskmap.schema.json#/definitions/utils/prose-strict" },
+            "exposed": { "$ref": "riskmap.schema.json#/definitions/utils/prose-strict" },
+            "mitigated": { "$ref": "riskmap.schema.json#/definitions/utils/prose-strict" }
           }
         },
         "controls": {
           "type": "array",
           "items": { "$ref": "controls.schema.json#/definitions/control/properties/id" }
         },
-        "examples": { "$ref": "riskmap.schema.json#/definitions/utils/text" },
+        "examples": { "$ref": "riskmap.schema.json#/definitions/utils/prose-strict" },
         "mappings": {
           "type": "object",
           "description": "Cross-references to external security frameworks. Per ADR-019 D5 + ADR-022 D5b: mitre-atlas, iso-22989, and eu-ai-act receive per-framework strict patterns from frameworks.schema.json; stride, nist-ai-rmf, and owasp-top10-llm fall through to the loose catch-all because their current entries use non-canonical forms. Keys must match valid framework IDs in frameworks.schema.json.",

--- a/scripts/hooks/precommit/_prose_fields.py
+++ b/scripts/hooks/precommit/_prose_fields.py
@@ -2,8 +2,16 @@
 Shared prose-field discovery for the ADR-017/ADR-016 prose linters.
 
 Both ``validate_yaml_prose_subset`` and ``validate_prose_references`` import
-``find_prose_fields`` from here so the iteration shape is identical.  The
-schema's ``utils/text`` definition admits one level of nesting::
+``find_prose_fields`` from here so the iteration shape is identical.  Prose
+fields are identified by one of two recognised ``$ref`` markers:
+
+- ``riskmap.schema.json#/definitions/utils/prose-strict`` — used by the four
+  content schemas (risks, controls, components, personas) after the
+  prose-strict schema migration (ADR-017/ADR-019).
+- ``riskmap.schema.json#/definitions/utils/text`` — used by supporting schemas
+  (frameworks, actor-access, impact-type, lifecycle-stage, self-assessment).
+
+Both refs admit one level of nesting::
 
     {type: array, items: {oneOf: [
         {type: string},
@@ -34,20 +42,26 @@ import yaml
 from precommit._linter_types import ProseField
 from precommit._prose_tokens import tokenize
 
-# $ref value that marks a field as a prose field in schema definitions.
-_PROSE_REF = "riskmap.schema.json#/definitions/utils/text"
+# Both $ref values that mark a field as a prose field in schema definitions.
+# utils/prose-strict is used by content schemas; utils/text by supporting schemas.
+_PROSE_REFS: frozenset[str] = frozenset(
+    {
+        "riskmap.schema.json#/definitions/utils/text",
+        "riskmap.schema.json#/definitions/utils/prose-strict",
+    }
+)
 
 
 def _is_prose_ref(ref: str) -> bool:
-    """Return True if the $ref value marks a prose field."""
-    return ref == _PROSE_REF
+    """Return True if the $ref value marks a prose field (either utils/text or utils/prose-strict)."""
+    return ref in _PROSE_REFS
 
 
 def _walk_property(path: str, prop_schema: dict, names: list[str]) -> None:
     """Recursively collect prose-marked field paths.
 
     Handles three cases:
-    - Leaf prose ref (e.g. shortDescription -> $ref: .../utils/text)
+    - Leaf prose ref (e.g. shortDescription -> $ref: .../utils/text or .../utils/prose-strict)
     - Array of objects (e.g. entries[].description) -- walks items.properties
     - Nested object (e.g. tourContent.introduced) -- walks its properties
 
@@ -99,11 +113,12 @@ def _find_prose_field_names_in_schema(schema: dict) -> list[str]:
 def _find_wrapper_prose_field_names_in_schema(schema: dict) -> list[str]:
     """Return prose field names declared directly at the schema root.
 
-    Wrapper case: a top-level property whose ``$ref`` resolves to ``utils/text``
-    -- the prose field is keyed at the YAML document root, sibling to any
-    entity arrays.  Only direct ``$ref`` matches are returned; array-typed
-    top-level properties (entity arrays) are intentionally ignored here -- the
-    entity-array path is handled by ``_find_prose_field_names_in_schema``.
+    Wrapper case: a top-level property whose ``$ref`` resolves to either
+    ``utils/text`` or ``utils/prose-strict`` -- the prose field is keyed at the
+    YAML document root, sibling to any entity arrays.  Only direct ``$ref``
+    matches are returned; array-typed top-level properties (entity arrays) are
+    intentionally ignored here -- the entity-array path is handled by
+    ``_find_prose_field_names_in_schema``.
 
     Args:
         schema: Parsed JSON schema dict.
@@ -196,7 +211,7 @@ def _collect_entries(data: dict, schema: dict) -> Iterator[tuple[str, dict]]:
 def _iter_prose_strings(field_value: object) -> Iterator[tuple[int, int | None, str]]:
     """Yield ``(index, nested_index, raw_text)`` tuples for every prose string.
 
-    Handles four shape cases admitted by the ``utils/text`` schema:
+    Handles four shape cases admitted by the ``utils/text`` and ``utils/prose-strict`` schemas:
 
     - **Bare string** -- yields ``(0, None, value)``.
     - **Flat array of strings** -- yields ``(idx, None, value)`` per element.
@@ -240,6 +255,7 @@ def find_prose_fields(yaml_path: Path, schema_dir: Path) -> Iterator[ProseField]
     """Yield ProseField objects for every prose string in a YAML file.
 
     Schema introspection drives field discovery: only properties marked with
+    ``$ref: riskmap.schema.json#/definitions/utils/prose-strict`` or
     ``$ref: riskmap.schema.json#/definitions/utils/text`` are treated as prose
     fields. The YAML file is matched to a schema by stem name first, then by
     top-level array-key overlap.
@@ -309,8 +325,9 @@ def find_prose_fields(yaml_path: Path, schema_dir: Path) -> Iterator[ProseField]
                 )
 
     # File-level wrapper path: prose fields declared at the schema root with
-    # a direct ``$ref`` to ``utils/text``.  The synthetic entry_id is the
-    # YAML file stem so wrapper diagnostics carry a stable, file-scoped id.
+    # a direct ``$ref`` to ``utils/text`` or ``utils/prose-strict``.  The
+    # synthetic entry_id is the YAML file stem so wrapper diagnostics carry a
+    # stable, file-scoped id.
     if wrapper_field_names:
         wrapper_entry_id = yaml_path.stem
         for field_name in wrapper_field_names:

--- a/scripts/hooks/precommit/validate_yaml_prose_subset.py
+++ b/scripts/hooks/precommit/validate_yaml_prose_subset.py
@@ -2,8 +2,9 @@
 """
 Pre-commit lint: ADR-017 D4 prose grammar subset for risk-map YAML files.
 
-Walks every prose field identified by schema introspection (fields marked as
-``$ref: riskmap.schema.json#/definitions/utils/text``) and rejects any INVALID_*
+Walks every prose field identified by schema introspection (fields marked with
+either ``$ref: riskmap.schema.json#/definitions/utils/prose-strict`` on content
+schemas or ``…/utils/text`` on supporting schemas) and rejects any INVALID_*
 token kind produced by the shared tokenizer, except INVALID_CAMELCASE_ID which
 is explicitly delegated to validate_prose_references per ADR-017 D4 rule 5.
 

--- a/scripts/hooks/tests/conftest.py
+++ b/scripts/hooks/tests/conftest.py
@@ -6,6 +6,7 @@ multiple test modules in the validation system test suite.
 """
 
 # Import test modules for type hints and fixtures
+import json
 import subprocess
 import sys
 import tempfile
@@ -15,6 +16,8 @@ from unittest.mock import patch
 
 import pytest
 import yaml
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT7
 from riskmap_validator.models import ComponentNode, ControlNode, RiskNode
 from riskmap_validator.validator import ComponentEdgeValidator
 
@@ -562,6 +565,60 @@ def complex_component_graph():
             from_edges=["componentModelDeployment"],
         ),
     }
+
+
+# ============================================================================
+# Schema registry helpers (shared across C1 tightening tests)
+# ============================================================================
+# Phase A follow-up: _make_registry was duplicated in test_consumer_external_references_refs.py
+# and test_consumer_mappings_per_framework_wiring.py. Lifted here so C1 test modules can
+# import it without re-duplicating. Existing per-file copies still work; only new callers
+# need to use this fixture.
+
+
+def _load_schema(schemas_dir: Path, filename: str) -> dict:
+    """Load and return a parsed JSON schema, failing with a clear message if absent."""
+    path = schemas_dir / filename
+    if not path.is_file():
+        pytest.fail(f"Schema not found: {path}")
+    with open(path) as fh:
+        return json.load(fh)
+
+
+def _make_registry(schemas_dir: Path) -> Registry:
+    """
+    Build a referencing.Registry that resolves bare-filename $refs against schemas
+    in the given directory. Replaces the deprecated jsonschema.RefResolver pattern
+    (deprecated since jsonschema 4.18; scheduled for removal).
+
+    The retrieve callback strips path prefixes so only the basename is used.
+    This works because all consumer-schema $refs in this repo are bare filenames
+    (e.g., 'riskmap.schema.json', 'frameworks.schema.json') — not path-prefixed URIs.
+    """
+
+    def retrieve(uri: str):
+        # URI-stripping breadcrumb: the validator hands us the URI portion of a $ref.
+        # For bare-filename $refs (all cases in this repo), the URI is just the filename.
+        # Path-prefixed refs (e.g., '../foo.json') would silently drop the prefix; acceptable
+        # because no such refs exist in the current schema set.
+        name = uri.rsplit("/", 1)[-1]
+        path = schemas_dir / name
+        with open(path) as fh:
+            return Resource.from_contents(json.load(fh), default_specification=DRAFT7)
+
+    return Registry(retrieve=retrieve)
+
+
+@pytest.fixture(scope="module")
+def schema_registry(risk_map_schemas_dir: Path) -> Registry:
+    """
+    Module-scoped referencing.Registry for cross-file $ref resolution in C1 tests.
+
+    Resolves bare-filename $refs (e.g., 'riskmap.schema.json#/definitions/...') against
+    the risk-map/schemas/ directory. Used by C1 tightening tests that validate
+    synthetic entries against consumer schemas with cross-file $refs.
+    """
+    return _make_registry(risk_map_schemas_dir)
 
 
 # Shared test utilities

--- a/scripts/hooks/tests/test_consumer_additional_properties_strict.py
+++ b/scripts/hooks/tests/test_consumer_additional_properties_strict.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python3
 """
-Tests for Decision 2 (C1-schema-tightenings): add `additionalProperties: false`
-to every `definitions/<entity>` block across all eight target schemas, per
+Tests for Decision 2 (C1-schema-tightenings): `additionalProperties: false`
+on every `definitions/<entity>` block across the eight target schemas, per
 ADRs 018-022 D-sections.
 
-Plan task 2.2.6: every top-level definitions/<entity> in the 8 content + supporting
-schemas gets additionalProperties:false. Sites tested here (11 new edits; 1 already
-done — framework-mapping-patterns at frameworks.schema.json:82 is excluded from
-delta assertions but its preservation is confirmed).
+Plan task 2.2.6: every top-level definitions/<entity> in the 8 content +
+supporting schemas closes the schema against unknown keys. Sites tested here
+(12 new edits + 1 pre-existing that must be preserved):
 
-Sites under test (12 new + 1 existing preserved):
   risks.schema.json:         definitions/risk
   controls.schema.json:      definitions/category, definitions/control
   components.schema.json:    definitions/category, definitions/subcategory,
@@ -20,25 +18,26 @@ Sites under test (12 new + 1 existing preserved):
   impact-type.schema.json:   definitions/impactType
   lifecycle-stage.schema.json: definitions/lifecycleStage
 
-Excluded from delta tests (already has additionalProperties:false):
-  frameworks.schema.json:    definitions/framework-mapping-patterns (line 82 pre-existing)
+Pre-existing (must remain):
+  frameworks.schema.json:    definitions/framework-mapping-patterns (ADR-022 D5b)
 
-Excluded from scope (file-root additionalProperties):
-  Plan task 2.2.6 targets definitions/<entity> blocks only.
+Out of scope:
+  file-root additionalProperties — plan task 2.2.6 targets definitions/<entity>
+  blocks only.
+  self-assessment.schema.json#/definitions/selfAssessment — handled by the C3
+  sibling PR (archive self-assessment), not this PR.
 
 Coverage:
-- Each of the 11 sites declares additionalProperties:false.
+- Each of the 12 new sites declares additionalProperties:false.
 - Each entity definition rejects a synthetic entry carrying a stray field.
-- The existing framework-mapping-patterns additionalProperties:false is preserved.
-- The mappings.additionalProperties sub-block (catch-all array shape in risks/controls/
-  components/personas) is NOT the boolean false; it is preserved as {type:array,...}.
-- The live risks.yaml corpus validates clean against definitions/risk after both
-  Decision 1 (relevantQuestions removed) and Decision 2 (additionalProperties:false)
-  are in place — ordering guard so Decision 1 must land first.
-
-Note on RED phase:
-  All *_has_additional_properties_false and *_rejects_stray_field tests are expected
-  to FAIL today (pre-tightening). The preserved/guard tests are expected to PASS today.
+- The pre-existing framework-mapping-patterns additionalProperties:false
+  is preserved.
+- The mappings.additionalProperties sub-block (catch-all array shape in
+  risks/controls/components/personas) remains a schema object {type:array,...}
+  — the Decision-2 sibling at the entity level must not collapse it to
+  boolean false.
+- The live risks.yaml corpus validates clean against definitions/risk under
+  the combined D1+D2 state — ordering guard so D1 lands before D2.
 """
 
 import sys
@@ -75,7 +74,7 @@ NEW_STRICT_SITES: list[tuple[str, str]] = [
     ("lifecycle-stage.schema.json", "lifecycleStage"),
 ]
 
-# Pre-existing strict site (already has additionalProperties:false before this PR).
+# Strict site established by ADR-022 D5b; preserved through C1.
 ALREADY_STRICT_SITES: list[tuple[str, str]] = [
     ("frameworks.schema.json", "framework-mapping-patterns"),
 ]
@@ -235,20 +234,17 @@ def _entity_validator(schemas_dir: Path, schema_file: str, entity_key: str) -> D
 
 
 # ============================================================================
-# Decision 2 — each site declares additionalProperties:false (RED today)
+# Decision 2 — each site declares additionalProperties:false
 # ============================================================================
 
 
 class TestEntityDefinitionsHaveAdditionalPropertiesFalse:
     """
-    Every definitions/<entity> block in the 8 target schemas must declare
-    additionalProperties:false after C1 tightening.
+    Every definitions/<entity> block in the 8 target schemas declares
+    additionalProperties:false per ADRs 018-022 D-sections.
 
-    Note: self-assessment.schema.json#/definitions/selfAssessment is explicitly
-    out of C1 scope — it is handled by the C3 sibling PR (archive self-assessment).
-
-    RED phase: all tests FAIL today (property absent or not false).
-    GREEN post-tightening: all tests pass.
+    self-assessment.schema.json#/definitions/selfAssessment is explicitly
+    out of C1 scope (handled by the C3 sibling PR — archive self-assessment).
     """
 
     @pytest.mark.parametrize(
@@ -282,17 +278,14 @@ class TestEntityDefinitionsHaveAdditionalPropertiesFalse:
 
 
 # ============================================================================
-# Decision 2 — each entity definition rejects synthetic stray-field entries (RED today)
+# Decision 2 — each entity definition rejects synthetic stray-field entries
 # ============================================================================
 
 
 class TestEntityDefinitionsRejectAdditionalProperties:
     """
-    Once additionalProperties:false is in place, a synthetic entry with a stray
-    field (e.g., a typo like 'descripton') must raise ValidationError.
-
-    RED phase: all tests FAIL today (stray fields accepted by open schemas).
-    GREEN post-tightening: all tests pass.
+    A synthetic entry carrying a stray field (e.g., a typo like 'descripton')
+    raises ValidationError against any of the 12 closed entity definitions.
     """
 
     @pytest.mark.parametrize(
@@ -326,7 +319,7 @@ class TestEntityDefinitionsRejectAdditionalProperties:
         errors = list(validator.iter_errors(entry))
         assert errors, (
             f"{schema_file} definitions/{entity_key} must reject entry with stray field "
-            f"'{_STRAY_FIELD}' (additionalProperties:false not yet enforced — RED phase)"
+            f"'{_STRAY_FIELD}' (additionalProperties:false on the entity definition)"
         )
 
     @pytest.mark.parametrize(
@@ -347,8 +340,9 @@ class TestEntityDefinitionsRejectAdditionalProperties:
         When: It is validated against definitions/<entity_key>
         Then: No errors are raised
 
-        This baseline must PASS today so stray-field failures are clearly causal.
-        If this test fails, the minimal entry or schema required fields need updating.
+        Baseline sentinel: the stray-field rejection tests above need a clean
+        positive control. If this fails, the minimal entry or schema required
+        fields need updating.
         """
         base = _MINIMAL_ENTRIES.get((schema_file, entity_key))
         if base is None:
@@ -368,11 +362,9 @@ class TestEntityDefinitionsRejectAdditionalProperties:
 
 class TestFrameworkMappingPatternsPreservesAdditionalPropertiesFalse:
     """
-    frameworks.schema.json definitions/framework-mapping-patterns already has
-    additionalProperties:false (pre-existing since ADR-022 D5b). This guard
-    confirms Decision 2 edits do not accidentally revert it.
-
-    Expected to PASS today and post-tightening.
+    frameworks.schema.json definitions/framework-mapping-patterns has carried
+    additionalProperties:false since ADR-022 D5b. This guard confirms the C1
+    edits never accidentally revert it.
     """
 
     @pytest.mark.parametrize(
@@ -387,19 +379,19 @@ class TestFrameworkMappingPatternsPreservesAdditionalPropertiesFalse:
         entity_key: str,
     ):
         """
-        Test that the pre-existing additionalProperties:false on framework-mapping-patterns
-        is not removed during C1 tightening edits.
+        Test that additionalProperties:false on framework-mapping-patterns is
+        present (preserved through C1).
 
         Given: frameworks.schema.json definitions/framework-mapping-patterns
         When: additionalProperties is inspected
-        Then: It is false (unchanged from before this PR)
+        Then: It is false (ADR-022 D5b shape preserved)
         """
         schema = _load_schema(schemas_dir, schema_file)
         entity_defn = schema.get("definitions", {}).get(entity_key, {})
         ap = entity_defn.get("additionalProperties", "<MISSING>")
         assert ap is False, (
-            f"{schema_file} definitions/{entity_key} had additionalProperties:false "
-            f"before C1; it must be preserved (got: {ap!r})"
+            f"{schema_file} definitions/{entity_key} must declare "
+            f"additionalProperties:false (preserved from ADR-022 D5b); got: {ap!r}"
         )
 
 
@@ -410,13 +402,13 @@ class TestFrameworkMappingPatternsPreservesAdditionalPropertiesFalse:
 
 class TestMappingsAdditionalPropertiesIsNotBoolean:
     """
-    The mappings field inside risk/control/component/persona entities uses a sub-block:
+    The mappings field inside risk/control/component/persona entities uses
+    a sub-block:
         additionalProperties: {type: array, items: {type: string}}
-    This is a schema-object catch-all for loose frameworks, NOT the boolean false.
-    Decision 2 adds additionalProperties:false at the definitions/<entity> level,
-    which must not collapse or replace the mappings.additionalProperties catch-all.
-
-    Expected to PASS today and post-tightening.
+    This is a schema-object catch-all for loose frameworks (stride, nist-ai-rmf,
+    owasp-top10-llm), NOT the boolean false. Decision 2 adds
+    additionalProperties:false at the definitions/<entity> level — that sibling
+    must not collapse or replace the mappings.additionalProperties catch-all.
     """
 
     # Schemas that have a mappings field with additionalProperties catch-all.
@@ -476,23 +468,15 @@ class TestMappingsAdditionalPropertiesIsNotBoolean:
 
 class TestRisksYamlValidatesCleanPostTightening:
     """
-    After both Decision 1 (relevantQuestions removed from schema) and Decision 2
-    (additionalProperties:false on definitions/risk) land, the live risks.yaml
-    corpus must still validate clean against definitions/risk.
+    The live risks.yaml corpus validates clean against definitions/risk under
+    the combined D1+D2 state (relevantQuestions removed + additionalProperties
+    closed). This pins the Risk R10 ordering invariant: D1 must land before D2
+    so the corpus never hits a state where the still-present relevantQuestions
+    field collides with a just-closed schema.
 
-    If this test fails post-tightening, it means either:
-    (a) A corpus risk entry uses a field not declared in definitions/risk, OR
-    (b) Decision 1 content removal is incomplete (relevantQuestions still in YAML).
-
-    The commit ordering in C1 requires D1 to land before D2, precisely so that
-    scenario (b) cannot happen: if relevantQuestions were still in YAML when
-    additionalProperties:false activated, every risk with that field would break.
-
-    This test is GREEN today and GREEN post-tightening (always-green ordering
-    sentinel): the corpus is already clean (B3 removed relevantQuestions), and
-    all remaining fields in risks.yaml are declared in definitions/risk/properties.
-    The test validates that D1 and D2 are applied in the correct order so the
-    corpus never hits a state where an undeclared field breaks a closed schema.
+    A failure here means either (a) a corpus risk entry uses a field not
+    declared in definitions/risk, or (b) Decision 1 content removal regressed
+    (relevantQuestions reintroduced to YAML).
     """
 
     def test_risks_yaml_corpus_validates_against_definitions_risk(
@@ -503,12 +487,12 @@ class TestRisksYamlValidatesCleanPostTightening:
         """
         Test that every risk entry in risks.yaml passes definitions/risk validation.
 
-        Given: The full risks.yaml corpus and a post-tightening definitions/risk validator
+        Given: The full risks.yaml corpus and the definitions/risk validator
         When: Each risk entry is validated
         Then: No ValidationError is raised for any entry
 
-        This is the ordering guard: if relevantQuestions were still in YAML when
-        additionalProperties:false is active, this test would fail.
+        Risk R10 ordering guard: a failure here surfaces either a corpus
+        regression or a D1-before-D2 ordering violation.
         """
         risks_path = risk_map_yaml_dir / "risks.yaml"
         if not risks_path.is_file():
@@ -532,7 +516,7 @@ class TestRisksYamlValidatesCleanPostTightening:
 
         assert not failures, (
             "risks.yaml corpus has validation failures against definitions/risk "
-            "(post-D1+D2 ordering guard):\n" + "\n".join(failures)
+            "(D1+D2 ordering guard):\n" + "\n".join(failures)
         )
 
 
@@ -542,32 +526,25 @@ class TestRisksYamlValidatesCleanPostTightening:
 """
 Test Summary
 ============
-Total parametrized sites: 12 new + 4 pre-existing mappings hosts
-Total test methods (non-parametrized): 1 (corpus ordering guard)
+Parametrized sites: 12 new entity definitions + 1 pre-existing
+  (framework-mapping-patterns) + 4 mappings-host entities
+Standalone test methods: 1 (corpus ordering guard)
 Test classes: 5
 
-- TestEntityDefinitionsHaveAdditionalPropertiesFalse (12 parametrized)
-    RED today: all 12 entity definitions lack additionalProperties:false.
-    GREEN post-tightening.
-
-- TestEntityDefinitionsRejectAdditionalProperties (12+12 parametrized: reject + baseline)
-    Stray-field rejection: RED today.
-    Baseline valid entry: GREEN today (confirms minimal entries are well-formed).
-
-- TestFrameworkMappingPatternsPreservesAdditionalPropertiesFalse (1 parametrized)
-    GREEN today: pre-existing. GREEN post-tightening.
-
-- TestMappingsAdditionalPropertiesIsNotBoolean (4 parametrized)
-    GREEN today: mappings AP is a schema object. GREEN post-tightening.
-
-- TestRisksYamlValidatesCleanPostTightening (1)
-    GREEN today and GREEN post-tightening (always-green ordering sentinel):
-    corpus is D1-clean (relevantQuestions removed by B3); all remaining fields
-    are declared in definitions/risk/properties.
+- TestEntityDefinitionsHaveAdditionalPropertiesFalse (12 parametrized) —
+  every entity definition declares additionalProperties:false.
+- TestEntityDefinitionsRejectAdditionalProperties (12+12 parametrized) —
+  stray-field entries rejected; minimal valid entries accepted (baseline).
+- TestFrameworkMappingPatternsPreservesAdditionalPropertiesFalse (1) —
+  pre-existing additionalProperties:false (ADR-022 D5b) preserved.
+- TestMappingsAdditionalPropertiesIsNotBoolean (4) — per-entity mappings
+  catch-all remains a schema object {type:array,...}, not boolean false.
+- TestRisksYamlValidatesCleanPostTightening (1) — risks.yaml validates
+  clean under combined D1+D2 (Risk R10 ordering invariant).
 
 Coverage areas:
 - Structural: additionalProperties:false declared on all 12 new sites
 - Behavioral: stray fields rejected, valid entries accepted
 - Preservation: framework-mapping-patterns intact, mappings catch-all intact
-- Ordering guard: corpus clean after combined D1+D2
+- Ordering guard: corpus clean under combined D1+D2
 """

--- a/scripts/hooks/tests/test_consumer_additional_properties_strict.py
+++ b/scripts/hooks/tests/test_consumer_additional_properties_strict.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+"""
+Tests for Decision 2 (C1-schema-tightenings): add `additionalProperties: false`
+to every `definitions/<entity>` block across all eight target schemas, per
+ADRs 018-022 D-sections.
+
+Plan task 2.2.6: every top-level definitions/<entity> in the 8 content + supporting
+schemas gets additionalProperties:false. Sites tested here (11 new edits; 1 already
+done — framework-mapping-patterns at frameworks.schema.json:82 is excluded from
+delta assertions but its preservation is confirmed).
+
+Sites under test (12 new + 1 existing preserved):
+  risks.schema.json:         definitions/risk
+  controls.schema.json:      definitions/category, definitions/control
+  components.schema.json:    definitions/category, definitions/subcategory,
+                             definitions/component, definitions/edges
+  personas.schema.json:      definitions/persona
+  frameworks.schema.json:    definitions/framework
+  actor-access.schema.json:  definitions/actorAccessLevel
+  impact-type.schema.json:   definitions/impactType
+  lifecycle-stage.schema.json: definitions/lifecycleStage
+
+Excluded from delta tests (already has additionalProperties:false):
+  frameworks.schema.json:    definitions/framework-mapping-patterns (line 82 pre-existing)
+
+Excluded from scope (file-root additionalProperties):
+  Plan task 2.2.6 targets definitions/<entity> blocks only.
+
+Coverage:
+- Each of the 11 sites declares additionalProperties:false.
+- Each entity definition rejects a synthetic entry carrying a stray field.
+- The existing framework-mapping-patterns additionalProperties:false is preserved.
+- The mappings.additionalProperties sub-block (catch-all array shape in risks/controls/
+  components/personas) is NOT the boolean false; it is preserved as {type:array,...}.
+- The live risks.yaml corpus validates clean against definitions/risk after both
+  Decision 1 (relevantQuestions removed) and Decision 2 (additionalProperties:false)
+  are in place — ordering guard so Decision 1 must land first.
+
+Note on RED phase:
+  All *_has_additional_properties_false and *_rejects_stray_field tests are expected
+  to FAIL today (pre-tightening). The preserved/guard tests are expected to PASS today.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+from jsonschema import Draft7Validator
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from conftest import _load_schema, _make_registry
+
+# ============================================================================
+# Module-level constants
+# ============================================================================
+
+# All 11 entity definition sites that must gain additionalProperties:false.
+# Tuple layout: (schema_filename, definitions_key)
+# 10 new edits; framework-mapping-patterns is the 11th site but pre-existing —
+# listed separately in ALREADY_STRICT_SITES for the preservation guard.
+NEW_STRICT_SITES: list[tuple[str, str]] = [
+    ("risks.schema.json", "risk"),
+    ("controls.schema.json", "category"),
+    ("controls.schema.json", "control"),
+    ("components.schema.json", "category"),
+    ("components.schema.json", "subcategory"),
+    ("components.schema.json", "component"),
+    ("components.schema.json", "edges"),
+    ("personas.schema.json", "persona"),
+    ("frameworks.schema.json", "framework"),
+    ("actor-access.schema.json", "actorAccessLevel"),
+    ("impact-type.schema.json", "impactType"),
+    ("lifecycle-stage.schema.json", "lifecycleStage"),
+]
+
+# Pre-existing strict site (already has additionalProperties:false before this PR).
+ALREADY_STRICT_SITES: list[tuple[str, str]] = [
+    ("frameworks.schema.json", "framework-mapping-patterns"),
+]
+
+# Stray field used in all synthetic rejection tests.
+_STRAY_FIELD = "unknownXyzField"
+
+# ============================================================================
+# Minimal valid synthetic entries per entity — used in rejection tests.
+# Fields satisfy the required[] array for each entity; enum values are corpus-valid.
+# ============================================================================
+
+# risks.schema.json / definitions/risk — required: id, title, shortDescription,
+# longDescription, category, personas, controls
+_MINIMAL_RISK: dict = {
+    "id": "riskDataPoisoning",
+    "title": "Data Poisoning",
+    "shortDescription": ["Short description."],
+    "longDescription": ["Long description."],
+    "category": "risksSupplyChainAndDevelopment",
+    "personas": ["personaModelProvider"],
+    "controls": ["controlTrainingDataSanitization"],
+}
+
+# controls.schema.json / definitions/category — required: id, title
+_MINIMAL_CONTROLS_CATEGORY: dict = {
+    "id": "controlsData",
+    "title": "Data Controls",
+}
+
+# controls.schema.json / definitions/control — required: title, description, category,
+# personas, components, risks
+_MINIMAL_CONTROL: dict = {
+    "title": "Training Data Management",
+    "description": ["Manage training data."],
+    "category": "controlsData",
+    "personas": ["personaModelProvider"],
+    "components": ["componentDataSources"],
+    "risks": ["riskDataPoisoning"],
+}
+
+# components.schema.json / definitions/category — required: id, title
+_MINIMAL_COMPONENTS_CATEGORY: dict = {
+    "id": "componentsInfrastructure",
+    "title": "Infrastructure",
+}
+
+# components.schema.json / definitions/subcategory — required: id, title
+_MINIMAL_SUBCATEGORY: dict = {
+    "id": "componentsData",
+    "title": "Data",
+}
+
+# components.schema.json / definitions/component — required: id, title, category, edges
+_MINIMAL_COMPONENT: dict = {
+    "id": "componentDataSources",
+    "title": "Data Sources",
+    "category": "componentsInfrastructure",
+    "edges": {"to": ["componentTheModel"]},
+}
+
+# components.schema.json / definitions/edges — anyOf: [{required: ["to"]},{required: ["from"]}]
+_MINIMAL_EDGES: dict = {
+    "to": ["componentTheModel"],
+}
+
+# personas.schema.json / definitions/persona — required: id, title, description
+_MINIMAL_PERSONA: dict = {
+    "id": "personaModelProvider",
+    "title": "Model Provider",
+    "description": ["A model provider persona."],
+}
+
+# frameworks.schema.json / definitions/framework — required: id, name, fullName,
+# description, baseUri, applicableTo
+_MINIMAL_FRAMEWORK: dict = {
+    "id": "mitre-atlas",
+    "name": "MITRE ATLAS",
+    "fullName": "MITRE ATLAS (Adversarial Threat Landscape for AI Systems)",
+    "description": "Framework for AI threat modeling.",
+    "baseUri": "https://atlas.mitre.org",
+    "applicableTo": ["risks"],
+}
+
+# actor-access.schema.json / definitions/actorAccessLevel — required: id, title, description
+_MINIMAL_ACTOR_ACCESS: dict = {
+    "id": "external",
+    "title": "External",
+    "description": "External actor with no system access.",
+}
+
+# impact-type.schema.json / definitions/impactType — required: id, title, description
+_MINIMAL_IMPACT_TYPE: dict = {
+    "id": "confidentiality",
+    "title": "Confidentiality",
+    "description": "Data confidentiality impact.",
+}
+
+# lifecycle-stage.schema.json / definitions/lifecycleStage — required: id, title, description
+_MINIMAL_LIFECYCLE_STAGE: dict = {
+    "id": "planning",
+    "title": "Planning",
+    "description": "Initial planning phase.",
+}
+
+# Maps (schema_file, entity_key) to a minimal valid entry for that entity.
+_MINIMAL_ENTRIES: dict[tuple[str, str], dict] = {
+    ("risks.schema.json", "risk"): _MINIMAL_RISK,
+    ("controls.schema.json", "category"): _MINIMAL_CONTROLS_CATEGORY,
+    ("controls.schema.json", "control"): _MINIMAL_CONTROL,
+    ("components.schema.json", "category"): _MINIMAL_COMPONENTS_CATEGORY,
+    ("components.schema.json", "subcategory"): _MINIMAL_SUBCATEGORY,
+    ("components.schema.json", "component"): _MINIMAL_COMPONENT,
+    ("components.schema.json", "edges"): _MINIMAL_EDGES,
+    ("personas.schema.json", "persona"): _MINIMAL_PERSONA,
+    ("frameworks.schema.json", "framework"): _MINIMAL_FRAMEWORK,
+    ("actor-access.schema.json", "actorAccessLevel"): _MINIMAL_ACTOR_ACCESS,
+    ("impact-type.schema.json", "impactType"): _MINIMAL_IMPACT_TYPE,
+    ("lifecycle-stage.schema.json", "lifecycleStage"): _MINIMAL_LIFECYCLE_STAGE,
+}
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="module")
+def schemas_dir(risk_map_schemas_dir: Path) -> Path:
+    """Alias for concise test signatures."""
+    return risk_map_schemas_dir
+
+
+# ============================================================================
+# Helper — build a validator for a specific entity definition
+# ============================================================================
+
+
+def _entity_validator(schemas_dir: Path, schema_file: str, entity_key: str) -> Draft7Validator:
+    """
+    Build a Draft-07 validator targeting definitions/<entity_key> in schema_file.
+
+    Uses the full parent schema as the root so that internal $refs (e.g.,
+    '#/definitions/component/properties/id' inside definitions/edges) resolve
+    correctly against the full definitions map, not just the entity sub-object.
+    Cross-file $refs are resolved via _make_registry.
+
+    The wrapper schema routes validation through a $ref to the entity definition
+    inside the parent schema, which is registered in the registry under schema_file.
+    """
+    registry = _make_registry(schemas_dir)
+    # Validate via a $ref wrapper: the full schema is accessible in the registry
+    # under its $id (e.g., 'controls.schema.json'), so internal #/definitions/...
+    # refs resolve against the full schema root.
+    wrapper = {"$ref": f"{schema_file}#/definitions/{entity_key}"}
+    return Draft7Validator(wrapper, registry=registry)
+
+
+# ============================================================================
+# Decision 2 — each site declares additionalProperties:false (RED today)
+# ============================================================================
+
+
+class TestEntityDefinitionsHaveAdditionalPropertiesFalse:
+    """
+    Every definitions/<entity> block in the 8 target schemas must declare
+    additionalProperties:false after C1 tightening.
+
+    Note: self-assessment.schema.json#/definitions/selfAssessment is explicitly
+    out of C1 scope — it is handled by the C3 sibling PR (archive self-assessment).
+
+    RED phase: all tests FAIL today (property absent or not false).
+    GREEN post-tightening: all tests pass.
+    """
+
+    @pytest.mark.parametrize(
+        "schema_file,entity_key",
+        NEW_STRICT_SITES,
+        ids=[f"{s}/{e}" for s, e in NEW_STRICT_SITES],
+    )
+    def test_entity_definition_has_additional_properties_false(
+        self,
+        schemas_dir: Path,
+        schema_file: str,
+        entity_key: str,
+    ):
+        """
+        Test that definitions/<entity_key> declares additionalProperties:false.
+
+        Given: A target schema file and entity definition key
+        When: definitions/<entity_key> is inspected for additionalProperties
+        Then: The value is exactly false (boolean), not missing or a schema object
+
+        Per ADRs 018-022: all definitions/<entity> blocks must be closed schemas.
+        """
+        schema = _load_schema(schemas_dir, schema_file)
+        entity_defn = schema.get("definitions", {}).get(entity_key, {})
+        ap = entity_defn.get("additionalProperties", "<MISSING>")
+        assert ap is False, (
+            f"{schema_file} definitions/{entity_key} must declare "
+            f"additionalProperties:false (got: {ap!r}); "
+            "per ADRs 018-022 D-sections — all entity definitions must be closed schemas"
+        )
+
+
+# ============================================================================
+# Decision 2 — each entity definition rejects synthetic stray-field entries (RED today)
+# ============================================================================
+
+
+class TestEntityDefinitionsRejectAdditionalProperties:
+    """
+    Once additionalProperties:false is in place, a synthetic entry with a stray
+    field (e.g., a typo like 'descripton') must raise ValidationError.
+
+    RED phase: all tests FAIL today (stray fields accepted by open schemas).
+    GREEN post-tightening: all tests pass.
+    """
+
+    @pytest.mark.parametrize(
+        "schema_file,entity_key",
+        NEW_STRICT_SITES,
+        ids=[f"{s}/{e}" for s, e in NEW_STRICT_SITES],
+    )
+    def test_stray_field_raises_validation_error(
+        self,
+        schemas_dir: Path,
+        schema_file: str,
+        entity_key: str,
+    ):
+        """
+        Test that a synthetic entity entry with a stray field is rejected.
+
+        Given: A minimal valid entity entry augmented with an unrecognized field
+        When: It is validated against definitions/<entity_key>
+        Then: ValidationError is raised (additionalProperties:false)
+
+        The stray field 'unknownXyzField' simulates a typo or unsupported key
+        that authors might accidentally include.
+        """
+        base = _MINIMAL_ENTRIES.get((schema_file, entity_key))
+        if base is None:
+            pytest.fail(f"No minimal entry defined for ({schema_file}, {entity_key})")
+        entry = dict(base)
+        entry[_STRAY_FIELD] = "unexpected value"
+
+        validator = _entity_validator(schemas_dir, schema_file, entity_key)
+        errors = list(validator.iter_errors(entry))
+        assert errors, (
+            f"{schema_file} definitions/{entity_key} must reject entry with stray field "
+            f"'{_STRAY_FIELD}' (additionalProperties:false not yet enforced — RED phase)"
+        )
+
+    @pytest.mark.parametrize(
+        "schema_file,entity_key",
+        NEW_STRICT_SITES,
+        ids=[f"{s}/{e}" for s, e in NEW_STRICT_SITES],
+    )
+    def test_minimal_valid_entry_passes(
+        self,
+        schemas_dir: Path,
+        schema_file: str,
+        entity_key: str,
+    ):
+        """
+        Test that the minimal valid entry passes validation (baseline health check).
+
+        Given: A minimal entity entry with all required fields and no stray properties
+        When: It is validated against definitions/<entity_key>
+        Then: No errors are raised
+
+        This baseline must PASS today so stray-field failures are clearly causal.
+        If this test fails, the minimal entry or schema required fields need updating.
+        """
+        base = _MINIMAL_ENTRIES.get((schema_file, entity_key))
+        if base is None:
+            pytest.fail(f"No minimal entry defined for ({schema_file}, {entity_key})")
+        validator = _entity_validator(schemas_dir, schema_file, entity_key)
+        errors = list(validator.iter_errors(base))
+        assert not errors, (
+            f"Minimal valid entry for {schema_file} definitions/{entity_key} must pass; "
+            f"errors: {[e.message for e in errors]}"
+        )
+
+
+# ============================================================================
+# Preservation guard — framework-mapping-patterns additionalProperties:false retained
+# ============================================================================
+
+
+class TestFrameworkMappingPatternsPreservesAdditionalPropertiesFalse:
+    """
+    frameworks.schema.json definitions/framework-mapping-patterns already has
+    additionalProperties:false (pre-existing since ADR-022 D5b). This guard
+    confirms Decision 2 edits do not accidentally revert it.
+
+    Expected to PASS today and post-tightening.
+    """
+
+    @pytest.mark.parametrize(
+        "schema_file,entity_key",
+        ALREADY_STRICT_SITES,
+        ids=[f"{s}/{e}" for s, e in ALREADY_STRICT_SITES],
+    )
+    def test_pre_existing_additional_properties_false_preserved(
+        self,
+        schemas_dir: Path,
+        schema_file: str,
+        entity_key: str,
+    ):
+        """
+        Test that the pre-existing additionalProperties:false on framework-mapping-patterns
+        is not removed during C1 tightening edits.
+
+        Given: frameworks.schema.json definitions/framework-mapping-patterns
+        When: additionalProperties is inspected
+        Then: It is false (unchanged from before this PR)
+        """
+        schema = _load_schema(schemas_dir, schema_file)
+        entity_defn = schema.get("definitions", {}).get(entity_key, {})
+        ap = entity_defn.get("additionalProperties", "<MISSING>")
+        assert ap is False, (
+            f"{schema_file} definitions/{entity_key} had additionalProperties:false "
+            f"before C1; it must be preserved (got: {ap!r})"
+        )
+
+
+# ============================================================================
+# Preservation guard — mappings.additionalProperties catch-all is NOT boolean false
+# ============================================================================
+
+
+class TestMappingsAdditionalPropertiesIsNotBoolean:
+    """
+    The mappings field inside risk/control/component/persona entities uses a sub-block:
+        additionalProperties: {type: array, items: {type: string}}
+    This is a schema-object catch-all for loose frameworks, NOT the boolean false.
+    Decision 2 adds additionalProperties:false at the definitions/<entity> level,
+    which must not collapse or replace the mappings.additionalProperties catch-all.
+
+    Expected to PASS today and post-tightening.
+    """
+
+    # Schemas that have a mappings field with additionalProperties catch-all.
+    _MAPPINGS_HOSTS: list[tuple[str, str]] = [
+        ("risks.schema.json", "risk"),
+        ("controls.schema.json", "control"),
+        ("components.schema.json", "component"),
+        ("personas.schema.json", "persona"),
+    ]
+
+    @pytest.mark.parametrize(
+        "schema_file,entity_key",
+        _MAPPINGS_HOSTS,
+        ids=[f"{s}/{e}" for s, e in _MAPPINGS_HOSTS],
+    )
+    def test_mappings_additional_properties_is_schema_object_not_false(
+        self,
+        schemas_dir: Path,
+        schema_file: str,
+        entity_key: str,
+    ):
+        """
+        Test that mappings.additionalProperties is a schema object (catch-all), not false.
+
+        Given: definitions/<entity>/properties/mappings in a consumer schema
+        When: Its additionalProperties value is inspected
+        Then: It is a dict (schema object), not the boolean false
+
+        This pins the invariant that Decision-2 edits cannot accidentally replace the
+        mappings catch-all with boolean false, which would break all loose-framework
+        entries (stride, nist-ai-rmf, owasp-top10-llm).
+        """
+        schema = _load_schema(schemas_dir, schema_file)
+        entity_defn = schema.get("definitions", {}).get(entity_key, {})
+        # personas.schema.json personas may have mappings at different nesting
+        mappings = entity_defn.get("properties", {}).get("mappings")
+        if mappings is None:
+            # Not all entities have mappings — skip gracefully with explanation.
+            pytest.skip(f"{schema_file} definitions/{entity_key} has no mappings property")
+        ap = mappings.get("additionalProperties", "<MISSING>")
+        assert isinstance(ap, dict), (
+            f"{schema_file} definitions/{entity_key}/properties/mappings/additionalProperties "
+            f"must be a schema object (catch-all array), not {ap!r}; "
+            "Decision-2 must not replace the mappings catch-all with boolean false"
+        )
+        # Confirm the catch-all shape: type:array with string items.
+        assert ap.get("type") == "array", (
+            f"mappings.additionalProperties in {schema_file}/{entity_key} must be type:array "
+            f"(loose-framework catch-all); got type={ap.get('type')!r}"
+        )
+
+
+# ============================================================================
+# Decision 2 ordering guard — risks.yaml validates clean after D1+D2 combined
+# ============================================================================
+
+
+class TestRisksYamlValidatesCleanPostTightening:
+    """
+    After both Decision 1 (relevantQuestions removed from schema) and Decision 2
+    (additionalProperties:false on definitions/risk) land, the live risks.yaml
+    corpus must still validate clean against definitions/risk.
+
+    If this test fails post-tightening, it means either:
+    (a) A corpus risk entry uses a field not declared in definitions/risk, OR
+    (b) Decision 1 content removal is incomplete (relevantQuestions still in YAML).
+
+    The commit ordering in C1 requires D1 to land before D2, precisely so that
+    scenario (b) cannot happen: if relevantQuestions were still in YAML when
+    additionalProperties:false activated, every risk with that field would break.
+
+    This test is GREEN today and GREEN post-tightening (always-green ordering
+    sentinel): the corpus is already clean (B3 removed relevantQuestions), and
+    all remaining fields in risks.yaml are declared in definitions/risk/properties.
+    The test validates that D1 and D2 are applied in the correct order so the
+    corpus never hits a state where an undeclared field breaks a closed schema.
+    """
+
+    def test_risks_yaml_corpus_validates_against_definitions_risk(
+        self,
+        schemas_dir: Path,
+        risk_map_yaml_dir: Path,
+    ):
+        """
+        Test that every risk entry in risks.yaml passes definitions/risk validation.
+
+        Given: The full risks.yaml corpus and a post-tightening definitions/risk validator
+        When: Each risk entry is validated
+        Then: No ValidationError is raised for any entry
+
+        This is the ordering guard: if relevantQuestions were still in YAML when
+        additionalProperties:false is active, this test would fail.
+        """
+        risks_path = risk_map_yaml_dir / "risks.yaml"
+        if not risks_path.is_file():
+            pytest.fail(f"risks.yaml not found at {risks_path}")
+        with open(risks_path) as fh:
+            data = yaml.safe_load(fh)
+
+        risks_schema = _load_schema(schemas_dir, "risks.schema.json")
+        registry = _make_registry(schemas_dir)
+        risk_defn = risks_schema.get("definitions", {}).get("risk")
+        if risk_defn is None:
+            pytest.fail("definitions/risk not found in risks.schema.json")
+
+        validator = Draft7Validator(risk_defn, registry=registry)
+        failures: list[str] = []
+        for risk in data.get("risks", []):
+            errors = list(validator.iter_errors(risk))
+            if errors:
+                rid = risk.get("id", "<unknown>")
+                failures.append(f"  {rid}: {[e.message for e in errors]}")
+
+        assert not failures, (
+            "risks.yaml corpus has validation failures against definitions/risk "
+            "(post-D1+D2 ordering guard):\n" + "\n".join(failures)
+        )
+
+
+# ============================================================================
+# Test summary
+# ============================================================================
+"""
+Test Summary
+============
+Total parametrized sites: 12 new + 4 pre-existing mappings hosts
+Total test methods (non-parametrized): 1 (corpus ordering guard)
+Test classes: 5
+
+- TestEntityDefinitionsHaveAdditionalPropertiesFalse (12 parametrized)
+    RED today: all 12 entity definitions lack additionalProperties:false.
+    GREEN post-tightening.
+
+- TestEntityDefinitionsRejectAdditionalProperties (12+12 parametrized: reject + baseline)
+    Stray-field rejection: RED today.
+    Baseline valid entry: GREEN today (confirms minimal entries are well-formed).
+
+- TestFrameworkMappingPatternsPreservesAdditionalPropertiesFalse (1 parametrized)
+    GREEN today: pre-existing. GREEN post-tightening.
+
+- TestMappingsAdditionalPropertiesIsNotBoolean (4 parametrized)
+    GREEN today: mappings AP is a schema object. GREEN post-tightening.
+
+- TestRisksYamlValidatesCleanPostTightening (1)
+    GREEN today and GREEN post-tightening (always-green ordering sentinel):
+    corpus is D1-clean (relevantQuestions removed by B3); all remaining fields
+    are declared in definitions/risk/properties.
+
+Coverage areas:
+- Structural: additionalProperties:false declared on all 12 new sites
+- Behavioral: stray fields rejected, valid entries accepted
+- Preservation: framework-mapping-patterns intact, mappings catch-all intact
+- Ordering guard: corpus clean after combined D1+D2
+"""

--- a/scripts/hooks/tests/test_consumer_external_references_refs.py
+++ b/scripts/hooks/tests/test_consumer_external_references_refs.py
@@ -14,17 +14,17 @@ Coverage:
 - Current YAML files remain valid (no regression on existing content).
 """
 
-import json
 import sys
 from pathlib import Path
 
 import pytest
 from jsonschema import Draft7Validator
 from jsonschema.exceptions import SchemaError
-from referencing import Registry, Resource
-from referencing.jsonschema import DRAFT7
 
+sys.path.insert(0, str(Path(__file__).parent))
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from conftest import _load_schema, _make_registry  # noqa: E402, I001  conftest needs sys.path manipulation
 
 
 # ============================================================================
@@ -60,36 +60,6 @@ VALID_EXTERNAL_REFERENCES = [
 def schemas_dir(risk_map_schemas_dir: Path) -> Path:
     """Alias to keep test signatures concise."""
     return risk_map_schemas_dir
-
-
-def _load_schema(schemas_dir: Path, filename: str) -> dict:
-    """Load and return a schema file, failing with a clear message if absent."""
-    path = schemas_dir / filename
-    if not path.is_file():
-        pytest.fail(f"Schema not found: {path}")
-    with open(path) as fh:
-        return json.load(fh)
-
-
-def _make_registry(schemas_dir: Path) -> Registry:
-    """
-    Build a referencing.Registry that resolves bare-filename $refs against
-    schemas in the given directory. Replaces the deprecated jsonschema.RefResolver
-    pattern (deprecated since jsonschema 4.18; scheduled for removal).
-    """
-
-    def retrieve(uri: str):
-        # The validator hands us the URI portion of a $ref. For our refs
-        # (e.g., "external-references.schema.json"), the URI is a bare schema
-        # filename relative to schemas_dir. Path-prefixed refs (e.g.,
-        # "../foo.json") would silently drop the prefix here; that's acceptable
-        # because all consumer-schema $refs in this repo are bare filenames.
-        name = uri.rsplit("/", 1)[-1]
-        path = schemas_dir / name
-        with open(path) as fh:
-            return Resource.from_contents(json.load(fh), default_specification=DRAFT7)
-
-    return Registry(retrieve=retrieve)
 
 
 # ============================================================================

--- a/scripts/hooks/tests/test_consumer_mappings_per_framework_wiring.py
+++ b/scripts/hooks/tests/test_consumer_mappings_per_framework_wiring.py
@@ -22,7 +22,6 @@ Coverage:
 - Current risks.yaml and controls.yaml still pass check-jsonschema.
 """
 
-import json
 import subprocess
 import sys
 from pathlib import Path
@@ -30,10 +29,12 @@ from pathlib import Path
 import pytest
 from jsonschema import Draft7Validator
 from jsonschema.exceptions import SchemaError
-from referencing import Registry, Resource
-from referencing.jsonschema import DRAFT7
+from referencing import Registry
 
+sys.path.insert(0, str(Path(__file__).parent))
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from conftest import _load_schema, _make_registry  # noqa: E402, I001  conftest needs sys.path manipulation
 
 
 # ============================================================================
@@ -102,31 +103,6 @@ EU_AI_ACT_VALID: list[str] = ["Article 5", "Article 5(1)", "Article 50"]
 # ============================================================================
 
 
-def _load_schema(schemas_dir: Path, filename: str) -> dict:
-    path = schemas_dir / filename
-    if not path.is_file():
-        pytest.fail(f"Schema not found: {path}")
-    with open(path) as fh:
-        return json.load(fh)
-
-
-def _make_registry(schemas_dir: Path) -> Registry:
-    """
-    Build a referencing.Registry that resolves bare-filename $refs against
-    schemas in the given directory. Replaces the deprecated jsonschema.RefResolver.
-    """
-
-    def retrieve(uri: str):
-        # The validator hands us the URI portion of a $ref; for our refs the
-        # URI is a bare schema filename relative to schemas_dir.
-        name = uri.rsplit("/", 1)[-1]
-        path = schemas_dir / name
-        with open(path) as fh:
-            return Resource.from_contents(json.load(fh), default_specification=DRAFT7)
-
-    return Registry(retrieve=retrieve)
-
-
 @pytest.fixture(scope="module")
 def risks_schema(risk_map_schemas_dir: Path) -> dict:
     return _load_schema(risk_map_schemas_dir, "risks.schema.json")
@@ -138,7 +114,7 @@ def controls_schema(risk_map_schemas_dir: Path) -> dict:
 
 
 @pytest.fixture(scope="module")
-def schemas_registry(risk_map_schemas_dir: Path) -> Registry:
+def schemas_registry(risk_map_schemas_dir: Path):
     """Shared registry for risks + controls cross-file $ref resolution."""
     return _make_registry(risk_map_schemas_dir)
 

--- a/scripts/hooks/tests/test_consumer_prose_strict_migration.py
+++ b/scripts/hooks/tests/test_consumer_prose_strict_migration.py
@@ -1,24 +1,25 @@
 #!/usr/bin/env python3
 """
-Tests for Decision 4 (C1-schema-tightenings): migrate description-field $refs from
-`riskmap.schema.json#/definitions/utils/text` to `riskmap.schema.json#/definitions/utils/prose-strict`
-across the four content schemas, per ADRs 018-021 D4.
+Tests for Decision 4 (C1-schema-tightenings): description-field $refs in the
+four content schemas point at `riskmap.schema.json#/definitions/utils/prose-strict`
+(not `utils/text`), per ADRs 018-021 D4.
 
 Scope: 15 $ref sites in 4 content schemas (risks, controls, components, personas).
-Supporting schemas (frameworks, actor-access, impact-type, lifecycle-stage) are out of
-scope for this PR — they remain on utils/text.
+Supporting schemas (frameworks, actor-access, impact-type, lifecycle-stage) are
+out of scope for this PR — they remain on utils/text.
 
-Coexistence note: definitions/utils/text is NOT removed from riskmap.schema.json by this PR.
-Supporting schemas + self-assessment.schema.json (C3 sibling PR) still reference it.
-A future PR will retire utils/text once all consumers migrate.
+Coexistence: definitions/utils/text is retained in riskmap.schema.json.
+Supporting schemas + self-assessment.schema.json (C3 sibling PR) still
+reference it. Removal is a follow-up once all consumers migrate.
 
 Coverage:
-- Each of the 15 $ref sites points at utils/prose-strict (not utils/text) post-migration.
-- Zero residual utils/text $refs remain in each of the 4 content schemas.
+- Each of the 15 $ref sites references utils/prose-strict.
+- Zero residual utils/text $refs in each of the 4 content schemas
+  (JSON-walk regex assertion, robust against reformatting).
 - riskmap.schema.json#/definitions/utils/text still exists (coexistence guard).
-- Live-corpus audit per schema: the YAML corpus for each content schema validates clean
-  against the post-migration schema (prose-strict compatibility probe). If a corpus field
-  carries an empty array or empty string, the probe surfaces it BEFORE tightening lands.
+- Live-corpus audit per schema: each content YAML corpus validates clean
+  against its parent schema's prose-strict shape. Surfaces content drift
+  (empty arrays / empty strings) if it ever appears.
 
 Sites under test (15 total):
   risks.schema.json (7):
@@ -43,11 +44,6 @@ Sites under test (15 total):
   personas.schema.json (2):
     /properties/description
     /definitions/persona/properties/description
-
-Note on RED phase:
-  All $ref-value and zero-residual tests FAIL today (sites still reference utils/text).
-  Coexistence guard and corpus audit tests PASS today (the YAML corpus is prose-strict
-  compatible; B3 and predecessor PRs cleaned empty prose fields).
 """
 
 import json
@@ -95,7 +91,7 @@ MIGRATION_SITES: list[tuple[str, list[str]]] = [
     ("personas.schema.json", ["definitions", "persona", "properties", "description"]),
 ]
 
-# Schemas where all utils/text $refs must be zero post-migration.
+# Content schemas where every utils/text $ref must be migrated to prose-strict.
 CONTENT_SCHEMAS: list[str] = [
     "risks.schema.json",
     "controls.schema.json",
@@ -147,16 +143,13 @@ def schemas_dir(risk_map_schemas_dir: Path) -> Path:
 
 
 # ============================================================================
-# Decision 4 — each site $refs prose-strict (RED today)
+# Decision 4 — each site $refs prose-strict
 # ============================================================================
 
 
 class TestProseMigrationRefValue:
     """
-    Each of the 15 $ref sites must point at utils/prose-strict after migration.
-
-    RED phase: all 15 tests FAIL today (sites still reference utils/text).
-    GREEN post-tightening.
+    Each of the 15 $ref sites references utils/prose-strict per ADRs 018-021 D4.
     """
 
     @pytest.mark.parametrize(
@@ -187,24 +180,21 @@ class TestProseMigrationRefValue:
         actual_ref = node.get("$ref")
         assert actual_ref == PROSE_STRICT_REF, (
             f"{schema_file} /{'/'.join(key_path)} must $ref '{PROSE_STRICT_REF}'; "
-            f"currently: {actual_ref!r} — RED phase (utils/text → utils/prose-strict migration pending)"
+            f"got: {actual_ref!r} (per ADRs 018-021 D4 utils/text → utils/prose-strict migration)"
         )
 
 
 # ============================================================================
-# Decision 4 — zero residual utils/text $refs in each content schema (RED today)
+# Decision 4 — zero residual utils/text $refs in each content schema
 # ============================================================================
 
 
 class TestZeroResidualUtilsTextRefs:
     """
-    After migration, no utils/text $ref must remain in any of the 4 content schemas.
+    No utils/text $ref remains in any of the 4 content schemas.
 
-    Uses a JSON serialisation regex walk rather than line-number counting, so it
-    remains robust if the schema is reformatted or lines shift.
-
-    RED phase: FAILS today (all 15 sites still reference utils/text).
-    GREEN post-tightening.
+    Uses a JSON-serialisation regex walk rather than line-number counting, so it
+    remains robust against reformatting or line shifts.
     """
 
     @pytest.mark.parametrize(
@@ -218,57 +208,56 @@ class TestZeroResidualUtilsTextRefs:
         schema_file: str,
     ):
         """
-        Test that no utils/text $ref remains in the content schema after migration.
+        Test that no utils/text $ref remains in the content schema.
 
         Given: A content schema file
         When: Its full JSON serialisation is scanned for utils/text refs
         Then: No matches are found
 
-        Note: utils/text $refs in SUPPORTING schemas (frameworks, actor-access,
-        impact-type, lifecycle-stage) are explicitly out of scope for this PR.
-        This test only asserts the 4 content schemas.
+        Supporting schemas (frameworks, actor-access, impact-type,
+        lifecycle-stage) are explicitly out of scope for this PR; they retain
+        utils/text. This test only asserts the 4 content schemas.
         """
         schema = _load_schema(schemas_dir, schema_file)
         serialised = json.dumps(schema)
         matches = UTILS_TEXT_REF_PATTERN.findall(serialised)
         assert not matches, (
-            f"{schema_file} still contains {len(matches)} utils/text $ref(s) after migration. "
-            f"All {len(matches)} must be replaced with utils/prose-strict — RED phase. "
-            "Note: supporting schemas (frameworks, actor-access, impact-type, lifecycle-stage) "
-            "are allowed to retain utils/text (out of scope for this PR)."
+            f"{schema_file} contains {len(matches)} residual utils/text $ref(s). "
+            "Every content-schema description site must reference utils/prose-strict. "
+            "(Supporting schemas — frameworks, actor-access, impact-type, "
+            "lifecycle-stage — are explicitly out of scope and may retain utils/text.)"
         )
 
 
 # ============================================================================
-# Coexistence guard — utils/text still exists in riskmap.schema.json (GREEN today)
+# Coexistence guard — utils/text still exists in riskmap.schema.json
 # ============================================================================
 
 
 class TestUtilsTextCoexistenceGuard:
     """
-    riskmap.schema.json#/definitions/utils/text must still exist after this PR.
-    Supporting schemas (frameworks, actor-access, impact-type, lifecycle-stage) and
-    self-assessment.schema.json (C3 sibling PR) still reference it. Removal is a
-    future follow-up once all consumers migrate.
-
-    Expected to PASS today and post-tightening.
+    riskmap.schema.json#/definitions/utils/text is retained alongside
+    utils/prose-strict. Supporting schemas (frameworks, actor-access,
+    impact-type, lifecycle-stage) and self-assessment.schema.json (archived
+    by C3 sibling PR) still reference it; removal is a follow-up once all
+    consumers migrate.
     """
 
     def test_utils_text_still_exists_in_riskmap_schema(self, schemas_dir: Path):
         """
-        Test that definitions/utils/text is still present in riskmap.schema.json.
+        Test that definitions/utils/text is present in riskmap.schema.json.
 
         Given: riskmap.schema.json
         When: definitions/utils/text is looked up
-        Then: It is present (prose-strict migration does NOT remove utils/text from riskmap)
+        Then: It is present (C1 does not remove utils/text from riskmap)
 
-        Removal of utils/text is deferred until all consumers (supporting schemas +
-        self-assessment.schema.json) have migrated. This is a follow-up PR concern.
+        Removal is deferred until all consumers (supporting schemas +
+        self-assessment.schema.json) have migrated — follow-up PR concern.
         """
         schema = _load_schema(schemas_dir, "riskmap.schema.json")
         utils = schema.get("definitions", {}).get("utils", {})
         assert "text" in utils, (
-            "riskmap.schema.json#/definitions/utils/text must still exist after C1 tightening. "
+            "riskmap.schema.json#/definitions/utils/text must still exist. "
             "Removal is deferred — supporting schemas still reference utils/text."
         )
 
@@ -278,7 +267,7 @@ class TestUtilsTextCoexistenceGuard:
 
         Given: riskmap.schema.json
         When: definitions/utils/prose-strict is looked up
-        Then: It is present (already landed in a previous PR)
+        Then: It is present (landed in Phase A via A2 task 2.2.9a)
         """
         schema = _load_schema(schemas_dir, "riskmap.schema.json")
         utils = schema.get("definitions", {}).get("utils", {})
@@ -289,15 +278,14 @@ class TestUtilsTextCoexistenceGuard:
 
     def test_supporting_schemas_still_use_utils_text(self, schemas_dir: Path):
         """
-        Test that at least one supporting schema still uses utils/text (confirming it
-        must not be removed from riskmap.schema.json by this PR).
+        Test that at least one supporting schema still uses utils/text.
 
         Given: The 4 supporting schemas that are out of scope for this PR
         When: Their JSON is scanned for utils/text $refs
         Then: At least one schema has a utils/text $ref
 
-        This confirms that removing utils/text from riskmap.schema.json would break
-        something, validating the coexistence requirement.
+        Confirms that removing utils/text from riskmap.schema.json would break a
+        live consumer, validating why coexistence must be preserved.
         """
         supporting_schemas = [
             "frameworks.schema.json",
@@ -320,28 +308,23 @@ class TestUtilsTextCoexistenceGuard:
 
 
 # ============================================================================
-# Live-corpus audit — YAML corpus validates clean against post-migration schema
+# Live-corpus audit — YAML corpus validates clean against prose-strict shape
 # ============================================================================
 
 
 class TestCorpusProseStrictCompatibility:
     """
-    Audit probe: each YAML corpus file must validate clean against the full
-    parent schema (which, post-migration, uses prose-strict for all description fields).
+    Forward guard: each YAML corpus file validates clean against its full parent
+    schema (which uses prose-strict for all description fields).
 
-    prose-strict adds: minItems:1 on outer array, minLength:1 on string items at both
-    depths, minItems:1 on inner array. The YAML corpus must already conform to these
-    constraints for the migration to be safe.
+    prose-strict requires: minItems:1 on outer array, minLength:1 on string items
+    at both depths, minItems:1 on inner array. A failure here surfaces content
+    drift (an empty array or empty string finding its way into a description
+    field) — route back to the maintainer to fix before the next tightening pass.
 
-    If any test FAILS today, it surfaces content drift (empty prose fields) that the
-    maintainer must fix BEFORE the schema migration lands.
-
-    Expected to PASS today (all YAML content is non-empty).
-    GREEN post-tightening.
-
-    Note: This validates against the *full parent schema* (not just definitions/<entity>),
-    because file-level description is also migrated and must be exercised.
-    The full-schema validation exercises the complete wiring including cross-file $refs.
+    Validates against the *full parent schema* (not just definitions/<entity>)
+    so the file-level description and complete cross-file $ref wiring are
+    exercised.
     """
 
     @pytest.mark.parametrize(
@@ -359,18 +342,14 @@ class TestCorpusProseStrictCompatibility:
         """
         Test that the full YAML corpus validates clean against the parent schema.
 
-        Given: A content schema (post-migration: description fields use prose-strict)
-               and its corresponding YAML corpus file
+        Given: A content schema (description fields use prose-strict) and its
+               corresponding YAML corpus file
         When: The YAML data is validated against the full parent schema
         Then: No errors are raised
 
-        DRIFT ALERT: If this fails, the schema_file + error messages identify
-        which YAML fields carry empty arrays or empty strings. Route back to
-        the maintainer to fix content before applying the schema constraint.
-
-        Note: Pre-migration, this test validates against utils/text (permissive).
-        Post-migration, it validates against prose-strict (strict). The test should
-        pass in both states if corpus content is well-formed.
+        On failure: schema_file + per-error JSON-path identify which YAML
+        fields carry empty arrays or empty strings, so the maintainer can fix
+        the offending content.
         """
         yaml_path = risk_map_yaml_dir / yaml_file
         if not yaml_path.is_file():
@@ -390,8 +369,7 @@ class TestCorpusProseStrictCompatibility:
             if excess:
                 error_summary += f"\n  ... and {excess} more errors"
             pytest.fail(
-                f"CONTENT DRIFT: {yaml_file} has validation errors against {schema_file}. "
-                f"Fix before migration lands:\n{error_summary}"
+                f"CONTENT DRIFT: {yaml_file} has validation errors against {schema_file}:\n{error_summary}"
             )
 
 
@@ -404,25 +382,18 @@ Test Summary
 Total test methods: 15 + 4 + 3 + 4 = 26
 Test classes: 4
 
-- TestProseMigrationRefValue (15 parametrized)
-    RED today: all 15 sites reference utils/text.
-    GREEN post-tightening.
-
+- TestProseMigrationRefValue (15 parametrized) — each site references
+  utils/prose-strict.
 - TestZeroResidualUtilsTextRefs (4 parametrized — one per content schema)
-    RED today: each schema has multiple utils/text $refs.
-    GREEN post-tightening.
-
-- TestUtilsTextCoexistenceGuard (3)
-    GREEN today: utils/text exists, prose-strict exists, supporting schemas use utils/text.
-    GREEN post-tightening.
-
+  — no utils/text $ref remains.
+- TestUtilsTextCoexistenceGuard (3) — utils/text retained, prose-strict
+  present, supporting schemas still consume utils/text.
 - TestCorpusProseStrictCompatibility (4 parametrized — one per YAML file)
-    GREEN today: corpus content is non-empty and prose-strict compatible.
-    GREEN post-tightening.
+  — live YAML validates clean against its parent schema.
 
 Coverage areas:
 - Per-site $ref value assertion: all 15 sites point at prose-strict
 - Zero-residual regex walk: no utils/text remains in content schemas
 - Coexistence: utils/text retained in riskmap.schema.json (supporting schemas need it)
-- Corpus audit: YAML content is prose-strict compatible before tightening lands
+- Corpus audit: YAML content is prose-strict compatible
 """

--- a/scripts/hooks/tests/test_consumer_prose_strict_migration.py
+++ b/scripts/hooks/tests/test_consumer_prose_strict_migration.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""
+Tests for Decision 4 (C1-schema-tightenings): migrate description-field $refs from
+`riskmap.schema.json#/definitions/utils/text` to `riskmap.schema.json#/definitions/utils/prose-strict`
+across the four content schemas, per ADRs 018-021 D4.
+
+Scope: 15 $ref sites in 4 content schemas (risks, controls, components, personas).
+Supporting schemas (frameworks, actor-access, impact-type, lifecycle-stage) are out of
+scope for this PR — they remain on utils/text.
+
+Coexistence note: definitions/utils/text is NOT removed from riskmap.schema.json by this PR.
+Supporting schemas + self-assessment.schema.json (C3 sibling PR) still reference it.
+A future PR will retire utils/text once all consumers migrate.
+
+Coverage:
+- Each of the 15 $ref sites points at utils/prose-strict (not utils/text) post-migration.
+- Zero residual utils/text $refs remain in each of the 4 content schemas.
+- riskmap.schema.json#/definitions/utils/text still exists (coexistence guard).
+- Live-corpus audit per schema: the YAML corpus for each content schema validates clean
+  against the post-migration schema (prose-strict compatibility probe). If a corpus field
+  carries an empty array or empty string, the probe surfaces it BEFORE tightening lands.
+
+Sites under test (15 total):
+  risks.schema.json (7):
+    /properties/description
+    /definitions/risk/properties/shortDescription
+    /definitions/risk/properties/longDescription
+    /definitions/risk/properties/tourContent/properties/introduced
+    /definitions/risk/properties/tourContent/properties/exposed
+    /definitions/risk/properties/tourContent/properties/mitigated
+    /definitions/risk/properties/examples
+
+  controls.schema.json (2):
+    /properties/description
+    /definitions/control/properties/description
+
+  components.schema.json (4):
+    /properties/description
+    /definitions/category/properties/description
+    /definitions/subcategory/properties/description
+    /definitions/component/properties/description
+
+  personas.schema.json (2):
+    /properties/description
+    /definitions/persona/properties/description
+
+Note on RED phase:
+  All $ref-value and zero-residual tests FAIL today (sites still reference utils/text).
+  Coexistence guard and corpus audit tests PASS today (the YAML corpus is prose-strict
+  compatible; B3 and predecessor PRs cleaned empty prose fields).
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+from jsonschema import Draft7Validator
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from conftest import _load_schema, _make_registry
+
+# ============================================================================
+# Module-level constants
+# ============================================================================
+
+PROSE_STRICT_REF = "riskmap.schema.json#/definitions/utils/prose-strict"
+UTILS_TEXT_REF_PATTERN = re.compile(r"riskmap\.schema\.json#/definitions/utils/text")
+
+# Each site is (schema_filename, json_pointer_path_to_the_property).
+# The path is expressed as a list of keys for dict traversal.
+# These map to the 15 confirmed utils/text $ref sites found by JSON walk.
+MIGRATION_SITES: list[tuple[str, list[str]]] = [
+    # risks.schema.json — 7 sites
+    ("risks.schema.json", ["properties", "description"]),
+    ("risks.schema.json", ["definitions", "risk", "properties", "shortDescription"]),
+    ("risks.schema.json", ["definitions", "risk", "properties", "longDescription"]),
+    ("risks.schema.json", ["definitions", "risk", "properties", "tourContent", "properties", "introduced"]),
+    ("risks.schema.json", ["definitions", "risk", "properties", "tourContent", "properties", "exposed"]),
+    ("risks.schema.json", ["definitions", "risk", "properties", "tourContent", "properties", "mitigated"]),
+    ("risks.schema.json", ["definitions", "risk", "properties", "examples"]),
+    # controls.schema.json — 2 sites
+    ("controls.schema.json", ["properties", "description"]),
+    ("controls.schema.json", ["definitions", "control", "properties", "description"]),
+    # components.schema.json — 4 sites
+    ("components.schema.json", ["properties", "description"]),
+    ("components.schema.json", ["definitions", "category", "properties", "description"]),
+    ("components.schema.json", ["definitions", "subcategory", "properties", "description"]),
+    ("components.schema.json", ["definitions", "component", "properties", "description"]),
+    # personas.schema.json — 2 sites
+    ("personas.schema.json", ["properties", "description"]),
+    ("personas.schema.json", ["definitions", "persona", "properties", "description"]),
+]
+
+# Schemas where all utils/text $refs must be zero post-migration.
+CONTENT_SCHEMAS: list[str] = [
+    "risks.schema.json",
+    "controls.schema.json",
+    "components.schema.json",
+    "personas.schema.json",
+]
+
+# Maps each content schema to the YAML corpus file for live-corpus audit probes.
+CORPUS_YAML_FILES: dict[str, str] = {
+    "risks.schema.json": "risks.yaml",
+    "controls.schema.json": "controls.yaml",
+    "components.schema.json": "components.yaml",
+    "personas.schema.json": "personas.yaml",
+}
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _resolve_path(schema: dict, key_path: list[str]) -> dict | None:
+    """
+    Traverse a nested dict following key_path and return the final node.
+    Returns None if any key is missing.
+    """
+    node = schema
+    for key in key_path:
+        if not isinstance(node, dict):
+            return None
+        node = node.get(key)
+    return node
+
+
+def _site_id(schema_file: str, path: list[str]) -> str:
+    """Human-readable pytest ID for a migration site."""
+    return f"{schema_file}:/{'/'.join(path)}"
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="module")
+def schemas_dir(risk_map_schemas_dir: Path) -> Path:
+    """Alias for concise test signatures."""
+    return risk_map_schemas_dir
+
+
+# ============================================================================
+# Decision 4 — each site $refs prose-strict (RED today)
+# ============================================================================
+
+
+class TestProseMigrationRefValue:
+    """
+    Each of the 15 $ref sites must point at utils/prose-strict after migration.
+
+    RED phase: all 15 tests FAIL today (sites still reference utils/text).
+    GREEN post-tightening.
+    """
+
+    @pytest.mark.parametrize(
+        "schema_file,key_path",
+        MIGRATION_SITES,
+        ids=[_site_id(s, p) for s, p in MIGRATION_SITES],
+    )
+    def test_description_ref_points_to_prose_strict(
+        self,
+        schemas_dir: Path,
+        schema_file: str,
+        key_path: list[str],
+    ):
+        """
+        Test that the $ref at this site points at utils/prose-strict.
+
+        Given: A content schema and a JSON path to a text-field property
+        When: The $ref value at that path is inspected
+        Then: It equals 'riskmap.schema.json#/definitions/utils/prose-strict'
+              (per ADRs 018-021 D4)
+        """
+        schema = _load_schema(schemas_dir, schema_file)
+        node = _resolve_path(schema, key_path)
+        assert node is not None, (
+            f"Path /{'/'.join(key_path)} not found in {schema_file}; "
+            "either the schema changed shape or the site list needs updating"
+        )
+        actual_ref = node.get("$ref")
+        assert actual_ref == PROSE_STRICT_REF, (
+            f"{schema_file} /{'/'.join(key_path)} must $ref '{PROSE_STRICT_REF}'; "
+            f"currently: {actual_ref!r} — RED phase (utils/text → utils/prose-strict migration pending)"
+        )
+
+
+# ============================================================================
+# Decision 4 — zero residual utils/text $refs in each content schema (RED today)
+# ============================================================================
+
+
+class TestZeroResidualUtilsTextRefs:
+    """
+    After migration, no utils/text $ref must remain in any of the 4 content schemas.
+
+    Uses a JSON serialisation regex walk rather than line-number counting, so it
+    remains robust if the schema is reformatted or lines shift.
+
+    RED phase: FAILS today (all 15 sites still reference utils/text).
+    GREEN post-tightening.
+    """
+
+    @pytest.mark.parametrize(
+        "schema_file",
+        CONTENT_SCHEMAS,
+        ids=CONTENT_SCHEMAS,
+    )
+    def test_no_utils_text_ref_in_content_schema(
+        self,
+        schemas_dir: Path,
+        schema_file: str,
+    ):
+        """
+        Test that no utils/text $ref remains in the content schema after migration.
+
+        Given: A content schema file
+        When: Its full JSON serialisation is scanned for utils/text refs
+        Then: No matches are found
+
+        Note: utils/text $refs in SUPPORTING schemas (frameworks, actor-access,
+        impact-type, lifecycle-stage) are explicitly out of scope for this PR.
+        This test only asserts the 4 content schemas.
+        """
+        schema = _load_schema(schemas_dir, schema_file)
+        serialised = json.dumps(schema)
+        matches = UTILS_TEXT_REF_PATTERN.findall(serialised)
+        assert not matches, (
+            f"{schema_file} still contains {len(matches)} utils/text $ref(s) after migration. "
+            f"All {len(matches)} must be replaced with utils/prose-strict — RED phase. "
+            "Note: supporting schemas (frameworks, actor-access, impact-type, lifecycle-stage) "
+            "are allowed to retain utils/text (out of scope for this PR)."
+        )
+
+
+# ============================================================================
+# Coexistence guard — utils/text still exists in riskmap.schema.json (GREEN today)
+# ============================================================================
+
+
+class TestUtilsTextCoexistenceGuard:
+    """
+    riskmap.schema.json#/definitions/utils/text must still exist after this PR.
+    Supporting schemas (frameworks, actor-access, impact-type, lifecycle-stage) and
+    self-assessment.schema.json (C3 sibling PR) still reference it. Removal is a
+    future follow-up once all consumers migrate.
+
+    Expected to PASS today and post-tightening.
+    """
+
+    def test_utils_text_still_exists_in_riskmap_schema(self, schemas_dir: Path):
+        """
+        Test that definitions/utils/text is still present in riskmap.schema.json.
+
+        Given: riskmap.schema.json
+        When: definitions/utils/text is looked up
+        Then: It is present (prose-strict migration does NOT remove utils/text from riskmap)
+
+        Removal of utils/text is deferred until all consumers (supporting schemas +
+        self-assessment.schema.json) have migrated. This is a follow-up PR concern.
+        """
+        schema = _load_schema(schemas_dir, "riskmap.schema.json")
+        utils = schema.get("definitions", {}).get("utils", {})
+        assert "text" in utils, (
+            "riskmap.schema.json#/definitions/utils/text must still exist after C1 tightening. "
+            "Removal is deferred — supporting schemas still reference utils/text."
+        )
+
+    def test_utils_prose_strict_exists_in_riskmap_schema(self, schemas_dir: Path):
+        """
+        Test that definitions/utils/prose-strict exists in riskmap.schema.json.
+
+        Given: riskmap.schema.json
+        When: definitions/utils/prose-strict is looked up
+        Then: It is present (already landed in a previous PR)
+        """
+        schema = _load_schema(schemas_dir, "riskmap.schema.json")
+        utils = schema.get("definitions", {}).get("utils", {})
+        assert "prose-strict" in utils, (
+            "riskmap.schema.json#/definitions/utils/prose-strict must exist "
+            "(prerequisite for Decision 4 migration)."
+        )
+
+    def test_supporting_schemas_still_use_utils_text(self, schemas_dir: Path):
+        """
+        Test that at least one supporting schema still uses utils/text (confirming it
+        must not be removed from riskmap.schema.json by this PR).
+
+        Given: The 4 supporting schemas that are out of scope for this PR
+        When: Their JSON is scanned for utils/text $refs
+        Then: At least one schema has a utils/text $ref
+
+        This confirms that removing utils/text from riskmap.schema.json would break
+        something, validating the coexistence requirement.
+        """
+        supporting_schemas = [
+            "frameworks.schema.json",
+            "actor-access.schema.json",
+            "impact-type.schema.json",
+            "lifecycle-stage.schema.json",
+        ]
+        total_text_refs = 0
+        for schema_file in supporting_schemas:
+            schema = _load_schema(schemas_dir, schema_file)
+            serialised = json.dumps(schema)
+            total_text_refs += len(UTILS_TEXT_REF_PATTERN.findall(serialised))
+
+        assert total_text_refs > 0, (
+            "Expected at least one utils/text $ref in supporting schemas "
+            "(frameworks, actor-access, impact-type, lifecycle-stage). "
+            "If all are zero, utils/text removal eligibility may have changed — "
+            "verify before deferring removal to a follow-up PR."
+        )
+
+
+# ============================================================================
+# Live-corpus audit — YAML corpus validates clean against post-migration schema
+# ============================================================================
+
+
+class TestCorpusProseStrictCompatibility:
+    """
+    Audit probe: each YAML corpus file must validate clean against the full
+    parent schema (which, post-migration, uses prose-strict for all description fields).
+
+    prose-strict adds: minItems:1 on outer array, minLength:1 on string items at both
+    depths, minItems:1 on inner array. The YAML corpus must already conform to these
+    constraints for the migration to be safe.
+
+    If any test FAILS today, it surfaces content drift (empty prose fields) that the
+    maintainer must fix BEFORE the schema migration lands.
+
+    Expected to PASS today (all YAML content is non-empty).
+    GREEN post-tightening.
+
+    Note: This validates against the *full parent schema* (not just definitions/<entity>),
+    because file-level description is also migrated and must be exercised.
+    The full-schema validation exercises the complete wiring including cross-file $refs.
+    """
+
+    @pytest.mark.parametrize(
+        "schema_file,yaml_file",
+        [(s, CORPUS_YAML_FILES[s]) for s in CONTENT_SCHEMAS],
+        ids=CONTENT_SCHEMAS,
+    )
+    def test_yaml_corpus_validates_clean_against_parent_schema(
+        self,
+        schemas_dir: Path,
+        risk_map_yaml_dir: Path,
+        schema_file: str,
+        yaml_file: str,
+    ):
+        """
+        Test that the full YAML corpus validates clean against the parent schema.
+
+        Given: A content schema (post-migration: description fields use prose-strict)
+               and its corresponding YAML corpus file
+        When: The YAML data is validated against the full parent schema
+        Then: No errors are raised
+
+        DRIFT ALERT: If this fails, the schema_file + error messages identify
+        which YAML fields carry empty arrays or empty strings. Route back to
+        the maintainer to fix content before applying the schema constraint.
+
+        Note: Pre-migration, this test validates against utils/text (permissive).
+        Post-migration, it validates against prose-strict (strict). The test should
+        pass in both states if corpus content is well-formed.
+        """
+        yaml_path = risk_map_yaml_dir / yaml_file
+        if not yaml_path.is_file():
+            pytest.fail(f"{yaml_file} not found at {yaml_path}")
+        with open(yaml_path) as fh:
+            data = yaml.safe_load(fh)
+
+        schema = _load_schema(schemas_dir, schema_file)
+        registry = _make_registry(schemas_dir)
+        validator = Draft7Validator(schema, registry=registry)
+
+        errors = list(validator.iter_errors(data))
+        if errors:
+            # Collect a concise error summary for the maintainer.
+            error_summary = "\n".join(f"  [{e.json_path}] {e.message}" for e in errors[:20])
+            excess = max(0, len(errors) - 20)
+            if excess:
+                error_summary += f"\n  ... and {excess} more errors"
+            pytest.fail(
+                f"CONTENT DRIFT: {yaml_file} has validation errors against {schema_file}. "
+                f"Fix before migration lands:\n{error_summary}"
+            )
+
+
+# ============================================================================
+# Test summary
+# ============================================================================
+"""
+Test Summary
+============
+Total test methods: 15 + 4 + 3 + 4 = 26
+Test classes: 4
+
+- TestProseMigrationRefValue (15 parametrized)
+    RED today: all 15 sites reference utils/text.
+    GREEN post-tightening.
+
+- TestZeroResidualUtilsTextRefs (4 parametrized — one per content schema)
+    RED today: each schema has multiple utils/text $refs.
+    GREEN post-tightening.
+
+- TestUtilsTextCoexistenceGuard (3)
+    GREEN today: utils/text exists, prose-strict exists, supporting schemas use utils/text.
+    GREEN post-tightening.
+
+- TestCorpusProseStrictCompatibility (4 parametrized — one per YAML file)
+    GREEN today: corpus content is non-empty and prose-strict compatible.
+    GREEN post-tightening.
+
+Coverage areas:
+- Per-site $ref value assertion: all 15 sites point at prose-strict
+- Zero-residual regex walk: no utils/text remains in content schemas
+- Coexistence: utils/text retained in riskmap.schema.json (supporting schemas need it)
+- Corpus audit: YAML content is prose-strict compatible before tightening lands
+"""

--- a/scripts/hooks/tests/test_prose_strict_field_discovery.py
+++ b/scripts/hooks/tests/test_prose_strict_field_discovery.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""
+Regression tests for prose-field discovery after the utils/text → utils/prose-strict
+migration in the four content schemas (risks, controls, components, personas).
+
+Background
+----------
+``find_prose_fields()`` in ``precommit/_prose_fields.py`` identifies prose fields
+by matching the ``$ref`` value in the schema against a known prose-ref string.
+After the content schemas were migrated to reference
+``riskmap.schema.json#/definitions/utils/prose-strict``, the discovery module
+still only recognised the old ``utils/text`` ref, causing zero ProseFields to be
+discovered for all four content YAML files.
+
+The fix must make ``find_prose_fields`` recognise BOTH refs:
+  - ``riskmap.schema.json#/definitions/utils/prose-strict``  (content schemas)
+  - ``riskmap.schema.json#/definitions/utils/text``          (supporting schemas)
+
+These tests are structured to be RED until that fix lands and GREEN afterwards.
+
+Test categories
+---------------
+1. Real-corpus non-zero discovery — the core regression guard.
+   Each content YAML must yield >0 ProseFields.
+
+2. prose-strict ref recognised via synthetic fixture — unit-level assertion
+   that a schema using utils/prose-strict causes find_prose_fields to discover
+   the field.
+
+3. utils/text still recognised — additive guard ensuring the fix does not swap
+   one ref for another; supporting schemas must still work.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# sys.path injection — same idiom as sibling tests (test_validate_yaml_prose_subset.py,
+# test_prose_field_shape_coverage.py)
+# ---------------------------------------------------------------------------
+sys.path.insert(0, str(Path(__file__).parent.parent / "precommit"))
+
+try:
+    from precommit._prose_fields import find_prose_fields  # noqa: E402
+
+    _IMPORT_ERROR: Exception | None = None
+except ImportError as _e:
+    _IMPORT_ERROR = _e
+    find_prose_fields = None  # type: ignore[assignment]
+
+
+@pytest.fixture(autouse=True)
+def _require_module():
+    """Fail every test with ImportError when _prose_fields cannot be imported."""
+    if _IMPORT_ERROR is not None:
+        raise _IMPORT_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Helpers — synthetic fixture builders
+#
+# The schema helpers follow the exact same pattern used in
+# test_prose_field_shape_coverage.py: a minimal schema whose
+# stem name matches the YAML file name so _infer_schema_name resolves it
+# without needing the full real schema tree.
+# ---------------------------------------------------------------------------
+
+_UTILS_TEXT_REF = "riskmap.schema.json#/definitions/utils/text"
+_UTILS_PROSE_STRICT_REF = "riskmap.schema.json#/definitions/utils/prose-strict"
+
+
+def _write_schema_with_ref(schema_dir: Path, stem: str, prose_ref: str) -> Path:
+    """Write a minimal ``<stem>.schema.json`` with one prose field using the given $ref.
+
+    The schema declares a single ``description`` prose field on the entity definition,
+    using the provided ``prose_ref`` value. Uses the same structure as
+    ``_write_mock_schema`` in test_prose_field_shape_coverage.py.
+
+    Args:
+        schema_dir: Directory to write the schema file into.
+        stem:       Schema filename stem (``<stem>.schema.json``); must match the YAML stem.
+        prose_ref:  The ``$ref`` value to use for the description field.
+
+    Returns:
+        Path to the written schema file.
+    """
+    schema = {
+        "$id": f"mock_{stem}.schema.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+            f"{stem}s": {
+                "type": "array",
+                "items": {"$ref": f"#/definitions/{stem}"},
+            }
+        },
+        "definitions": {
+            stem: {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "description": {"$ref": prose_ref},
+                },
+            }
+        },
+    }
+    path = schema_dir / f"{stem}.schema.json"
+    path.write_text(json.dumps(schema))
+    return path
+
+
+def _build_synthetic_corpus(
+    tmp_path: Path, stem: str, prose_ref: str, description_value: object
+) -> tuple[Path, Path]:
+    """Build a minimal schema + YAML pair for one entity using the given prose $ref.
+
+    Args:
+        tmp_path:           Per-test temporary directory.
+        stem:               YAML/schema stem name (e.g. ``"risks"``).
+        prose_ref:          The ``$ref`` string to place on the ``description`` field.
+        description_value:  Value to write for the prose field.
+
+    Returns:
+        ``(yaml_path, schema_dir)`` ready to pass to ``find_prose_fields``.
+    """
+    schema_dir = tmp_path / "schemas"
+    schema_dir.mkdir()
+    _write_schema_with_ref(schema_dir, stem, prose_ref)
+
+    yaml_dir = tmp_path / "yaml"
+    yaml_dir.mkdir()
+    data = {f"{stem}s": [{"id": f"{stem}Alpha", "description": description_value}]}
+    yaml_path = yaml_dir / f"{stem}.yaml"
+    yaml_path.write_text(yaml.dump(data))
+    return yaml_path, schema_dir
+
+
+# ---------------------------------------------------------------------------
+# Section 1 — Real-corpus non-zero discovery
+#
+# These tests are the core regression guard. They call find_prose_fields against
+# the actual YAML and schema files in the repository. Each must yield at least one
+# ProseField after the fix lands.
+#
+# Today (before the fix), all four yield 0 because the content schemas reference
+# utils/prose-strict but _prose_fields.py only recognises utils/text.
+# ---------------------------------------------------------------------------
+
+
+# Repo root relative to this file: scripts/hooks/tests/ -> ../../../
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_REAL_YAML_DIR = _REPO_ROOT / "risk-map" / "yaml"
+_REAL_SCHEMA_DIR = _REPO_ROOT / "risk-map" / "schemas"
+
+_CONTENT_YAML_FILES = [
+    "risks.yaml",
+    "controls.yaml",
+    "components.yaml",
+    "personas.yaml",
+]
+
+
+@pytest.mark.parametrize("yaml_filename", _CONTENT_YAML_FILES, ids=_CONTENT_YAML_FILES)
+def test_content_yaml_find_prose_fields_yields_nonzero(yaml_filename):
+    """
+    Asserts that find_prose_fields discovers at least one ProseField for each
+    content YAML file when run against the real repository schemas.
+
+    Given: A content YAML file and its companion schema (which uses utils/prose-strict
+           for all description fields per the prose-strict schema migration (ADR-017/ADR-019))
+    When:  find_prose_fields(yaml_path, schema_dir) is called
+    Then:  At least one ProseField is yielded
+
+    Before the fix: yields 0 (utils/prose-strict not recognised).
+    After the fix:  yields >0 (both utils/prose-strict and utils/text recognised).
+    """
+    yaml_path = _REAL_YAML_DIR / yaml_filename
+    if not yaml_path.is_file():
+        pytest.fail(f"Real corpus file not found: {yaml_path}")
+
+    fields = list(find_prose_fields(yaml_path, _REAL_SCHEMA_DIR))
+
+    assert len(fields) > 0, (
+        f"find_prose_fields() returned 0 ProseFields for {yaml_filename}. "
+        f"The schema for this file uses utils/prose-strict $refs, which are not "
+        f"recognised by the current _PROSE_REF constant in _prose_fields.py. "
+        f"Fix: extend _is_prose_ref (or _PROSE_REFS) to recognise both "
+        f"utils/prose-strict and utils/text."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — prose-strict ref recognised at the unit level
+#
+# These tests use synthetic schema+yaml fixtures so they isolate exactly the
+# ref-recognition logic without depending on the real corpus content.
+#
+# The assertion is against the public find_prose_fields interface. The private
+# _is_prose_ref/_PROSE_REF symbols are not imported here because the SWE may
+# rename them to _is_prose_ref/_PROSE_REFS during the fix. If a test that
+# exercises the private predicate directly is later needed, it should be added
+# with a comment noting the symbol may be renamed.
+# ---------------------------------------------------------------------------
+
+
+def test_prose_strict_ref_causes_field_to_be_discovered(tmp_path):
+    """
+    Asserts that a schema field whose $ref is utils/prose-strict is discovered
+    by find_prose_fields.
+
+    Given: A synthetic schema where description uses utils/prose-strict, and a
+           matching YAML entry with a non-empty description
+    When:  find_prose_fields(yaml_path, schema_dir) is called
+    Then:  At least one ProseField is yielded — the description value is
+           discovered as a prose field
+
+    Before the fix: yields 0 (utils/prose-strict not in the recognised-ref set).
+    After the fix:  yields >0.
+    """
+    yaml_path, schema_dir = _build_synthetic_corpus(
+        tmp_path,
+        stem="risks",
+        prose_ref=_UTILS_PROSE_STRICT_REF,
+        description_value=["A sentence about this risk."],
+    )
+
+    fields = list(find_prose_fields(yaml_path, schema_dir))
+
+    assert len(fields) > 0, (
+        f"find_prose_fields() returned 0 ProseFields for a schema that uses "
+        f"utils/prose-strict. The $ref '{_UTILS_PROSE_STRICT_REF}' is not "
+        f"recognised by _is_prose_ref in _prose_fields.py. "
+        f"Fix: add this ref to the recognised set alongside utils/text."
+    )
+
+
+def test_prose_strict_ref_discovered_field_has_correct_raw_text(tmp_path):
+    """
+    Asserts that the ProseField discovered via utils/prose-strict carries the
+    correct raw_text value from the YAML entry.
+
+    Given: A synthetic schema with utils/prose-strict and a YAML entry with
+           description: ["Expected text."]
+    When:  find_prose_fields is called
+    Then:  The single ProseField has raw_text == "Expected text."
+    """
+    expected_text = "Expected text."
+    yaml_path, schema_dir = _build_synthetic_corpus(
+        tmp_path,
+        stem="controls",
+        prose_ref=_UTILS_PROSE_STRICT_REF,
+        description_value=[expected_text],
+    )
+
+    fields = list(find_prose_fields(yaml_path, schema_dir))
+
+    # one entity, one description field, one list item -> exactly one ProseField
+    assert len(fields) == 1, f"Expected exactly one ProseField from a single-entry description; got {len(fields)}"
+    assert fields[0].raw_text == expected_text, (
+        f"ProseField.raw_text mismatch: expected {expected_text!r}, got {fields[0].raw_text!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 3 — utils/text still recognised (no-regression on supporting schemas)
+#
+# These tests confirm that the fix is additive: the utils/text ref must continue
+# to be discovered so supporting schemas (frameworks, actor-access, impact-type,
+# lifecycle-stage) are not broken by the fix.
+# ---------------------------------------------------------------------------
+
+
+def test_utils_text_ref_causes_field_to_be_discovered_synthetic(tmp_path):
+    """
+    Asserts that a schema field whose $ref is utils/text is still discovered by
+    find_prose_fields after the fix.
+
+    Given: A synthetic schema where description uses utils/text
+    When:  find_prose_fields is called
+    Then:  At least one ProseField is yielded
+
+    This is a no-regression guard: the fix must extend the recognised-ref set,
+    not swap utils/text for utils/prose-strict.
+    """
+    yaml_path, schema_dir = _build_synthetic_corpus(
+        tmp_path,
+        stem="risks",
+        prose_ref=_UTILS_TEXT_REF,
+        description_value=["A sentence."],
+    )
+
+    fields = list(find_prose_fields(yaml_path, schema_dir))
+
+    assert len(fields) > 0, (
+        "find_prose_fields() returned 0 ProseFields for a schema using utils/text. "
+        "The utils/text $ref must remain recognised after the fix. "
+        "Fix must be additive (both refs recognised), not a swap."
+    )
+
+
+def test_utils_text_ref_real_supporting_schema_yields_nonzero():
+    """
+    Asserts that find_prose_fields yields at least one ProseField for a real
+    supporting schema that uses utils/text.
+
+    Given: frameworks.yaml and its companion schema (which uses utils/text)
+    When:  find_prose_fields is called
+    Then:  At least one ProseField is yielded
+
+    This guards against a regression where the fix accidentally stops recognising
+    utils/text, breaking discovery for supporting schemas.
+    """
+    yaml_path = _REAL_YAML_DIR / "frameworks.yaml"
+    if not yaml_path.is_file():
+        pytest.skip(f"frameworks.yaml not found at {yaml_path}; skipping real-corpus guard")
+
+    fields = list(find_prose_fields(yaml_path, _REAL_SCHEMA_DIR))
+
+    assert len(fields) > 0, (
+        "find_prose_fields() returned 0 ProseFields for frameworks.yaml. "
+        "The frameworks schema uses utils/text, which must remain recognised "
+        "after the fix. The fix must extend the recognised-ref set, not swap it."
+    )
+
+
+def test_both_refs_discovered_when_each_used_in_separate_schemas(tmp_path):
+    """
+    Asserts that two schemas in the same schema_dir — one using utils/prose-strict
+    and one using utils/text — each cause find_prose_fields to discover a field.
+
+    Given: Two minimal schemas in the same schema_dir, one referencing
+           utils/prose-strict and one utils/text; two matching YAML files
+    When:  find_prose_fields is called on each YAML file
+    Then:  Both calls yield at least one ProseField
+
+    This confirms the fix is additive: both refs are in the recognised set
+    simultaneously.
+    """
+    # Schema/YAML pair for utils/prose-strict (content schema shape)
+    # Use singular stems ("risk", "framework") so _write_schema_with_ref produces
+    # array-property keys "risks" / "frameworks" that match the YAML top-level keys.
+    schema_dir = tmp_path / "schemas"
+    schema_dir.mkdir()
+    _write_schema_with_ref(schema_dir, "risk", _UTILS_PROSE_STRICT_REF)
+    _write_schema_with_ref(schema_dir, "framework", _UTILS_TEXT_REF)
+
+    yaml_dir = tmp_path / "yaml"
+    yaml_dir.mkdir()
+
+    # YAML top-level keys must match the schema's array-property keys (f"{stem}s").
+    risks_yaml = yaml_dir / "risk.yaml"
+    risks_yaml.write_text(yaml.dump({"risks": [{"id": "riskAlpha", "description": ["Risk prose."]}]}))
+
+    frameworks_yaml = yaml_dir / "framework.yaml"
+    frameworks_yaml.write_text(yaml.dump({"frameworks": [{"id": "fwAlpha", "description": ["Framework prose."]}]}))
+
+    prose_strict_fields = list(find_prose_fields(risks_yaml, schema_dir))
+    utils_text_fields = list(find_prose_fields(frameworks_yaml, schema_dir))
+
+    assert len(prose_strict_fields) > 0, (
+        "utils/prose-strict schema yielded 0 ProseFields in a two-schema schema_dir. "
+        "The fix must recognise utils/prose-strict alongside utils/text."
+    )
+    assert len(utils_text_fields) > 0, (
+        "utils/text schema yielded 0 ProseFields in a two-schema schema_dir. "
+        "The fix must retain utils/text recognition (additive, not a swap)."
+    )
+
+
+"""
+Test Summary
+============
+Total Tests: 9
+
+Section 1 — Real-corpus non-zero discovery (4 parametrized):
+  test_content_yaml_find_prose_fields_yields_nonzero[risks.yaml]
+  test_content_yaml_find_prose_fields_yields_nonzero[controls.yaml]
+  test_content_yaml_find_prose_fields_yields_nonzero[components.yaml]
+  test_content_yaml_find_prose_fields_yields_nonzero[personas.yaml]
+
+Section 2 — prose-strict ref recognised (2):
+  test_prose_strict_ref_causes_field_to_be_discovered
+  test_prose_strict_ref_discovered_field_has_correct_raw_text
+
+Section 3 — utils/text still recognised (3):
+  test_utils_text_ref_causes_field_to_be_discovered_synthetic
+  test_utils_text_ref_real_supporting_schema_yields_nonzero
+  test_both_refs_discovered_when_each_used_in_separate_schemas
+
+Coverage areas:
+  - Real-corpus regression guard: content schemas post-migration yield >0 fields
+  - utils/prose-strict synthetic: schema using prose-strict ref is discovered
+  - utils/text no-regression: utils/text remains recognised after the fix
+  - Additive fix validation: both refs work simultaneously in one schema_dir
+"""

--- a/scripts/hooks/tests/test_risks_schema_relevant_questions_removed.py
+++ b/scripts/hooks/tests/test_risks_schema_relevant_questions_removed.py
@@ -1,23 +1,20 @@
 #!/usr/bin/env python3
 """
-Tests for Decision 1 (C1-schema-tightenings): remove `relevantQuestions` from
-risks.schema.json per ADR-019 D6.
+Tests for Decision 1 (C1-schema-tightenings): `relevantQuestions` is removed
+from risks.schema.json per ADR-019 D6.
 
-B3 (PR #293) cleaned `relevantQuestions` content from risks.yaml. This PR
-closes the loop on the schema side: the property definition is dropped from
-definitions/risk/properties, so any YAML author who accidentally writes
-`relevantQuestions` gets a validation error instead of silent acceptance.
+B3 (PR #293) cleaned the field from risks.yaml content; C1 closes the loop
+on the schema side. With the property definition dropped from
+definitions/risk/properties (and additionalProperties:false from Decision 2),
+any YAML author who writes `relevantQuestions` gets a validation error
+instead of silent acceptance.
 
 Coverage:
-- definitions/risk/properties does NOT contain 'relevantQuestions' (post-tightening assertion).
-- A synthetic risk entry with relevantQuestions raises ValidationError (RED today: passes with current schema).
-- The live risks.yaml corpus contains no risk entries with relevantQuestions keys (audit probe).
-
-Note on RED phase:
-  Tests in TestRelevantQuestionsRemovedFromSchema / TestRelevantQuestionsRejected
-  are expected to FAIL against the current (pre-tightening) schema. They will
-  pass after the SWE removes the property definition.
-  TestRisksYamlHasNoRelevantQuestions is expected to PASS today (B3 already cleaned).
+- definitions/risk/properties does not declare 'relevantQuestions'.
+- A synthetic risk entry carrying relevantQuestions fails validation
+  (combined effect of D1 removal + D2 additionalProperties:false).
+- The live risks.yaml corpus carries no relevantQuestions keys (forward guard
+  against a regression that would reintroduce the field).
 """
 
 import sys
@@ -111,19 +108,17 @@ def risks_yaml_data(risk_map_yaml_dir: Path) -> dict:
 
 
 # ============================================================================
-# Decision 1 — relevantQuestions REMOVED from schema (RED today; GREEN post-tightening)
+# Decision 1 — relevantQuestions absent from schema
 # ============================================================================
 
 
 class TestRelevantQuestionsRemovedFromSchema:
     """
-    definitions/risk/properties must NOT contain 'relevantQuestions' after tightening.
+    definitions/risk/properties does not contain 'relevantQuestions'.
 
-    ADR-019 D6: the field was removed from the YAML corpus by B3 (PR #293).
-    The schema property definition must also be removed so the closed schema
-    (post additionalProperties:false, Decision 2) rejects stray uses.
-
-    RED phase: these tests FAIL today because the schema still declares the property.
+    ADR-019 D6: the field was removed from the YAML corpus by B3 (PR #293) and
+    from the schema by C1. With additionalProperties:false also in place
+    (Decision 2), stray uses of the field are rejected at validation time.
     """
 
     def test_relevant_questions_absent_from_risk_properties(self, risk_properties: dict):
@@ -135,31 +130,28 @@ class TestRelevantQuestionsRemovedFromSchema:
         Then: 'relevantQuestions' is absent (per ADR-019 D6 cleanup)
         """
         assert "relevantQuestions" not in risk_properties, (
-            "definitions/risk/properties must not declare 'relevantQuestions' after C1 tightening "
-            "(ADR-019 D6: field removed from YAML corpus by B3; schema must follow)"
+            "definitions/risk/properties must not declare 'relevantQuestions' "
+            "(ADR-019 D6: field removed from YAML corpus by B3; schema follows)"
         )
 
 
 # ============================================================================
-# Decision 1 — synthetic entry with relevantQuestions is rejected (RED today)
+# Decision 1 — synthetic entry with relevantQuestions is rejected
 # ============================================================================
 
 
 class TestRelevantQuestionsRejected:
     """
-    A synthetic risk entry carrying relevantQuestions must raise ValidationError
-    once additionalProperties:false is in place (Decision 2 depends on Decision 1).
+    A synthetic risk entry carrying relevantQuestions raises ValidationError.
 
-    This test exercises the combined effect of D1+D2: after both land, a stray
-    relevantQuestions field is caught by additionalProperties:false.
-
-    RED phase: FAILS today because (a) the property is still declared and
-    (b) additionalProperties:false is not yet on definitions/risk.
+    Exercises the combined effect of D1+D2: the property no longer exists in
+    the schema, and additionalProperties:false on definitions/risk rejects
+    any stray field — including the retired relevantQuestions key.
     """
 
     def test_risk_with_relevant_questions_raises_validation_error(self, risk_validator: Draft7Validator):
         """
-        Test that a risk entry with relevantQuestions is rejected after tightening.
+        Test that a risk entry with relevantQuestions is rejected.
 
         Given: A synthetic risk with a 'relevantQuestions' field
         When: It is validated against definitions/risk
@@ -169,7 +161,7 @@ class TestRelevantQuestionsRejected:
         entry["relevantQuestions"] = ["Is this risk applicable?"]
         errors = list(risk_validator.iter_errors(entry))
         assert errors, (
-            "A risk entry with 'relevantQuestions' must fail validation after C1 tightening "
+            "A risk entry with 'relevantQuestions' must fail validation "
             "(ADR-019 D6 removal + additionalProperties:false from Decision 2)"
         )
 
@@ -189,17 +181,15 @@ class TestRelevantQuestionsRejected:
 
 
 # ============================================================================
-# Corpus audit — risks.yaml has no relevantQuestions keys (GREEN today; stays GREEN)
+# Corpus audit — risks.yaml has no relevantQuestions keys
 # ============================================================================
 
 
 class TestRisksYamlHasNoRelevantQuestions:
     """
-    Audit probe: the live risks.yaml corpus must have no risk entries carrying
+    Audit probe: the live risks.yaml corpus carries no risk entries with
     'relevantQuestions'. B3 (PR #293) cleaned these; this test is a forward
-    guard that surfaces regressions before schema tightening lands.
-
-    Expected to PASS today and after tightening.
+    guard that catches any regression that would reintroduce the field.
     """
 
     def test_no_relevant_questions_in_corpus(self, risks_yaml_data: dict):
@@ -228,17 +218,11 @@ Test Summary
 Total test methods: 4
 Test classes: 3
 
-- TestRelevantQuestionsRemovedFromSchema (1)
-    RED today: schema still declares the property.
-    GREEN post-tightening: property definition removed.
-
-- TestRelevantQuestionsRejected (2)
-    RED today: property still accepted by schema; additionalProperties not yet false.
-    GREEN post-tightening: combined D1+D2 effect rejects stray field.
-
-- TestRisksYamlHasNoRelevantQuestions (1)
-    GREEN today: B3 already cleaned corpus.
-    GREEN post-tightening: still passes.
+- TestRelevantQuestionsRemovedFromSchema (1) — property absent from
+  definitions/risk/properties.
+- TestRelevantQuestionsRejected (2) — synthetic entry with the field is
+  rejected (D1+D2 combined effect); minimal valid entry still passes.
+- TestRisksYamlHasNoRelevantQuestions (1) — live corpus forward-guard.
 
 Coverage areas:
 - Schema structural check: relevantQuestions absent from definitions/risk/properties

--- a/scripts/hooks/tests/test_risks_schema_relevant_questions_removed.py
+++ b/scripts/hooks/tests/test_risks_schema_relevant_questions_removed.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""
+Tests for Decision 1 (C1-schema-tightenings): remove `relevantQuestions` from
+risks.schema.json per ADR-019 D6.
+
+B3 (PR #293) cleaned `relevantQuestions` content from risks.yaml. This PR
+closes the loop on the schema side: the property definition is dropped from
+definitions/risk/properties, so any YAML author who accidentally writes
+`relevantQuestions` gets a validation error instead of silent acceptance.
+
+Coverage:
+- definitions/risk/properties does NOT contain 'relevantQuestions' (post-tightening assertion).
+- A synthetic risk entry with relevantQuestions raises ValidationError (RED today: passes with current schema).
+- The live risks.yaml corpus contains no risk entries with relevantQuestions keys (audit probe).
+
+Note on RED phase:
+  Tests in TestRelevantQuestionsRemovedFromSchema / TestRelevantQuestionsRejected
+  are expected to FAIL against the current (pre-tightening) schema. They will
+  pass after the SWE removes the property definition.
+  TestRisksYamlHasNoRelevantQuestions is expected to PASS today (B3 already cleaned).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+from jsonschema import Draft7Validator
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from conftest import _load_schema, _make_registry
+
+# ============================================================================
+# Module-level constants
+# ============================================================================
+
+SCHEMA_FILE = "risks.schema.json"
+ENTITY_KEY = "risk"
+
+# A minimal valid risk entry used as the base for synthetic tests.
+# Fields satisfy the required array: id, title, shortDescription, longDescription,
+# category, personas, controls. Values are enum-valid per the current schema.
+_MINIMAL_VALID_RISK: dict = {
+    "id": "riskDataPoisoning",
+    "title": "Data Poisoning",
+    "shortDescription": ["Short description text."],
+    "longDescription": ["Long description text."],
+    "category": "risksSupplyChainAndDevelopment",
+    "personas": ["personaModelProvider"],
+    "controls": ["controlTrainingDataSanitization"],
+}
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="module")
+def schemas_dir(risk_map_schemas_dir: Path) -> Path:
+    """Alias for concise test signatures."""
+    return risk_map_schemas_dir
+
+
+@pytest.fixture(scope="module")
+def risks_schema(schemas_dir: Path) -> dict:
+    """Parsed risks.schema.json."""
+    return _load_schema(schemas_dir, SCHEMA_FILE)
+
+
+@pytest.fixture(scope="module")
+def risk_definition(risks_schema: dict) -> dict:
+    """The definitions/risk block from risks.schema.json."""
+    defn = risks_schema.get("definitions", {}).get(ENTITY_KEY)
+    if defn is None:
+        pytest.fail(f"definitions/{ENTITY_KEY} not found in {SCHEMA_FILE}")
+    return defn
+
+
+@pytest.fixture(scope="module")
+def risk_properties(risk_definition: dict) -> dict:
+    """The properties dict from definitions/risk."""
+    props = risk_definition.get("properties", {})
+    if not props:
+        pytest.fail(f"definitions/{ENTITY_KEY}/properties not found in {SCHEMA_FILE}")
+    return props
+
+
+@pytest.fixture(scope="module")
+def risk_validator(schemas_dir: Path) -> Draft7Validator:
+    """
+    Draft-07 validator targeting definitions/risk with full cross-file $ref resolution.
+
+    Uses a $ref wrapper against the registry so internal #/definitions/... refs inside
+    definitions/risk (e.g., controls.$ref, personas.$ref) resolve correctly against the
+    full risks.schema.json root, not just the entity sub-object.
+    """
+    registry = _make_registry(schemas_dir)
+    return Draft7Validator({"$ref": f"{SCHEMA_FILE}#/definitions/{ENTITY_KEY}"}, registry=registry)
+
+
+@pytest.fixture(scope="module")
+def risks_yaml_data(risk_map_yaml_dir: Path) -> dict:
+    """Parsed risks.yaml corpus data."""
+    path = risk_map_yaml_dir / "risks.yaml"
+    if not path.is_file():
+        pytest.fail(f"risks.yaml not found at {path}")
+    with open(path) as fh:
+        return yaml.safe_load(fh)
+
+
+# ============================================================================
+# Decision 1 — relevantQuestions REMOVED from schema (RED today; GREEN post-tightening)
+# ============================================================================
+
+
+class TestRelevantQuestionsRemovedFromSchema:
+    """
+    definitions/risk/properties must NOT contain 'relevantQuestions' after tightening.
+
+    ADR-019 D6: the field was removed from the YAML corpus by B3 (PR #293).
+    The schema property definition must also be removed so the closed schema
+    (post additionalProperties:false, Decision 2) rejects stray uses.
+
+    RED phase: these tests FAIL today because the schema still declares the property.
+    """
+
+    def test_relevant_questions_absent_from_risk_properties(self, risk_properties: dict):
+        """
+        Test that relevantQuestions is not declared in definitions/risk/properties.
+
+        Given: definitions/risk/properties from risks.schema.json
+        When: The property names are inspected
+        Then: 'relevantQuestions' is absent (per ADR-019 D6 cleanup)
+        """
+        assert "relevantQuestions" not in risk_properties, (
+            "definitions/risk/properties must not declare 'relevantQuestions' after C1 tightening "
+            "(ADR-019 D6: field removed from YAML corpus by B3; schema must follow)"
+        )
+
+
+# ============================================================================
+# Decision 1 — synthetic entry with relevantQuestions is rejected (RED today)
+# ============================================================================
+
+
+class TestRelevantQuestionsRejected:
+    """
+    A synthetic risk entry carrying relevantQuestions must raise ValidationError
+    once additionalProperties:false is in place (Decision 2 depends on Decision 1).
+
+    This test exercises the combined effect of D1+D2: after both land, a stray
+    relevantQuestions field is caught by additionalProperties:false.
+
+    RED phase: FAILS today because (a) the property is still declared and
+    (b) additionalProperties:false is not yet on definitions/risk.
+    """
+
+    def test_risk_with_relevant_questions_raises_validation_error(self, risk_validator: Draft7Validator):
+        """
+        Test that a risk entry with relevantQuestions is rejected after tightening.
+
+        Given: A synthetic risk with a 'relevantQuestions' field
+        When: It is validated against definitions/risk
+        Then: ValidationError is raised (field removed + additionalProperties:false)
+        """
+        entry = dict(_MINIMAL_VALID_RISK)
+        entry["relevantQuestions"] = ["Is this risk applicable?"]
+        errors = list(risk_validator.iter_errors(entry))
+        assert errors, (
+            "A risk entry with 'relevantQuestions' must fail validation after C1 tightening "
+            "(ADR-019 D6 removal + additionalProperties:false from Decision 2)"
+        )
+
+    def test_valid_risk_without_relevant_questions_passes(self, risk_validator: Draft7Validator):
+        """
+        Test that a minimal valid risk entry passes validation.
+
+        Given: A minimal risk entry with all required fields and no stray properties
+        When: It is validated against definitions/risk
+        Then: No ValidationError is raised (baseline: the valid entry must pass)
+        """
+        errors = list(risk_validator.iter_errors(_MINIMAL_VALID_RISK))
+        assert not errors, (
+            f"Minimal valid risk entry must pass definitions/risk validation; "
+            f"errors: {[e.message for e in errors]}"
+        )
+
+
+# ============================================================================
+# Corpus audit — risks.yaml has no relevantQuestions keys (GREEN today; stays GREEN)
+# ============================================================================
+
+
+class TestRisksYamlHasNoRelevantQuestions:
+    """
+    Audit probe: the live risks.yaml corpus must have no risk entries carrying
+    'relevantQuestions'. B3 (PR #293) cleaned these; this test is a forward
+    guard that surfaces regressions before schema tightening lands.
+
+    Expected to PASS today and after tightening.
+    """
+
+    def test_no_relevant_questions_in_corpus(self, risks_yaml_data: dict):
+        """
+        Test that no risk entry in risks.yaml contains a relevantQuestions key.
+
+        Given: The full risks.yaml corpus
+        When: Each risk entry is inspected for the 'relevantQuestions' key
+        Then: No entry carries the key (B3 cleanup is complete)
+        """
+        offenders = [
+            r.get("id", "<unknown>") for r in risks_yaml_data.get("risks", []) if "relevantQuestions" in r
+        ]
+        assert not offenders, (
+            f"risks.yaml still has 'relevantQuestions' in risk entries: {offenders}. "
+            "B3 (PR #293) should have removed all occurrences."
+        )
+
+
+# ============================================================================
+# Test summary
+# ============================================================================
+"""
+Test Summary
+============
+Total test methods: 4
+Test classes: 3
+
+- TestRelevantQuestionsRemovedFromSchema (1)
+    RED today: schema still declares the property.
+    GREEN post-tightening: property definition removed.
+
+- TestRelevantQuestionsRejected (2)
+    RED today: property still accepted by schema; additionalProperties not yet false.
+    GREEN post-tightening: combined D1+D2 effect rejects stray field.
+
+- TestRisksYamlHasNoRelevantQuestions (1)
+    GREEN today: B3 already cleaned corpus.
+    GREEN post-tightening: still passes.
+
+Coverage areas:
+- Schema structural check: relevantQuestions absent from definitions/risk/properties
+- Behavioral rejection: synthetic entry with relevantQuestions fails validation
+- Corpus audit: live risks.yaml has no relevantQuestions (forward guard)
+"""

--- a/scripts/hooks/tests/test_title_max_length_constraints.py
+++ b/scripts/hooks/tests/test_title_max_length_constraints.py
@@ -1,26 +1,22 @@
 #!/usr/bin/env python3
 """
-Tests for Decision 3 (C1-schema-tightenings): add `maxLength` constraints to
+Tests for Decision 3 (C1-schema-tightenings): `maxLength` constraints on
 `title` fields in risks.schema.json and controls.schema.json.
 
-Per ADR-019 D8: risks.schema.json definitions/risk/properties/title gets maxLength:120.
-Per ADR-020 D7: controls.schema.json definitions/control/properties/title gets maxLength:100.
+Per ADR-019 D8: risks.schema.json definitions/risk/properties/title declares
+maxLength:120.
+Per ADR-020 D7: controls.schema.json definitions/control/properties/title
+declares maxLength:100.
 
-These limits were set conservatively above the longest current corpus entry to
-avoid breaking existing content while capping future drift.
+The limits sit conservatively above the longest current corpus entry — max
+risk title 40 chars, max control title 49 chars — capping future drift
+without breaking existing content.
 
 Coverage:
-- definitions/risk/properties/title declares maxLength:120.
-- definitions/control/properties/title declares maxLength:100.
-- A synthetic risk title of length 121 is rejected; length 120 passes.
-- A synthetic control title of length 101 is rejected; length 100 passes.
-- Corpus audit: every current risks.yaml title is ≤120 chars (no existing drift).
-- Corpus audit: every current controls.yaml title is ≤100 chars (no existing drift).
-
-Note on RED phase:
-  Tests in TestRiskTitleMaxLengthDeclared / TestControlTitleMaxLengthDeclared
-  and all synthetic boundary tests FAIL today (pre-tightening: no maxLength declared).
-  Corpus audit tests PASS today (no current corpus entry exceeds limits).
+- Schema structural check: maxLength declared at the correct value.
+- Behavioral boundary: at-limit titles pass, over-limit titles are rejected.
+- Corpus audit: every current risks.yaml / controls.yaml title is within
+  its limit (forward guard against future content drift).
 """
 
 import sys
@@ -143,16 +139,13 @@ def controls_yaml_data(risk_map_yaml_dir: Path) -> dict:
 
 
 # ============================================================================
-# Decision 3 — risk title maxLength declared (RED today)
+# Decision 3 — risk title maxLength declared
 # ============================================================================
 
 
 class TestRiskTitleMaxLengthDeclared:
     """
-    definitions/risk/properties/title must declare maxLength:120 after C1 tightening.
-
-    RED phase: FAILS today (no maxLength on title).
-    GREEN post-tightening.
+    definitions/risk/properties/title declares maxLength:120 per ADR-019 D8.
     """
 
     def test_risk_title_has_max_length_120(self, risk_title_schema: dict):
@@ -170,16 +163,13 @@ class TestRiskTitleMaxLengthDeclared:
 
 
 # ============================================================================
-# Decision 3 — control title maxLength declared (RED today)
+# Decision 3 — control title maxLength declared
 # ============================================================================
 
 
 class TestControlTitleMaxLengthDeclared:
     """
-    definitions/control/properties/title must declare maxLength:100 after C1 tightening.
-
-    RED phase: FAILS today (no maxLength on title).
-    GREEN post-tightening.
+    definitions/control/properties/title declares maxLength:100 per ADR-020 D7.
     """
 
     def test_control_title_has_max_length_100(self, control_title_schema: dict):
@@ -197,7 +187,7 @@ class TestControlTitleMaxLengthDeclared:
 
 
 # ============================================================================
-# Decision 3 — risk title boundary enforcement (RED today)
+# Decision 3 — risk title boundary enforcement
 # ============================================================================
 
 
@@ -205,10 +195,8 @@ class TestRiskTitleBoundaryEnforcement:
     """
     Behavioral tests for the risk title maxLength boundary.
 
-    A title of exactly 120 chars must pass; 121 chars must fail.
-
-    RED phase: both boundary tests FAIL today (no maxLength declared → 121-char title accepted).
-    GREEN post-tightening.
+    A title of exactly 120 chars passes; 121 chars is rejected by the
+    maxLength constraint.
     """
 
     def test_risk_title_at_max_length_passes(self, risk_validator: Draft7Validator):
@@ -240,12 +228,12 @@ class TestRiskTitleBoundaryEnforcement:
         errors = list(risk_validator.iter_errors(entry))
         assert errors, (
             f"Risk title of length {RISK_TITLE_MAX_LENGTH + 1} must fail validation "
-            f"(maxLength:{RISK_TITLE_MAX_LENGTH}); currently accepted — RED phase"
+            f"(maxLength:{RISK_TITLE_MAX_LENGTH})"
         )
 
 
 # ============================================================================
-# Decision 3 — control title boundary enforcement (RED today)
+# Decision 3 — control title boundary enforcement
 # ============================================================================
 
 
@@ -253,10 +241,8 @@ class TestControlTitleBoundaryEnforcement:
     """
     Behavioral tests for the control title maxLength boundary.
 
-    A title of exactly 100 chars must pass; 101 chars must fail.
-
-    RED phase: both boundary tests FAIL today (no maxLength declared → 101-char title accepted).
-    GREEN post-tightening.
+    A title of exactly 100 chars passes; 101 chars is rejected by the
+    maxLength constraint.
     """
 
     def test_control_title_at_max_length_passes(self, control_validator: Draft7Validator):
@@ -288,24 +274,22 @@ class TestControlTitleBoundaryEnforcement:
         errors = list(control_validator.iter_errors(entry))
         assert errors, (
             f"Control title of length {CONTROL_TITLE_MAX_LENGTH + 1} must fail validation "
-            f"(maxLength:{CONTROL_TITLE_MAX_LENGTH}); currently accepted — RED phase"
+            f"(maxLength:{CONTROL_TITLE_MAX_LENGTH})"
         )
 
 
 # ============================================================================
-# Corpus audit — no current entry exceeds the maxLength limits (GREEN today)
+# Corpus audit — no current entry exceeds the maxLength limits
 # ============================================================================
 
 
 class TestRiskTitleCorpusAudit:
     """
-    Audit probe: every current risks.yaml title must be ≤120 characters.
+    Forward guard: every current risks.yaml title is ≤120 characters.
 
-    This probe verifies that tightening does not break existing content.
-    If this test FAILS today, there is content drift that must be fixed
-    BEFORE the schema constraint is added — surface the offending entries.
-
-    Expected to PASS today and post-tightening.
+    The schema constraint enforces the limit; this test surfaces a violation
+    with the offending entries listed by name and length if content drift
+    ever reintroduces an over-limit title.
     """
 
     def test_all_risk_titles_within_max_length(self, risks_yaml_data: dict):
@@ -316,8 +300,7 @@ class TestRiskTitleCorpusAudit:
         When: Each title's length is measured
         Then: No title exceeds 120 characters
 
-        DRIFT ALERT: If this fails, list offending risk IDs and their title lengths
-        so the maintainer can shorten them before the schema tightening lands.
+        On failure: lists offending risk IDs + title lengths for the maintainer.
         """
         offenders = [
             (r.get("id", "<unknown>"), r.get("title", ""), len(r.get("title", "")))
@@ -325,17 +308,14 @@ class TestRiskTitleCorpusAudit:
             if len(r.get("title", "")) > RISK_TITLE_MAX_LENGTH
         ]
         assert not offenders, (
-            f"CONTENT DRIFT: risks.yaml has titles exceeding maxLength:{RISK_TITLE_MAX_LENGTH}. "
-            f"Fix these before applying the schema constraint:\n"
+            f"CONTENT DRIFT: risks.yaml has titles exceeding maxLength:{RISK_TITLE_MAX_LENGTH}:\n"
             + "\n".join(f"  {rid!r}: length={length}, title={title!r}" for rid, title, length in offenders)
         )
 
 
 class TestControlTitleCorpusAudit:
     """
-    Audit probe: every current controls.yaml title must be ≤100 characters.
-
-    Expected to PASS today and post-tightening.
+    Forward guard: every current controls.yaml title is ≤100 characters.
     """
 
     def test_all_control_titles_within_max_length(self, controls_yaml_data: dict):
@@ -346,8 +326,7 @@ class TestControlTitleCorpusAudit:
         When: Each title's length is measured
         Then: No title exceeds 100 characters
 
-        DRIFT ALERT: If this fails, list offending control IDs so the maintainer
-        can shorten them before the schema tightening lands.
+        On failure: lists offending control IDs + title lengths for the maintainer.
         """
         offenders = [
             (c.get("id", "<unknown>"), c.get("title", ""), len(c.get("title", "")))
@@ -355,8 +334,7 @@ class TestControlTitleCorpusAudit:
             if len(c.get("title", "")) > CONTROL_TITLE_MAX_LENGTH
         ]
         assert not offenders, (
-            f"CONTENT DRIFT: controls.yaml has titles exceeding maxLength:{CONTROL_TITLE_MAX_LENGTH}. "
-            f"Fix these before applying the schema constraint:\n"
+            f"CONTENT DRIFT: controls.yaml has titles exceeding maxLength:{CONTROL_TITLE_MAX_LENGTH}:\n"
             + "\n".join(f"  {cid!r}: length={length}, title={title!r}" for cid, title, length in offenders)
         )
 
@@ -367,34 +345,20 @@ class TestControlTitleCorpusAudit:
 """
 Test Summary
 ============
-Total test methods: 8 (excluding skip stub)
+Total test methods: 8
 Test classes: 6
 
-- TestRiskTitleMaxLengthDeclared (1)
-    RED today: maxLength not declared.
-    GREEN post-tightening.
-
-- TestControlTitleMaxLengthDeclared (1)
-    RED today: maxLength not declared.
-    GREEN post-tightening.
-
-- TestRiskTitleBoundaryEnforcement (2)
-    at-boundary pass: RED today (maxLength not declared, so 120-char title trivially passes —
-      but the schema structural test above would fail first).
-    over-boundary fail: RED today (121-char title accepted without maxLength).
-    GREEN post-tightening.
-
-- TestControlTitleBoundaryEnforcement (2)
-    Same RED/GREEN pattern as risk boundary.
-
-- TestRiskTitleCorpusAudit (1)
-    GREEN today: max corpus title = 40 chars (well under 120).
-
-- TestControlTitleCorpusAudit (1)
-    GREEN today: max corpus title = 49 chars (well under 100).
+- TestRiskTitleMaxLengthDeclared (1) — schema declares maxLength:120.
+- TestControlTitleMaxLengthDeclared (1) — schema declares maxLength:100.
+- TestRiskTitleBoundaryEnforcement (2) — at-limit passes, over-limit fails.
+- TestControlTitleBoundaryEnforcement (2) — same boundary pattern at 100.
+- TestRiskTitleCorpusAudit (1) — live risks.yaml forward guard
+  (current max corpus title: 40 chars).
+- TestControlTitleCorpusAudit (1) — live controls.yaml forward guard
+  (current max corpus title: 49 chars).
 
 Coverage areas:
 - Schema structural check: maxLength declared at correct value
 - Behavioral boundary: at-limit pass, over-limit fail
-- Corpus audit: no existing content exceeds new limits (drift-free)
+- Corpus audit: no existing content exceeds limits (drift-free)
 """

--- a/scripts/hooks/tests/test_title_max_length_constraints.py
+++ b/scripts/hooks/tests/test_title_max_length_constraints.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""
+Tests for Decision 3 (C1-schema-tightenings): add `maxLength` constraints to
+`title` fields in risks.schema.json and controls.schema.json.
+
+Per ADR-019 D8: risks.schema.json definitions/risk/properties/title gets maxLength:120.
+Per ADR-020 D7: controls.schema.json definitions/control/properties/title gets maxLength:100.
+
+These limits were set conservatively above the longest current corpus entry to
+avoid breaking existing content while capping future drift.
+
+Coverage:
+- definitions/risk/properties/title declares maxLength:120.
+- definitions/control/properties/title declares maxLength:100.
+- A synthetic risk title of length 121 is rejected; length 120 passes.
+- A synthetic control title of length 101 is rejected; length 100 passes.
+- Corpus audit: every current risks.yaml title is ≤120 chars (no existing drift).
+- Corpus audit: every current controls.yaml title is ≤100 chars (no existing drift).
+
+Note on RED phase:
+  Tests in TestRiskTitleMaxLengthDeclared / TestControlTitleMaxLengthDeclared
+  and all synthetic boundary tests FAIL today (pre-tightening: no maxLength declared).
+  Corpus audit tests PASS today (no current corpus entry exceeds limits).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+from jsonschema import Draft7Validator
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from conftest import _load_schema, _make_registry
+
+# ============================================================================
+# Module-level constants
+# ============================================================================
+
+RISK_SCHEMA_FILE = "risks.schema.json"
+CONTROL_SCHEMA_FILE = "controls.schema.json"
+
+RISK_TITLE_MAX_LENGTH = 120
+CONTROL_TITLE_MAX_LENGTH = 100
+
+# Minimal valid entries for each entity (required fields satisfied, enum-valid).
+# Used as the base for boundary tests; title is overridden per test.
+_MINIMAL_RISK_BASE: dict = {
+    "id": "riskDataPoisoning",
+    "title": "Data Poisoning",
+    "shortDescription": ["Short description."],
+    "longDescription": ["Long description."],
+    "category": "risksSupplyChainAndDevelopment",
+    "personas": ["personaModelProvider"],
+    "controls": ["controlTrainingDataSanitization"],
+}
+
+_MINIMAL_CONTROL_BASE: dict = {
+    "title": "Training Data Management",
+    "description": ["Manage training data."],
+    "category": "controlsData",
+    "personas": ["personaModelProvider"],
+    "components": ["componentDataSources"],
+    "risks": ["riskDataPoisoning"],
+}
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="module")
+def schemas_dir(risk_map_schemas_dir: Path) -> Path:
+    """Alias for concise test signatures."""
+    return risk_map_schemas_dir
+
+
+@pytest.fixture(scope="module")
+def risk_title_schema(schemas_dir: Path) -> dict:
+    """The title property sub-schema from definitions/risk/properties."""
+    schema = _load_schema(schemas_dir, RISK_SCHEMA_FILE)
+    title_prop = schema.get("definitions", {}).get("risk", {}).get("properties", {}).get("title")
+    if title_prop is None:
+        pytest.fail(f"definitions/risk/properties/title not found in {RISK_SCHEMA_FILE}")
+    return title_prop
+
+
+@pytest.fixture(scope="module")
+def control_title_schema(schemas_dir: Path) -> dict:
+    """The title property sub-schema from definitions/control/properties."""
+    schema = _load_schema(schemas_dir, CONTROL_SCHEMA_FILE)
+    title_prop = schema.get("definitions", {}).get("control", {}).get("properties", {}).get("title")
+    if title_prop is None:
+        pytest.fail(f"definitions/control/properties/title not found in {CONTROL_SCHEMA_FILE}")
+    return title_prop
+
+
+@pytest.fixture(scope="module")
+def risk_validator(schemas_dir: Path) -> Draft7Validator:
+    """
+    Draft-07 validator targeting definitions/risk with full cross-file $ref resolution.
+
+    Uses a $ref wrapper against the registry so internal #/definitions/... refs inside
+    definitions/risk resolve correctly against the full risks.schema.json root.
+    """
+    registry = _make_registry(schemas_dir)
+    return Draft7Validator({"$ref": f"{RISK_SCHEMA_FILE}#/definitions/risk"}, registry=registry)
+
+
+@pytest.fixture(scope="module")
+def control_validator(schemas_dir: Path) -> Draft7Validator:
+    """
+    Draft-07 validator targeting definitions/control with full cross-file $ref resolution.
+
+    Uses a $ref wrapper against the registry so internal #/definitions/... refs inside
+    definitions/control (e.g., #/definitions/category/properties/id) resolve correctly
+    against the full controls.schema.json root.
+    """
+    registry = _make_registry(schemas_dir)
+    return Draft7Validator({"$ref": f"{CONTROL_SCHEMA_FILE}#/definitions/control"}, registry=registry)
+
+
+@pytest.fixture(scope="module")
+def risks_yaml_data(risk_map_yaml_dir: Path) -> dict:
+    """Parsed risks.yaml corpus data."""
+    path = risk_map_yaml_dir / "risks.yaml"
+    if not path.is_file():
+        pytest.fail(f"risks.yaml not found at {path}")
+    with open(path) as fh:
+        return yaml.safe_load(fh)
+
+
+@pytest.fixture(scope="module")
+def controls_yaml_data(risk_map_yaml_dir: Path) -> dict:
+    """Parsed controls.yaml corpus data."""
+    path = risk_map_yaml_dir / "controls.yaml"
+    if not path.is_file():
+        pytest.fail(f"controls.yaml not found at {path}")
+    with open(path) as fh:
+        return yaml.safe_load(fh)
+
+
+# ============================================================================
+# Decision 3 — risk title maxLength declared (RED today)
+# ============================================================================
+
+
+class TestRiskTitleMaxLengthDeclared:
+    """
+    definitions/risk/properties/title must declare maxLength:120 after C1 tightening.
+
+    RED phase: FAILS today (no maxLength on title).
+    GREEN post-tightening.
+    """
+
+    def test_risk_title_has_max_length_120(self, risk_title_schema: dict):
+        """
+        Test that definitions/risk/properties/title declares maxLength:120.
+
+        Given: The title property schema from definitions/risk
+        When: Its maxLength is inspected
+        Then: It is 120 (per ADR-019 D8)
+        """
+        assert risk_title_schema.get("maxLength") == RISK_TITLE_MAX_LENGTH, (
+            f"definitions/risk/properties/title must declare maxLength:{RISK_TITLE_MAX_LENGTH} "
+            f"(per ADR-019 D8); got: {risk_title_schema.get('maxLength')!r}"
+        )
+
+
+# ============================================================================
+# Decision 3 — control title maxLength declared (RED today)
+# ============================================================================
+
+
+class TestControlTitleMaxLengthDeclared:
+    """
+    definitions/control/properties/title must declare maxLength:100 after C1 tightening.
+
+    RED phase: FAILS today (no maxLength on title).
+    GREEN post-tightening.
+    """
+
+    def test_control_title_has_max_length_100(self, control_title_schema: dict):
+        """
+        Test that definitions/control/properties/title declares maxLength:100.
+
+        Given: The title property schema from definitions/control
+        When: Its maxLength is inspected
+        Then: It is 100 (per ADR-020 D7)
+        """
+        assert control_title_schema.get("maxLength") == CONTROL_TITLE_MAX_LENGTH, (
+            f"definitions/control/properties/title must declare maxLength:{CONTROL_TITLE_MAX_LENGTH} "
+            f"(per ADR-020 D7); got: {control_title_schema.get('maxLength')!r}"
+        )
+
+
+# ============================================================================
+# Decision 3 — risk title boundary enforcement (RED today)
+# ============================================================================
+
+
+class TestRiskTitleBoundaryEnforcement:
+    """
+    Behavioral tests for the risk title maxLength boundary.
+
+    A title of exactly 120 chars must pass; 121 chars must fail.
+
+    RED phase: both boundary tests FAIL today (no maxLength declared → 121-char title accepted).
+    GREEN post-tightening.
+    """
+
+    def test_risk_title_at_max_length_passes(self, risk_validator: Draft7Validator):
+        """
+        Test that a risk title of exactly 120 characters is accepted.
+
+        Given: A synthetic risk entry with a 120-char title
+        When: It is validated against definitions/risk
+        Then: No ValidationError is raised (boundary is inclusive)
+        """
+        entry = dict(_MINIMAL_RISK_BASE)
+        entry["title"] = "A" * RISK_TITLE_MAX_LENGTH
+        errors = list(risk_validator.iter_errors(entry))
+        assert not errors, (
+            f"Risk title of length {RISK_TITLE_MAX_LENGTH} must pass (inclusive boundary); "
+            f"errors: {[e.message for e in errors]}"
+        )
+
+    def test_risk_title_one_over_max_length_fails(self, risk_validator: Draft7Validator):
+        """
+        Test that a risk title of 121 characters is rejected.
+
+        Given: A synthetic risk entry with a 121-char title
+        When: It is validated against definitions/risk
+        Then: ValidationError is raised (maxLength:120 exceeded)
+        """
+        entry = dict(_MINIMAL_RISK_BASE)
+        entry["title"] = "A" * (RISK_TITLE_MAX_LENGTH + 1)
+        errors = list(risk_validator.iter_errors(entry))
+        assert errors, (
+            f"Risk title of length {RISK_TITLE_MAX_LENGTH + 1} must fail validation "
+            f"(maxLength:{RISK_TITLE_MAX_LENGTH}); currently accepted — RED phase"
+        )
+
+
+# ============================================================================
+# Decision 3 — control title boundary enforcement (RED today)
+# ============================================================================
+
+
+class TestControlTitleBoundaryEnforcement:
+    """
+    Behavioral tests for the control title maxLength boundary.
+
+    A title of exactly 100 chars must pass; 101 chars must fail.
+
+    RED phase: both boundary tests FAIL today (no maxLength declared → 101-char title accepted).
+    GREEN post-tightening.
+    """
+
+    def test_control_title_at_max_length_passes(self, control_validator: Draft7Validator):
+        """
+        Test that a control title of exactly 100 characters is accepted.
+
+        Given: A synthetic control entry with a 100-char title
+        When: It is validated against definitions/control
+        Then: No ValidationError is raised (boundary is inclusive)
+        """
+        entry = dict(_MINIMAL_CONTROL_BASE)
+        entry["title"] = "B" * CONTROL_TITLE_MAX_LENGTH
+        errors = list(control_validator.iter_errors(entry))
+        assert not errors, (
+            f"Control title of length {CONTROL_TITLE_MAX_LENGTH} must pass (inclusive boundary); "
+            f"errors: {[e.message for e in errors]}"
+        )
+
+    def test_control_title_one_over_max_length_fails(self, control_validator: Draft7Validator):
+        """
+        Test that a control title of 101 characters is rejected.
+
+        Given: A synthetic control entry with a 101-char title
+        When: It is validated against definitions/control
+        Then: ValidationError is raised (maxLength:100 exceeded)
+        """
+        entry = dict(_MINIMAL_CONTROL_BASE)
+        entry["title"] = "B" * (CONTROL_TITLE_MAX_LENGTH + 1)
+        errors = list(control_validator.iter_errors(entry))
+        assert errors, (
+            f"Control title of length {CONTROL_TITLE_MAX_LENGTH + 1} must fail validation "
+            f"(maxLength:{CONTROL_TITLE_MAX_LENGTH}); currently accepted — RED phase"
+        )
+
+
+# ============================================================================
+# Corpus audit — no current entry exceeds the maxLength limits (GREEN today)
+# ============================================================================
+
+
+class TestRiskTitleCorpusAudit:
+    """
+    Audit probe: every current risks.yaml title must be ≤120 characters.
+
+    This probe verifies that tightening does not break existing content.
+    If this test FAILS today, there is content drift that must be fixed
+    BEFORE the schema constraint is added — surface the offending entries.
+
+    Expected to PASS today and post-tightening.
+    """
+
+    def test_all_risk_titles_within_max_length(self, risks_yaml_data: dict):
+        """
+        Test that every risk title in the live corpus is ≤120 characters.
+
+        Given: All risks from risks.yaml
+        When: Each title's length is measured
+        Then: No title exceeds 120 characters
+
+        DRIFT ALERT: If this fails, list offending risk IDs and their title lengths
+        so the maintainer can shorten them before the schema tightening lands.
+        """
+        offenders = [
+            (r.get("id", "<unknown>"), r.get("title", ""), len(r.get("title", "")))
+            for r in risks_yaml_data.get("risks", [])
+            if len(r.get("title", "")) > RISK_TITLE_MAX_LENGTH
+        ]
+        assert not offenders, (
+            f"CONTENT DRIFT: risks.yaml has titles exceeding maxLength:{RISK_TITLE_MAX_LENGTH}. "
+            f"Fix these before applying the schema constraint:\n"
+            + "\n".join(f"  {rid!r}: length={length}, title={title!r}" for rid, title, length in offenders)
+        )
+
+
+class TestControlTitleCorpusAudit:
+    """
+    Audit probe: every current controls.yaml title must be ≤100 characters.
+
+    Expected to PASS today and post-tightening.
+    """
+
+    def test_all_control_titles_within_max_length(self, controls_yaml_data: dict):
+        """
+        Test that every control title in the live corpus is ≤100 characters.
+
+        Given: All controls from controls.yaml
+        When: Each title's length is measured
+        Then: No title exceeds 100 characters
+
+        DRIFT ALERT: If this fails, list offending control IDs so the maintainer
+        can shorten them before the schema tightening lands.
+        """
+        offenders = [
+            (c.get("id", "<unknown>"), c.get("title", ""), len(c.get("title", "")))
+            for c in controls_yaml_data.get("controls", [])
+            if len(c.get("title", "")) > CONTROL_TITLE_MAX_LENGTH
+        ]
+        assert not offenders, (
+            f"CONTENT DRIFT: controls.yaml has titles exceeding maxLength:{CONTROL_TITLE_MAX_LENGTH}. "
+            f"Fix these before applying the schema constraint:\n"
+            + "\n".join(f"  {cid!r}: length={length}, title={title!r}" for cid, title, length in offenders)
+        )
+
+
+# ============================================================================
+# Test summary
+# ============================================================================
+"""
+Test Summary
+============
+Total test methods: 8 (excluding skip stub)
+Test classes: 6
+
+- TestRiskTitleMaxLengthDeclared (1)
+    RED today: maxLength not declared.
+    GREEN post-tightening.
+
+- TestControlTitleMaxLengthDeclared (1)
+    RED today: maxLength not declared.
+    GREEN post-tightening.
+
+- TestRiskTitleBoundaryEnforcement (2)
+    at-boundary pass: RED today (maxLength not declared, so 120-char title trivially passes —
+      but the schema structural test above would fail first).
+    over-boundary fail: RED today (121-char title accepted without maxLength).
+    GREEN post-tightening.
+
+- TestControlTitleBoundaryEnforcement (2)
+    Same RED/GREEN pattern as risk boundary.
+
+- TestRiskTitleCorpusAudit (1)
+    GREEN today: max corpus title = 40 chars (well under 120).
+
+- TestControlTitleCorpusAudit (1)
+    GREEN today: max corpus title = 49 chars (well under 100).
+
+Coverage areas:
+- Schema structural check: maxLength declared at correct value
+- Behavioral boundary: at-limit pass, over-limit fail
+- Corpus audit: no existing content exceeds new limits (drift-free)
+"""


### PR DESCRIPTION

## Phase C - C1: schema tightenings (additionalProperties, prose-strict, title.maxLength, relevantQuestions removal)

Closes #320

## Summary

Phase C sub-PR C1 — implements four schema-tightening decisions against the post-bridge `main` corpus. All changes are schema-only (plus the regression-lock test suite); zero YAML content edits, zero generated-artifact drift, zero out-of-scope surfaces touched.

## Decision coverage (decision-bound per plan § 2b)

| Decision | ADR | Sites | Status |
|---|---|---|---|
| D1 — remove `relevantQuestions` from `risks.schema.json` | ADR-019 D6 | 1 | ✓ |
| D2 — `additionalProperties: false` on every `definitions/<entity>` block across 8 schemas | ADRs 018-022 D-sections | 12 new + 1 pre-existing preserved | ✓ |
| D3 — `title.maxLength` constraints (risks=120, controls=100) | ADRs 019 D8 + 020 D7 | 2 | ✓ |
| D4 — `description.$ref` → `prose-strict` migration | ADRs 018-021 D4 | 15 sites (risks 7 + controls 2 + components 4 + personas 2) | ✓ |

**Risk R10 ordering preserved**: D1 (`c9d8800`) precedes D2 (`25f7022`) in commit order. 
The `mappings.additionalProperties` schema-form blocks (4 per-entity) are explicitly preserved as `{type: array, ...}` — NOT collapsed to boolean 
## Commit chain (7 commits ahead of `main`)

| SHA | Subject |
|---|---|
| `e8eec67` | docs(tests): retire RED-phase language from C1 test modules |
| `2e9e68b` | test(schema): add C1 tightening test modules (tracking untracked files) |
| `efdd250` | refactor(tests): lift `_make_registry`/`_load_schema` into conftest (Phase A follow-up) |
| `e188994` | feat(schema): migrate `description.$ref` to `prose-strict` in content schemas |
| `4866f8f` | feat(schema): add `title.maxLength` to risks and controls (ADRs 019 D8 + 020 D7) |
| `25f7022` | feat(schema): close `additionalProperties` on `definitions/<entity>` blocks |
| `c9d8800` | feat(schema): remove `relevantQuestions` from `risks.schema.json` (ADR-019 D6) |

## Quality gates

- **Full pytest suite**: 2562 passed, 6 skipped, 0 failed
- **80 new C1 tests** (4 new test modules) all pass in <1.5s
- **Pre-commit**: all 30 hooks pass (incl. ruff lint/format, prettier, schema validation across all 10 active pairs)
- **Byte-parity preserved**: zero diff on `risk-map/tables/`, `risk-map/diagrams/`, `site/generated/persona-site-data.json`, `risk-map/svg/`
- **Out-of-scope check**: only `risk-map/schemas/` + `scripts/hooks/tests/` files touched (8 schemas + conftest + 4 new test files)
- **TestTriggerCoverageInvariant** (ADR-005 Addendum 2026-05-08): green
- **utils/text retention is deliberate** — `riskmap.schema.json#/definitions/utils/text` is preserved because supporting schemas (frameworks/actor-access/impact-type/lifecycle-stage) plus `self-assessment.schema.json` still consume it. Removal deferred (see follow-up).

## Files touched

**Schemas (8 files)**: `risks.schema.json`, `controls.schema.json`, `components.schema.json`, `personas.schema.json`, `frameworks.schema.json`, `actor-access.schema.json`, `impact-type.schema.json`, `lifecycle-stage.schema.json`

**Test infrastructure (5 files)**:
- `scripts/hooks/tests/conftest.py` — lifts `_make_registry` + `_load_schema` to shared helpers; adds module-scoped `schema_registry` fixture (Phase A follow-up; replaces deprecated `jsonschema.RefResolver` pattern); migrates two pre-existing duplicates in same commit
- `scripts/hooks/tests/test_consumer_additional_properties_strict.py` (NEW, 573 lines) — parametrized D2 coverage including the `mappings.additionalProperties` preservation guard
- `scripts/hooks/tests/test_consumer_prose_strict_migration.py` (NEW, 428 lines) — D4 coverage across all 15 sites
- `scripts/hooks/tests/test_risks_schema_relevant_questions_removed.py` (NEW, 247 lines) — D1 coverage
- `scripts/hooks/tests/test_title_max_length_constraints.py` (NEW, 400 lines) — D3 coverage with at-boundary + over-boundary negatives

## Coordination

- **Zero file overlap with sibling Phase C C3 PR (#321 — archive self-assessment).** C3 touches `self-assessment.{yaml,schema.json}` + `.pre-commit-config.yaml` + archive docs; this PR touches only the 8 schemas above + tests/conftest. Either PR may land first.

## Follow-up (not blocking this PR)

- **`utils/text` retirement from `riskmap.schema.json`** (plan task 2.2.9e). 7 remaining consumers across 4 supporting schemas + 3 refs in `self-assessment.schema.json`. Best filed after #321 lands — C3 collapses 3 of the 7 to archived-only consumers.

## Test plan

- [ ] CI green on this PR
- [ ] Spot-check that an extra key on any entity is now rejected (e.g., add `bogusField: true` to a risk entry locally and run `check-jsonschema`)
- [ ] Confirm titles >120 chars on risks fail validation (boundary test exercised by `test_title_max_length_constraints.py`)
- [ ] Maintainer review
