### PR TITLE
Flip conformance-sweep validators to block mode and require identificationQuestions on active persona

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -207,7 +207,7 @@ repos:
       - id: validate-component-edges
         name: 'risk-map: component edge consistency'
         language: system
-        entry: python3 scripts/hooks/validate_riskmap.py
+        entry: python3 scripts/hooks/validate_riskmap.py --block
         files: ^risk-map/yaml/(components|controls|risks)\.yaml$
         pass_filenames: false
 
@@ -221,7 +221,7 @@ repos:
       - id: validate-framework-references
         name: 'risk-map: framework reference consistency'
         language: system
-        entry: python3 scripts/hooks/validate_framework_references.py
+        entry: python3 scripts/hooks/validate_framework_references.py --block
         files: ^risk-map/yaml/(controls|frameworks|personas|risks)\.yaml$
         pass_filenames: false
 
@@ -241,14 +241,14 @@ repos:
 
       - id: validate-identification-questions
         name: 'validate: identification-questions structural rules'
-        entry: python3 scripts/hooks/precommit/validate_identification_questions.py
+        entry: python3 scripts/hooks/precommit/validate_identification_questions.py --block
         language: system
         files: ^risk-map/yaml/personas\.yaml$
         pass_filenames: true
 
   # ---------------------------------------------------------------------------
   # Prose authoring linters. Both consume the shared _prose_tokens.py tokenizer
-  # and ship warn-only (default; block-mode flip is C2 / sweep-close).
+  # and block on violations.
   # validate-yaml-prose-subset enforces ADR-017 D4 grammar rejections;
   # validate-prose-references enforces ADR-016 D6 sentinel ID resolution +
   # bare-camelCase rejection. Diagnostics emit to stderr in the format
@@ -259,14 +259,14 @@ repos:
       - id: validate-yaml-prose-subset
         name: 'validate: YAML prose authoring subset'
         language: system
-        entry: python3 scripts/hooks/precommit/validate_yaml_prose_subset.py
+        entry: python3 scripts/hooks/precommit/validate_yaml_prose_subset.py --block
         files: ^risk-map/yaml/(components|controls|risks|personas)\.yaml$
         pass_filenames: true
 
       - id: validate-prose-references
         name: 'validate: YAML prose references (sentinels + IDs)'
         language: system
-        entry: python3 scripts/hooks/precommit/validate_prose_references.py
+        entry: python3 scripts/hooks/precommit/validate_prose_references.py --block
         files: ^risk-map/yaml/(components|controls|risks|personas)\.yaml$
         pass_filenames: true
 

--- a/risk-map/schemas/personas.schema.json
+++ b/risk-map/schemas/personas.schema.json
@@ -73,6 +73,12 @@
         }
       },
       "required": ["id", "title", "description"],
+      "if": {
+        "not": { "properties": { "deprecated": { "const": true } }, "required": ["deprecated"] }
+      },
+      "then": {
+        "required": ["identificationQuestions"]
+      },
       "additionalProperties": false
     }
   }

--- a/scripts/hooks/tests/test_consumer_additional_properties_strict.py
+++ b/scripts/hooks/tests/test_consumer_additional_properties_strict.py
@@ -141,11 +141,14 @@ _MINIMAL_EDGES: dict = {
     "to": ["componentTheModel"],
 }
 
-# personas.schema.json / definitions/persona — required: id, title, description
+# personas.schema.json / definitions/persona — required: id, title, description.
+# Non-deprecated personas also require identificationQuestions (ADR-021 D8
+# if/then constraint), so an active minimal persona must carry the block.
 _MINIMAL_PERSONA: dict = {
     "id": "personaModelProvider",
     "title": "Model Provider",
     "description": ["A model provider persona."],
+    "identificationQuestions": ["Do you supply or license AI models to other organizations?"],
 }
 
 # frameworks.schema.json / definitions/framework — required: id, name, fullName,

--- a/scripts/hooks/tests/test_persona_schema_updates.py
+++ b/scripts/hooks/tests/test_persona_schema_updates.py
@@ -313,15 +313,18 @@ class TestPersonaBackwardCompatibility:
             f"Existing personas.yaml should validate with updated schema.\nError output:\n{result.stderr}"
         )
 
-    def test_legacy_persona_without_optional_fields_passes_validation(
+    def test_deprecated_persona_without_optional_fields_passes_validation(
         self, tmp_path, personas_schema_path, base_uri
     ):
         """
-        Test that persona with only required fields validates.
+        Test that a deprecated persona with only core fields validates.
 
-        Given: A persona with only id, title, description (no optional fields)
+        Given: A deprecated persona with id, title, description, and deprecated: true
+               but no identificationQuestions or other optional fields
         When: Schema validation is performed
-        Then: Validation passes
+        Then: Validation passes — the ADR-021 D8 conditional constraint exempts
+              deprecated personas, so the minimal valid persona without
+              identificationQuestions is one marked deprecated: true
         """
         yaml_content = """
 title: Test Personas
@@ -332,6 +335,7 @@ personas:
     title: Model Creator
     description:
       - Organizations that train and tune models
+    deprecated: true
 """
         yaml_file = tmp_path / "personas.yaml"
         yaml_file.write_text(yaml_content)
@@ -345,7 +349,9 @@ personas:
             text=True,
         )
 
-        assert result.returncode == 0, f"Legacy persona should validate. Error: {result.stderr}"
+        assert result.returncode == 0, (
+            f"Deprecated persona without identificationQuestions should validate. Error: {result.stderr}"
+        )
 
 
 # ============================================================================
@@ -373,6 +379,9 @@ personas:
     title: Model Provider
     description:
       - Organizations that provide AI models
+    identificationQuestions:
+      - "Do you supply or license AI models to other organizations?"
+      - "Are you responsible for the training and release of AI model artifacts?"
 """
         yaml_file = tmp_path / "personas.yaml"
         yaml_file.write_text(yaml_content)
@@ -450,6 +459,9 @@ personas:
       iso-22989:
         - "Data supplier"
         - "Data provider"
+    identificationQuestions:
+      - "Do you collect, curate, or license datasets used to train AI systems?"
+      - "Are you responsible for the quality and provenance of data supplied to AI pipelines?"
 """
         yaml_file = tmp_path / "personas.yaml"
         yaml_file.write_text(yaml_content)
@@ -490,6 +502,9 @@ personas:
       - "Establish AI governance policies"
       - "Monitor compliance with regulations"
       - "Define risk management frameworks"
+    identificationQuestions:
+      - "Do you set or enforce AI governance policies within your organization?"
+      - "Are you responsible for AI risk management or compliance oversight?"
 """
         yaml_file = tmp_path / "personas.yaml"
         yaml_file.write_text(yaml_content)
@@ -803,6 +818,9 @@ personas:
     description:
       - Test persona
     mappings: {}
+    identificationQuestions:
+      - "Do you operate the compute or serving infrastructure on which AI models run?"
+      - "Are you responsible for platform-level security controls for AI workloads?"
 """
         yaml_file = tmp_path / "personas.yaml"
         yaml_file.write_text(yaml_content)
@@ -842,6 +860,9 @@ personas:
     description:
       - Test persona
     responsibilities: []
+    identificationQuestions:
+      - "Do you build or operate autonomous AI agents that act on behalf of users?"
+      - "Are you responsible for orchestrating multi-step AI workflows or pipelines?"
 """
         yaml_file = tmp_path / "personas.yaml"
         yaml_file.write_text(yaml_content)
@@ -881,6 +902,8 @@ personas:
     mappings:
       iso-22989:
         - "Model provider"
+    identificationQuestions:
+      - "Do you supply or license AI models to other organizations?"
 
   - id: personaDataProvider
     title: Data Provider
@@ -888,11 +911,15 @@ personas:
       - Provider with responsibilities only
     responsibilities:
       - "Provide data"
+    identificationQuestions:
+      - "Do you collect or curate datasets used to train AI systems?"
 
   - id: personaPlatformProvider
     title: Platform Provider
     description:
-      - Provider with no optional fields
+      - Provider with questions only
+    identificationQuestions:
+      - "Do you operate the infrastructure on which AI models are served?"
 
   - id: personaModelCreator
     title: Model Creator (Legacy)
@@ -918,6 +945,215 @@ personas:
 
         assert result.returncode == 0, (
             f"Multiple personas with mixed fields should validate. Error: {result.stderr}"
+        )
+
+
+# ============================================================================
+# Conditional identificationQuestions requirement (ADR-021 D8)
+# ============================================================================
+
+
+class TestIdentificationQuestionsConditionalRequirement:
+    """
+    Schema constraint tests for the if/then conditional requirement on
+    identificationQuestions (ADR-021 D8).
+
+    Non-deprecated personas must supply identificationQuestions.  Deprecated
+    personas (personaModelCreator / personaModelConsumer) are exempt so that
+    their existing minimal entries remain valid.
+
+    The constraint must be expressed as JSON Schema if/then at the
+    definitions.persona level — NOT as a flat addition to required[] — because
+    a flat required addition would wrongly reject the two legitimately-deprecated
+    empty personas.
+    """
+
+    def test_non_deprecated_persona_without_identification_questions_is_rejected(
+        self, tmp_path, personas_schema_path, base_uri
+    ):
+        """
+        Test that a non-deprecated persona missing identificationQuestions fails validation.
+
+        Given: A persona with id/title/description but no deprecated flag and
+               no identificationQuestions field
+        When:  Schema validation is run with check-jsonschema
+        Then:  Validation fails (non-zero exit)
+
+        This is the primary constraint introduced by ADR-021 D8: active personas
+        must declare identification questions so framework consumers can determine
+        which persona applies to their context.
+        """
+        yaml_content = """
+title: Test Personas
+description:
+  - Test personas for validation
+personas:
+  - id: personaEndUser
+    title: End User
+    description:
+      - End users of AI-powered systems
+"""
+        yaml_file = tmp_path / "personas.yaml"
+        yaml_file.write_text(yaml_content)
+
+        result = subprocess.run(
+            [
+                "check-jsonschema",
+                "--base-uri",
+                base_uri,
+                "--schemafile",
+                str(personas_schema_path),
+                str(yaml_file),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode != 0, (
+            "Non-deprecated persona without identificationQuestions must fail validation "
+            "(ADR-021 D8 requires the if/then conditional constraint); "
+            "schema currently lacks this constraint."
+        )
+
+    def test_deprecated_persona_without_identification_questions_is_accepted(
+        self, tmp_path, personas_schema_path, base_uri
+    ):
+        """
+        Test that a deprecated persona without identificationQuestions passes validation.
+
+        Given: A persona with deprecated: true and no identificationQuestions field
+        When:  Schema validation is run with check-jsonschema
+        Then:  Validation passes (zero exit)
+
+        The if/then constraint must be conditional on the absence of deprecated: true
+        so that personaModelCreator and personaModelConsumer (which carry
+        deprecated: true and no identification questions) remain valid.
+        A flat required[] addition would break these entries.
+        """
+        yaml_content = """
+title: Test Personas
+description:
+  - Test personas for validation
+personas:
+  - id: personaModelCreator
+    title: Model Creator
+    description:
+      - Legacy persona superseded by personaModelProvider
+    deprecated: true
+"""
+        yaml_file = tmp_path / "personas.yaml"
+        yaml_file.write_text(yaml_content)
+
+        result = subprocess.run(
+            [
+                "check-jsonschema",
+                "--base-uri",
+                base_uri,
+                "--schemafile",
+                str(personas_schema_path),
+                str(yaml_file),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, (
+            "Deprecated persona without identificationQuestions must pass validation; "
+            "the constraint must be conditional (if/then), not a flat required[]. "
+            f"Error output:\n{result.stderr}"
+        )
+
+    def test_non_deprecated_persona_with_identification_questions_is_accepted(
+        self, tmp_path, personas_schema_path, base_uri
+    ):
+        """
+        Test that a non-deprecated persona with identificationQuestions passes validation.
+
+        Given: A persona with id/title/description and a valid identificationQuestions array
+        When:  Schema validation is run with check-jsonschema
+        Then:  Validation passes (zero exit)
+
+        Confirms the happy path: once the if/then constraint is present, a well-formed
+        active persona that includes identificationQuestions must still validate cleanly.
+        """
+        yaml_content = """
+title: Test Personas
+description:
+  - Test personas for validation
+personas:
+  - id: personaEndUser
+    title: End User
+    description:
+      - End users of AI-powered systems
+    identificationQuestions:
+      - "Do you directly interact with AI-powered applications as a consumer?"
+      - "Are you a primary recipient of AI-generated outputs rather than a developer or operator?"
+"""
+        yaml_file = tmp_path / "personas.yaml"
+        yaml_file.write_text(yaml_content)
+
+        result = subprocess.run(
+            [
+                "check-jsonschema",
+                "--base-uri",
+                base_uri,
+                "--schemafile",
+                str(personas_schema_path),
+                str(yaml_file),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, (
+            "Non-deprecated persona with identificationQuestions must pass validation. "
+            f"Error output:\n{result.stderr}"
+        )
+
+    def test_non_deprecated_persona_model_provider_without_identification_questions_is_rejected(
+        self, tmp_path, personas_schema_path, base_uri
+    ):
+        """
+        Test that the D8 constraint applies to personaModelProvider, not only personaEndUser.
+
+        Given: A personaModelProvider with id/title/description but no deprecated flag
+               and no identificationQuestions field
+        When:  Schema validation is run with check-jsonschema
+        Then:  Validation fails (non-zero exit)
+
+        This guards against a regression where the if/then constraint is narrowed
+        to a specific persona id rather than applying generally to all non-deprecated
+        personas (ADR-021 D8).
+        """
+        yaml_content = """
+title: Test Personas
+description:
+  - Test personas for validation
+personas:
+  - id: personaModelProvider
+    title: Model Provider
+    description:
+      - Organizations that supply AI models to consumers
+"""
+        yaml_file = tmp_path / "personas.yaml"
+        yaml_file.write_text(yaml_content)
+
+        result = subprocess.run(
+            [
+                "check-jsonschema",
+                "--base-uri",
+                base_uri,
+                "--schemafile",
+                str(personas_schema_path),
+                str(yaml_file),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode != 0, (
+            "Non-deprecated personaModelProvider without identificationQuestions must fail validation "
+            "(ADR-021 D8 constraint must be general, not limited to personaEndUser)."
         )
 
 

--- a/scripts/hooks/tests/test_precommit_hook_install.py
+++ b/scripts/hooks/tests/test_precommit_hook_install.py
@@ -860,3 +860,143 @@ class TestInstallDepsIntegration:
         assert "install-precommit-hook.sh" not in content, (
             "install-deps.sh still references the deleted bash installer"
         )
+
+
+# ===========================================================================
+# Sweep-validator block-mode posture lock
+# ===========================================================================
+
+
+class TestSweepValidatorsBlockMode:
+    """
+    Config-posture lock: sweep validators must carry --block in their entry.
+
+    Each of the five sweep validators supports a dual-mode CLI: bare invocation
+    warns and exits 0; --block causes a non-zero exit on violations so the
+    pre-commit framework fails the commit.  The hook entry must include --block
+    so staged violations are not silently swallowed.
+
+    Two hooks that do not have dual-mode logic (validate-lifecycle-stage and
+    validate-control-risk-references) must NOT carry --block; the guard tests
+    below pin that invariant to prevent accidental mirroring.
+    """
+
+    def test_validate_component_edges_entry_has_block_flag(self):
+        """
+        Test that validate-component-edges hook entry contains --block.
+
+        Given: .pre-commit-config.yaml validate-component-edges hook
+        When:  inspecting the entry: field
+        Then:  the entry contains the --block token
+        """
+        hooks = _hooks_by_id("validate-component-edges")
+        assert len(hooks) == 1, "Exactly one validate-component-edges hook expected"
+        entry = hooks[0].get("entry", "")
+        assert "--block" in entry, (
+            "validate-component-edges entry must contain --block so staged violations "
+            "fail the commit rather than warn-and-continue; got: " + repr(entry)
+        )
+
+    def test_validate_framework_references_entry_has_block_flag(self):
+        """
+        Test that validate-framework-references hook entry contains --block.
+
+        Given: .pre-commit-config.yaml validate-framework-references hook
+        When:  inspecting the entry: field
+        Then:  the entry contains the --block token
+        """
+        hooks = _hooks_by_id("validate-framework-references")
+        assert len(hooks) == 1, "Exactly one validate-framework-references hook expected"
+        entry = hooks[0].get("entry", "")
+        assert "--block" in entry, (
+            "validate-framework-references entry must contain --block so staged violations "
+            "fail the commit rather than warn-and-continue; got: " + repr(entry)
+        )
+
+    def test_validate_identification_questions_entry_has_block_flag(self):
+        """
+        Test that validate-identification-questions hook entry contains --block.
+
+        Given: .pre-commit-config.yaml validate-identification-questions hook
+        When:  inspecting the entry: field
+        Then:  the entry contains the --block token
+        """
+        hooks = _hooks_by_id("validate-identification-questions")
+        assert len(hooks) == 1, "Exactly one validate-identification-questions hook expected"
+        entry = hooks[0].get("entry", "")
+        assert "--block" in entry, (
+            "validate-identification-questions entry must contain --block so staged violations "
+            "fail the commit rather than warn-and-continue; got: " + repr(entry)
+        )
+
+    def test_validate_yaml_prose_subset_entry_has_block_flag(self):
+        """
+        Test that validate-yaml-prose-subset hook entry contains --block.
+
+        Given: .pre-commit-config.yaml validate-yaml-prose-subset hook
+        When:  inspecting the entry: field
+        Then:  the entry contains the --block token
+        """
+        hooks = _hooks_by_id("validate-yaml-prose-subset")
+        assert len(hooks) == 1, "Exactly one validate-yaml-prose-subset hook expected"
+        entry = hooks[0].get("entry", "")
+        assert "--block" in entry, (
+            "validate-yaml-prose-subset entry must contain --block so staged violations "
+            "fail the commit rather than warn-and-continue; got: " + repr(entry)
+        )
+
+    def test_validate_prose_references_entry_has_block_flag(self):
+        """
+        Test that validate-prose-references hook entry contains --block.
+
+        Given: .pre-commit-config.yaml validate-prose-references hook
+        When:  inspecting the entry: field
+        Then:  the entry contains the --block token
+        """
+        hooks = _hooks_by_id("validate-prose-references")
+        assert len(hooks) == 1, "Exactly one validate-prose-references hook expected"
+        entry = hooks[0].get("entry", "")
+        assert "--block" in entry, (
+            "validate-prose-references entry must contain --block so staged violations "
+            "fail the commit rather than warn-and-continue; got: " + repr(entry)
+        )
+
+    def test_validate_lifecycle_stage_entry_does_not_have_block_flag(self):
+        """
+        Test that validate-lifecycle-stage hook entry does NOT contain --block.
+
+        Given: .pre-commit-config.yaml validate-lifecycle-stage hook
+        When:  inspecting the entry: field
+        Then:  the entry does NOT contain --block
+
+        validate-lifecycle-stage has no dual-mode logic; it exits non-zero on
+        any violation regardless.  Adding --block would be meaningless noise and
+        risks confusing future maintainers about which hooks are sweep validators.
+        """
+        hooks = _hooks_by_id("validate-lifecycle-stage")
+        assert len(hooks) == 1, "Exactly one validate-lifecycle-stage hook expected"
+        entry = hooks[0].get("entry", "")
+        assert "--block" not in entry, (
+            "validate-lifecycle-stage entry must NOT contain --block "
+            "(not a sweep validator; has no dual-mode logic); got: " + repr(entry)
+        )
+
+    def test_validate_control_risk_references_entry_does_not_have_block_flag(self):
+        """
+        Test that validate-control-risk-references hook entry does NOT contain --block.
+
+        Given: .pre-commit-config.yaml validate-control-risk-references hook
+        When:  inspecting the entry: field
+        Then:  the entry does NOT contain --block
+
+        validate-control-risk-references has no dual-mode logic; it exits non-zero
+        on any violation regardless.  This guard prevents accidental --block
+        mirroring from a sweep-validator bulk edit.
+        """
+        hooks = _hooks_by_id("validate-control-risk-references")
+        assert len(hooks) == 1, "Exactly one validate-control-risk-references hook expected"
+        entry = hooks[0].get("entry", "")
+        assert "--block" not in entry, (
+            "validate-control-risk-references entry must NOT contain --block "
+            "(not a sweep validator; has no dual-mode logic); got: " + repr(entry)
+        )


### PR DESCRIPTION

## Flip conformance-sweep validators to block mode and require identificationQuestions on active personas

Closes: #335 

## Summary
Closes the conformance sweep by turning on the `--block` flag (already plumbed) for the five sweep validators, so a staged violation now fails the commit instead of warning and continuing. Couples the persona-schema tightening (ADR-021 D8) in the same change so the schema and the linter enforce identification-questions presence in lockstep.

## What changed
- **`.pre-commit-config.yaml`** — `--block` added to five hook entries:
  `validate-component-edges`, `validate-framework-references`, `validate-identification-questions`, `validate-yaml-prose-subset`, `validate-prose-references`. `validate-lifecycle-stage` (block-immediate) and `validate-control-risk-references` are intentionally left unflipped.
- **`risk-map/schemas/personas.schema.json`** — a JSON Schema `if`/`then` on `definitions.persona`: if a persona is not `deprecated: true`, then `identificationQuestions` is required (ADR-021 D8). Implemented as a conditional, not a flat `required` addition, so the two legitimately deprecated personas remain valid without the block.
- **Tests** — a config-posture lock asserting the five entries carry `--block` (and the two non-sweep hooks do not); schema tests proving a non-deprecated persona missing `identificationQuestions` is rejected (asserted for two distinct ids so the constraint stays general) while a deprecated persona without it is accepted; and schema-completion of the pre-existing persona fixtures the tightening would otherwise invalidate.

## Verification
- `pre-commit run --all-files` — all five flipped hooks pass on the full corpus in block mode (verified individually and in-suite).
- `pytest scripts/hooks/tests/` — 2395 passed, 6 skipped.
- `check-jsonschema` on `personas.yaml` — clean (8 active personas carry the block; 2 deprecated validate without it).
- Trigger-coverage invariant and hook-contract tests stay green.

## Notes for reviewers
- The persona-schema tightening fans out to test fixtures that previously built non-deprecated personas without `identificationQuestions` and asserted they validate (7 in `test_persona_schema_updates.py` plus `_MINIMAL_PERSONA` in `test_consumer_additional_properties_strict.py`). These were made schema-complete; each test still exercises its original subject.
- The existing dual-mode unit tests (argless `main()` warns and exits 0; `--block` exits 1) are unchanged — the config flip does not alter the validators' argless default, so those contracts still hold.


Co-authored-by: AI Assistant <ai-assistant@coalitionforsecureai.org>

