### PR TITLE
Add schema registry coverage to persona site data tests

### DIFF
--- a/scripts/hooks/tests/test_build_persona_site_data.py
+++ b/scripts/hooks/tests/test_build_persona_site_data.py
@@ -490,8 +490,36 @@ risks:
             ),
             "persona object missing required 'id' field",
         ),
+        (
+            lambda d: d["risks"].append(
+                {
+                    "id": "riskWithExternalReference",
+                    "title": "Risk With External Reference",
+                    "category": "risksTest",
+                    "shortDescription": [],
+                    "longDescription": [],
+                    "examples": [],
+                    "controlIds": [],
+                    "personaIds": [],
+                    "externalReferences": [
+                        {
+                            "type": "other",
+                            "id": "non-https-ref",
+                            "title": "Non-HTTPS reference",
+                            "url": "http://example.com/reference",
+                        }
+                    ],
+                }
+            ),
+            "risk object with externalReferences violating the shared referenced schema",
+        ),
     ],
-    ids=["missing-top-level-key", "wrong-type-top-level", "nested-object-missing-id"],
+    ids=[
+        "missing-top-level-key",
+        "wrong-type-top-level",
+        "nested-object-missing-id",
+        "referenced-external-references-schema",
+    ],
 )
 def test_persona_site_data_schema_rejects_structural_violations(
     risk_map_schemas_dir: Path,
@@ -512,11 +540,15 @@ def test_persona_site_data_schema_rejects_structural_violations(
     with schema_path.open("r", encoding="utf-8") as handle:
         schema = json.load(handle)
 
+    # Keep this rejection test on the same resolver path as live-output
+    # validation, so future mutators can safely traverse cross-file $refs.
+    registry = _make_schema_registry(risk_map_schemas_dir)
+
     bad = copy.deepcopy(_minimal_valid_site_data())
     mutator(bad)
 
     with pytest.raises(jsonschema.ValidationError):
-        jsonschema.validate(instance=bad, schema=schema)
+        jsonschema.validate(instance=bad, schema=schema, registry=registry)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Add the persona site data schema registry to the structural-violation `jsonschema.validate()` test.
- Add a cross-file schema-reference invalid `externalReferences` case so the regression is pinned.
- Audit every validator call in `scripts/hooks/tests/` against the class of bug #307 describes (validator runs against a schema with cross-file `$ref` without a `referencing.Registry`).

Closes #307.

## Root cause

Issue #307 identified a latent sibling test that validated `persona-site-data.schema.json` without a `referencing.Registry`. That was safe only while its mutators avoided fields backed by cross-file schema references — a future mutator touching `externalReferences` (or any other cross-file `$ref` field) would have raised `referencing.exceptions.Unresolvable`, which is *not* a subclass of `jsonschema.ValidationError` and would not be caught by the `pytest.raises(jsonschema.ValidationError)` assertion.

## What changed

`scripts/hooks/tests/test_build_persona_site_data.py` (+34 / −2):

1. `test_persona_site_data_schema_rejects_structural_violations` now builds `registry = _make_schema_registry(risk_map_schemas_dir)` and passes `registry=registry` into `jsonschema.validate()` — the same resolver path the live-output validation already uses.
2. A new parametrize case (`external-references-url-non-https`) appends a risk whose `externalReferences[0].url = "http://example.com/reference"` to traverse the cross-file `$ref` and exercise the `^https://` constraint that lives only in `external-references.schema.json`.

The mutator is load-bearing: without the registry the assertion would fail (Unresolvable, not ValidationError); with the registry it correctly raises ValidationError on the non-HTTPS URL.

## Class-of-bug audit (tree-wide)

Per #307's framing — *"the pattern is a class of bug, not a one-off"* — every `jsonschema`-family validator call in `scripts/hooks/tests/` was surveyed for the same latent shape (validator runs against a schema with cross-file `$ref` without a `referencing.Registry`). Two call-site forms were checked: `jsonschema.validate(...)` (top-level) and `Draft7Validator(schema).validate(...)`.

| Call site | Wrapped schema | `registry=` | Cross-file `$ref` traversed? |
|---|---|---|---|
| `test_build_persona_site_data.py:376` | `persona-site-data.schema.json` (whole) | yes (pre-existing, `8670fdd`) | yes — covered |
| `test_build_persona_site_data.py:551` | `persona-site-data.schema.json` (whole) | **yes (this PR)** | yes — covered |
| `test_lifecycle_stage_order_range.py:78` | `lifecycle-stage` `order` property | no | no (leaf int schema) |
| `test_riskmap_prose_strict.py:96,102` | `riskmap.schema.json#/definitions/utils/{text,prose-strict}` | no | no (self-contained) |
| `test_framework_mapping_patterns.py:324,348,428` | `framework-mapping-patterns` entries | no | no (string+pattern leaves) |
| `test_external_references_schema.py:147,290,303` | `external-references.schema.json` fragments | no | no (file is self-contained) |
| `test_persona_site_data_prose_items.py:128` | `persona-site-data.schema.json#/definitions/prose` | no | no today; fragile (see follow-up) |

**Net:** the two `jsonschema.validate(` sites identified in #307 were the only sites whose target schema actually traverses a cross-file `$ref` at validation time. Both are now registry-aware. One forward-fragility note (`test_persona_site_data_prose_items.py:128`) is filed as a separate LOW follow-up.

## Validation

- `python3 -m pytest scripts/hooks/tests/test_build_persona_site_data.py -q` — full file passes
- `python3 -m pytest scripts/hooks/tests/test_build_persona_site_data.py -q -k structural_violations -v` — 4 / 4 parametrized cases fail-as-expected
- `ruff check scripts/hooks/tests/test_build_persona_site_data.py` — clean
- `./scripts/tools/validate-all.sh --quiet` — clean
- `python3 -m pytest scripts/hooks/tests -q` — 2403 passed, 9 skipped (two local-environment-sensitive failures unrelated to this PR: Playwright Chromium dry-run skip assertion, and verify-deps.sh requiring Python >= 3.14 while this machine has 3.12.10)