### PR TITLE
Align Arm 1 documentation with the post-sweep ADRs 014–022 (Phase C C4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,8 @@ The CoSAI Risk Map includes mappings to established security frameworks, enablin
 
 These mappings allow organizations to align CoSAI risks and controls with existing security standards and compliance requirements. Framework references are automatically validated to ensure consistency across the risk map.
 
+#### **Reusing This Content**
+
+This repository's code and the Risk Map content (`risk-map/yaml/**`) are licensed under [Apache-2.0](./LICENSE.md). For what the framework guarantees to downstream consumers (shape, provenance), what it does not (safety in your pipeline), and the sanitization you are responsible for, see [`risk-map/docs/reuse-contract.md`](./risk-map/docs/reuse-contract.md). For what prose fields carry, see [`risk-map/docs/yaml-authoring-subset.md`](./risk-map/docs/yaml-authoring-subset.md).
+
 [Explore the full CoSAI Risk Map project here...](./risk-map/)

--- a/risk-map/docs/contributing/common-review-findings.md
+++ b/risk-map/docs/contributing/common-review-findings.md
@@ -13,6 +13,10 @@ Findings are grouped by severity. Structural issues block submission until fixed
 3. [Bidirectional inconsistency](#3-bidirectional-inconsistency)
 4. [Missing required fields](#4-missing-required-fields)
 5. [Invalid enum value](#5-invalid-enum-value)
+6. [Raw HTML or inline URL in prose](#6-raw-html-or-inline-url-in-prose)
+7. [Bare identifier in prose (use a sentinel)](#7-bare-identifier-in-prose-use-a-sentinel)
+8. [Unresolved or malformed sentinel](#8-unresolved-or-malformed-sentinel)
+9. [Retired field (`relevantQuestions`)](#9-retired-field-relevantquestions)
 
 **Content-quality issues (flagged for human review)**
 
@@ -69,6 +73,31 @@ A field constrained by schema enum (e.g., `category`, `lifecycle`, `impact`, `ac
 
 - Fix: copy the allowed values from the schema; do not invent new categories inline.
 
+### 6. Raw HTML or inline URL in prose
+
+A prose field (`description`, `shortDescription`, `longDescription`, `examples`, `responsibilities`, `tourContent.*`) contains a raw HTML tag (`<a>`, `<strong>`, `<em>`, `<br>`, …) or an inline URL of any scheme (`https://…`, `[text](url)`, `mailto:`, …). The `validate-yaml-prose-subset` and `validate-prose-references` hooks block both ([ADR-017](../../../docs/adr/017-yaml-prose-authoring-subset.md), [ADR-016](../../../docs/adr/016-reference-strategy.md)).
+
+- Fix (emphasis): use `**bold**`, `*italic*`/`_italic_` — never `<strong>`/`<em>`.
+- Fix (links/citations): move the URL into the entry's `externalReferences` array (`type`, `id`, `title`, `url`) and reference it from prose with a `{{ref:identifier}}` sentinel. There is no inline-URL form. See [`yaml-authoring-subset.md`](../yaml-authoring-subset.md).
+
+### 7. Bare identifier in prose (use a sentinel)
+
+Prose mentions another entity by writing its bare camelCase ID (`riskPromptInjection`, `controlInputValidationAndSanitization`) instead of a sentinel. `validate-prose-references` blocks bare IDs that match the known prefixes ([ADR-016](../../../docs/adr/016-reference-strategy.md) D6).
+
+- Fix: wrap the mention in a `{{<entity-id>}}` sentinel — `{{riskPromptInjection}}`. The generator resolves it to the entity's title (tables) or an in-page link (site). Authors never hand-write the display title.
+
+### 8. Unresolved or malformed sentinel
+
+A `{{…}}` sentinel does not resolve: `{{<entity-id>}}` names an ID absent from the schema enum, or `{{ref:identifier}}` names an `id` absent from the entry's `externalReferences`. `validate-prose-references` blocks it, and both generators fail the build on an unresolved sentinel.
+
+- Fix: correct the ID to match the schema enum, or add the missing `externalReferences` entry. Per-entry `id` values must be unique within the entry.
+
+### 9. Retired field (`relevantQuestions`)
+
+The proposal adds a `relevantQuestions` field to a risk. The field was removed from `risks.schema.json` in the conformance sweep ([ADR-019](../../../docs/adr/019-risks-schema.md) D6); `additionalProperties: false` now rejects it at commit.
+
+- Fix: remove the field. It had no consumer. Reader-facing questions belong to personas (`identificationQuestions`), not risks.
+
 ---
 
 ## Content-quality issues (flagged for human review)
@@ -117,13 +146,13 @@ The risk's `controls` field includes one of the 7 universal controls (`controlRe
 
 The `examples` field cites "what if" scenarios or product launch blog posts rather than real incidents or research.
 
-- Fix: replace with published incidents, academic papers, CVEs, or post-mortems. Every example must include a verifiable URL.
+- Fix: replace with published incidents, academic papers, CVEs, or post-mortems. Every example must be backed by a verifiable source — but the URL lives in the entry's `externalReferences` array, not inline. Reference it from the example prose with a `{{ref:identifier}}` sentinel ([ADR-016](../../../docs/adr/016-reference-strategy.md)). See [`yaml-authoring-subset.md`](../yaml-authoring-subset.md) for the structured-citation flow.
 
 ### 8. Framework mapping ID doesn't exist or is the wrong type
 
-The proposal maps to an invalid MITRE ATLAS technique, a non-existent OWASP LLM entry, or applies a mitigation ID to a risk (or vice versa).
+The proposal maps to an invalid MITRE ATLAS technique, a non-existent OWASP LLM entry, applies a mitigation ID to a risk (or vice versa), or uses a non-canonical identifier form (lowercase STRIDE, `GV-/MP-/MS-/MG-` NIST abbreviations, un-versioned `LLM##`).
 
-- Fix: verify each ID against the referenced framework. Risks use techniques (`AML.T####`), controls use mitigations (`AML.M####`). See [`framework-mappings-style-guide.md`](./framework-mappings-style-guide.md).
+- Fix: verify each ID against the referenced framework and use the **canonical** form — `Tampering` (not `tampering`), `GOVERN-1.1` (not `GV-1.1`), `LLM01:2025` (not `LLM01`). Risks use techniques (`AML.T####`), controls use mitigations (`AML.M####`). The schema enforces MITRE ATLAS, EU AI Act, and ISO 22989 strictly; STRIDE/NIST/OWASP fall through pending content migration but should still be authored canonically. See [`framework-mappings-style-guide.md`](./framework-mappings-style-guide.md).
 
 ### 9. Parent technique and sub-technique both listed (MITRE ATLAS)
 

--- a/risk-map/docs/contributing/control-titles-style-guide.md
+++ b/risk-map/docs/contributing/control-titles-style-guide.md
@@ -28,6 +28,8 @@ Write titles of 2-6 words. Most controls use 3-4 words.
 | 5 | Model and Data Access Controls | Compound subject + capability |
 | 6 | Privacy Enhancing Technologies for Inference | Upper bound — uses "for" scope qualifier |
 
+The schema also caps control titles at **100 characters** (`controls.schema.json` `title.maxLength`, per [ADR-022](../../../docs/adr/022-supporting-schemas.md) / C1 #322). The 2-6 word guidance keeps you well inside that limit; the character cap is a hard backstop a conformant title never reaches.
+
 ### Form
 
 Titles must be **noun phrases** that name the defensive capability, security measure, or governance practice. They describe what the control provides, not what risk it prevents.

--- a/risk-map/docs/contributing/framework-mappings-style-guide.md
+++ b/risk-map/docs/contributing/framework-mappings-style-guide.md
@@ -2,6 +2,8 @@
 
 This guide covers how to write framework mappings across all entity types (risks, controls, personas) in the CoSAI Risk Map. It documents identifier formats, per-framework conventions, and the principles that should guide mapping decisions.
 
+Identifier formats are the **canonical** forms committed in [ADR-022](../../../docs/adr/022-supporting-schemas.md) D5b. Where a framework's canonical form is machine-enforced by a schema regex, this guide marks it; where the schema currently accepts a looser form for migration reasons, the canonical form is still the one to author (per [ADR-026](../../../docs/adr/026-issue-template-domain.md) D4b — teach the canonical form even where validators accept loose input). See [Identifier Enforcement](#identifier-enforcement).
+
 ---
 
 ## Table of Contents
@@ -9,18 +11,19 @@ This guide covers how to write framework mappings across all entity types (risks
 1. [Purpose](#purpose)
 2. [General Principles](#general-principles)
 3. [Framework Applicability](#framework-applicability)
-4. [Per-Framework Conventions](#per-framework-conventions)
+4. [Identifier Enforcement](#identifier-enforcement)
+5. [Per-Framework Conventions](#per-framework-conventions)
    - [MITRE ATLAS](#mitre-atlas)
    - [NIST AI RMF](#nist-ai-rmf)
    - [STRIDE](#stride)
    - [OWASP Top 10 for LLM](#owasp-top-10-for-llm)
    - [ISO 22989](#iso-22989)
    - [EU AI Act](#eu-ai-act)
-5. [Granularity Guidelines](#granularity-guidelines)
-6. [Entity-Specific Guidance](#entity-specific-guidance)
-7. [Adding Mappings for a New Framework](#adding-mappings-for-a-new-framework)
-8. [Reviewer Checklist](#reviewer-checklist)
-9. [Related Documentation](#related-documentation)
+6. [Granularity Guidelines](#granularity-guidelines)
+7. [Entity-Specific Guidance](#entity-specific-guidance)
+8. [Adding Mappings for a New Framework](#adding-mappings-for-a-new-framework)
+9. [Reviewer Checklist](#reviewer-checklist)
+10. [Related Documentation](#related-documentation)
 
 ---
 
@@ -51,6 +54,8 @@ Mappings are not exhaustive catalogs. Every entry should be there because it is 
 
 **Mappings are not authoritative endorsements.** No framework maintainer has reviewed or approved these mappings. They represent the CoSAI working group's best-effort interpretation.
 
+**Mappings carry taxonomy IDs only — citations go in `externalReferences`.** The `mappings` block is a list of framework identifiers, never prose, URLs, or rationale ([ADR-022](../../../docs/adr/022-supporting-schemas.md) D5b — no per-mapping rationale fields). When a mapping rests on a paper, advisory, or spec the reader should be able to follow, add a structured entry to the entity's `externalReferences` array and cite it from prose with a `{{ref:identifier}}` sentinel ([ADR-016](../../../docs/adr/016-reference-strategy.md)). See [`yaml-authoring-subset.md`](../yaml-authoring-subset.md) for the structured-citation flow.
+
 ---
 
 ## Framework Applicability
@@ -70,6 +75,25 @@ STRIDE, NIST AI RMF, and EU AI Act are asymmetric by design: STRIDE categorizes 
 
 ---
 
+## Identifier Enforcement
+
+The canonical identifier patterns ([ADR-022](../../../docs/adr/022-supporting-schemas.md) D5b) live in `risk-map/schemas/frameworks.schema.json` under `definitions/framework-mapping-patterns`. Each entity schema (`risks`, `controls`, `components`) references them for the `mappings` field. Three frameworks are enforced strictly today; three accept any string while their existing entries are migrated to the canonical form.
+
+| Framework | Canonical pattern | Schema status |
+|-----------|-------------------|---------------|
+| MITRE ATLAS | `^AML\.(T\|M)\d{4}(\.\d{3})?$` | **Enforced** — non-conforming IDs fail at commit |
+| EU AI Act | `^Article\s\d+(\(\d+\))?$` | **Enforced** |
+| ISO 22989 | bare string (role descriptors) | **Enforced** as free text — documented exception, see [ISO 22989](#iso-22989) |
+| STRIDE | `^(Spoofing\|Tampering\|Repudiation\|InformationDisclosure\|DenialOfService\|ElevationOfPrivilege)$` | **Fall-through** — schema accepts any string pending content migration |
+| NIST AI RMF | `^(GOVERN\|MAP\|MEASURE\|MANAGE)-\d+(\.\d+)*$` | **Fall-through** |
+| OWASP Top 10 LLM | `^LLM\d{2}:\d{4}$` | **Fall-through** |
+
+**Author the canonical form regardless of enforcement status.** For the three fall-through frameworks, the schema currently accepts the older non-canonical form (lowercase-kebab STRIDE, `GV-/MP-/MS-/MG-` NIST abbreviations, un-versioned `LLM##`) so that existing entries do not break before they are migrated. New content uses the canonical form below; a future content sweep migrates the remaining entries and flips the three patterns to strict.
+
+ISO 22989 is a deliberate, permanent exception: its persona mappings are role descriptors (`AI Partner (data supplier)`), not codes, so the schema leaves it as a bare string (ADR-021 D8, ADR-022 D5b).
+
+---
+
 ## Per-Framework Conventions
 
 ### MITRE ATLAS
@@ -78,10 +102,12 @@ STRIDE, NIST AI RMF, and EU AI Act are asymmetric by design: STRIDE categorizes 
 
 **Source:** [https://atlas.mitre.org](https://atlas.mitre.org) — version 5.0.1 as of October 2025
 
-**Identifier formats:**
+**Identifier formats** — canonical pattern `^AML\.(T|M)\d{4}(\.\d{3})?$` (schema-enforced):
 - Techniques: `AML.T####` (e.g., `AML.T0020`)
 - Sub-techniques: `AML.T####.###` (e.g., `AML.T0010.002`)
 - Mitigations: `AML.M####` (e.g., `AML.M0007`)
+
+The single pattern covers techniques (`T`), mitigations (`M`), and optional sub-technique suffixes. A malformed ATLAS ID fails schema validation at commit.
 
 **Risks map to techniques.** ATLAS techniques (`AML.T####`) describe adversary actions; a risk in CoSAI describes what can go wrong. The connection is: "An attacker using [technique] realizes [this risk]." Use the most specific technique available. If only a sub-technique applies, use the sub-technique, not the parent.
 
@@ -110,24 +136,26 @@ mappings:
 
 **Source:** NIST AI 100-1 — [https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.100-1.pdf](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.100-1.pdf)
 
-**Identifier format:** `[Function]-[Category].[Subcategory]`
+**Identifier format:** `[FUNCTION]-[Category].[Subcategory]` — canonical pattern `^(GOVERN|MAP|MEASURE|MANAGE)-\d+(\.\d+)*$`
 
-The four functions are:
-- `GV` — Govern
-- `MP` — Map
-- `MS` — Measure
-- `MG` — Manage
+The four functions use their **full uppercase names**, not the legacy two-letter abbreviations:
+- `GOVERN` — Govern (legacy `GV`)
+- `MAP` — Map (legacy `MP`)
+- `MEASURE` — Measure (legacy `MS`)
+- `MANAGE` — Manage (legacy `MG`)
 
-Examples: `GV-1.1`, `MS-2.7`, `MP-4.1`, `MG-4.1`
+Examples: `GOVERN-1.1`, `MEASURE-2.7`, `MAP-4.1`, `MANAGE-4.1`
 
-Always use the subcategory-level identifier (e.g., `MS-2.7`), not the category level alone (`MS-2`). The framework's subcategories are the actionable units; the category level is too coarse for meaningful mapping.
+Always use the subcategory-level identifier (e.g., `MEASURE-2.7`), not the category level alone (`MEASURE-2`). The framework's subcategories are the actionable units; the category level is too coarse for meaningful mapping.
 
 ```yaml
 mappings:
   nist-ai-rmf:
-    - MS-2.7
-    - MS-2.3
+    - MEASURE-2.7
+    - MEASURE-2.3
 ```
+
+The `nist-ai-rmf` key currently falls through to the loose schema pattern (see [Identifier Enforcement](#identifier-enforcement)) because legacy entries still use the `GV-/MP-/MS-/MG-` abbreviations. Author the full-word form; do not add new abbreviated IDs.
 
 **Limitation:** NIST AI RMF v1.0 is control-oriented and relatively coarse-grained. Some CoSAI controls span multiple RMF subcategories, and some have no close match. Do not force a mapping where the fit is weak.
 
@@ -139,24 +167,26 @@ mappings:
 
 **Source:** [https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool-threats](https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool-threats)
 
-**Identifier format:** lowercase category name (no codes — STRIDE uses descriptive names, not IDs)
+**Identifier format:** PascalCase category name — canonical pattern `^(Spoofing|Tampering|Repudiation|InformationDisclosure|DenialOfService|ElevationOfPrivilege)$`
 
-Valid values:
-- `spoofing`
-- `tampering`
-- `repudiation`
-- `information-disclosure`
-- `denial-of-service`
-- `elevation-of-privilege`
+Valid values (exactly these six, PascalCase, no separators):
+- `Spoofing`
+- `Tampering`
+- `Repudiation`
+- `InformationDisclosure`
+- `DenialOfService`
+- `ElevationOfPrivilege`
 
 Map based on the primary security impact of the risk. Multiple STRIDE categories are appropriate when a risk has meaningfully distinct impacts across categories. However, be conservative — most risks have one or two primary STRIDE categories.
 
 ```yaml
 mappings:
   stride:
-    - tampering
-    - elevation-of-privilege
+    - Tampering
+    - ElevationOfPrivilege
 ```
+
+The `stride` key currently falls through to the loose schema pattern (see [Identifier Enforcement](#identifier-enforcement)) because legacy entries still use the lowercase-kebab form (`denial-of-service`). Author the PascalCase form; do not add new kebab-case values.
 
 **Limitation:** STRIDE was designed for traditional software systems. The categories are coarse and do not capture AI-specific threat nuances. Use MITRE ATLAS alongside STRIDE to provide more precise classification.
 
@@ -168,7 +198,9 @@ mappings:
 
 **Source:** [https://owasp.org/www-project-top-10-for-large-language-model-applications](https://owasp.org/www-project-top-10-for-large-language-model-applications) — version 2025 (released November 2024)
 
-**Identifier format:** `LLM##` (zero-padded two-digit number, e.g., `LLM04`, not `LLM4`)
+**Identifier format:** `LLM##:YYYY` (zero-padded two-digit number, colon, four-digit list year) — canonical pattern `^LLM\d{2}:\d{4}$`. Example: `LLM01:2025`, not `LLM01` or `LLM1`.
+
+The version suffix pins the mapping to a specific edition of the list (the OWASP LLM Top 10 is re-issued; `LLM01` referred to different categories across editions). Use `:2025` for the current list.
 
 The 2025 Top 10:
 | ID    | Title |
@@ -192,13 +224,15 @@ The 2025 Top 10:
 # Risk
 mappings:
   owasp-top10-llm:
-    - LLM04
+    - LLM04:2025
 
 # Control that mitigates prompt injection
 mappings:
   owasp-top10-llm:
-    - LLM01
+    - LLM01:2025
 ```
+
+The `owasp-top10-llm` key currently falls through to the loose schema pattern (see [Identifier Enforcement](#identifier-enforcement)) because legacy entries still use the un-versioned `LLM##` form. Author the versioned `LLM##:2025` form; do not add new un-versioned IDs.
 
 ---
 
@@ -209,6 +243,8 @@ mappings:
 **Source:** ISO/IEC 22989:2022 — [https://www.iso.org/standard/74296.html](https://www.iso.org/standard/74296.html)
 
 **Identifier format:** Free-text role names from the standard. No codes. Parenthetical qualifiers are part of the identifier when the standard uses them.
+
+ISO 22989 is the **documented permanent exception** to the canonical-ID rule ([ADR-021](../../../docs/adr/021-personas-and-self-assessment-schema.md) D8, [ADR-022](../../../docs/adr/022-supporting-schemas.md) D5b): its mappings are role descriptors, not canonical identifiers, so the schema enforces them as a bare string. There is no regex to satisfy — preserve the role label exactly as the standard writes it.
 
 Examples of valid values:
 - `AI Producer`
@@ -232,24 +268,25 @@ mappings:
 
 ### EU AI Act
 
-**Applies to:** personas, controls (newly added — no mappings exist in the project yet)
+**Applies to:** personas, controls
 
 **Source:** EUR-Lex — [https://eur-lex.europa.eu/eli/reg/2024/1689](https://eur-lex.europa.eu/eli/reg/2024/1689)
 
-**Conventions are not yet established for this project.** The guidance below is a starting recommendation, not settled practice. Early contributions should use this as a baseline and note in their PR if they are departing from it.
-
-**Recommended identifier format:** Article-level references using the pattern `Article {N}` or `Article {N}({paragraph})`. Use the official EUR-Lex text as the source for article numbering.
+**Identifier format:** Article-level references — canonical pattern `^Article\s\d+(\(\d+\))?$` (schema-enforced). One space after `Article`; the optional parenthetical is a paragraph number.
 
 Examples:
 - `Article 9` (risk management system requirements)
 - `Article 13` (transparency and provision of information)
+- `Article 13(1)` (a specific paragraph within an article)
 - `Article 72` (obligations for providers of general-purpose AI models)
+
+A malformed reference (`Article9`, `Art. 9`, `Article 9.1`) fails schema validation at commit. Use the official EUR-Lex text as the source for article numbering.
 
 **For personas:** Map to the EU AI Act's defined roles where the CoSAI persona corresponds to a legal obligation-bearer. The Act defines roles including "provider", "deployer", "importer", "distributor", and "authorised representative" (Articles 3 and 25). Use the Act's own terminology.
 
 **For controls:** Map to articles that impose the obligation the control helps satisfy. The goal is to answer: "Which article requires or recommends this type of control?"
 
-Because no mappings exist yet, the first contributions will set the de facto conventions. Raise questions in the PR discussion before merging novel patterns.
+The `Article {N}` / `Article {N}({paragraph})` form is the settled, schema-enforced convention. Map personas to the obligation-bearing role by mapping to the article that defines it; map controls to the article that imposes the obligation the control satisfies.
 
 ---
 
@@ -333,21 +370,26 @@ If you are proposing to add mappings for a framework not currently in `framework
 
 When reviewing a PR that adds or modifies `mappings:` fields:
 
-- [ ] Identifiers match the format specified in this guide for each framework
+- [ ] Identifiers match the **canonical** format for each framework (see [Identifier Enforcement](#identifier-enforcement)), even where the schema currently accepts a looser form
 - [ ] No parent technique is mapped alongside its sub-technique
 - [ ] Risks reference only techniques (`AML.T####`) and controls reference only mitigations (`AML.M####`) for MITRE ATLAS
-- [ ] STRIDE values are lowercase and match the six valid categories exactly
-- [ ] OWASP identifiers are zero-padded (`LLM04`, not `LLM4`) and from the 2025 version
+- [ ] STRIDE values are PascalCase and match the six valid categories exactly (`Tampering`, not `tampering` or `t`)
+- [ ] NIST AI RMF uses full-word function prefixes (`GOVERN-1.1`, not `GV-1.1`)
+- [ ] OWASP identifiers are versioned (`LLM04:2025`, not `LLM04` or `LLM4`)
+- [ ] EU AI Act references use the `Article {N}` / `Article {N}({paragraph})` form
 - [ ] ISO 22989 role names preserve parenthetical qualifiers exactly as they appear in the standard
+- [ ] Mappings carry taxonomy IDs only — no inline rationale or URLs; supporting citations live in `externalReferences` (see below) and non-obvious rationale in the PR description
 - [ ] Mappings with more than four entries per framework have been scrutinized
 - [ ] No framework is used for an entity type not listed in its `applicableTo`
-- [ ] Non-obvious mappings are explained in the PR description, not the YAML
 
 ---
 
 ## Related Documentation
 
 - [guide-frameworks.md](../guide-frameworks.md) — How to register a new framework, framework definition file structure, validation rules
+- [yaml-authoring-subset.md](../yaml-authoring-subset.md) — Prose authoring rules, the `externalReferences` structured-citation flow, and the `{{ref:identifier}}` sentinel form
+- [ADR-022](../../../docs/adr/022-supporting-schemas.md) D5b — Canonical per-framework mapping-ID regex patterns (source of truth)
+- [ADR-021](../../../docs/adr/021-personas-and-self-assessment-schema.md) D8 — Persona mappings (ISO 22989 role-descriptor exception)
 - [design/metadata-mappings.md](../design/metadata-mappings.md) — Phase 2 methodology: rationale tables for initial mappings, per-framework gap analysis, sources used (forthcoming)
 - [guide-risks.md](../guide-risks.md) — Complete guide for adding or updating risks
 - [guide-controls.md](../guide-controls.md) — Complete guide for adding or updating controls

--- a/risk-map/docs/contributing/identification-questions-style-guide.md
+++ b/risk-map/docs/contributing/identification-questions-style-guide.md
@@ -2,6 +2,8 @@
 
 This guide covers how to write `identificationQuestions` for personas in `risk-map/yaml/personas.yaml`. Identification questions help readers determine whether a given persona applies to them based on what they do, not what their job title is.
 
+Some of the rules in this guide are **machine-enforced** by the `validate-identification-questions` pre-commit hook (in block mode); the rest are **editorial** and checked by the content-reviewer agent and the `audit-identification-questions` skill. Each rule below is tagged accordingly, per [ADR-021](../../../docs/adr/021-personas-and-self-assessment-schema.md) D7. The [Rule enforcement summary](#rule-enforcement-summary) collects the split in one table.
+
 ---
 
 ## Purpose
@@ -11,9 +13,9 @@ Identification questions serve two functions:
 1. **Self-selection** — Readers scan these questions to determine which persona(s) describe their activities and, by extension, which risks and controls apply to them.
 2. **Boundary clarification** — Questions prevent incorrect persona assignment by scoping in or scoping out activities that might appear ambiguous from the persona description alone.
 
-Questions are most valuable for personas with fuzzy or emerging boundaries. Personas with sharply distinct scopes (e.g., `personaModelServing`, whose separation from `personaModelProvider` is well-defined) may omit questions without loss of clarity.
+Questions are most valuable for personas with fuzzy or emerging boundaries, but every active persona carries them — even a sharply-scoped persona (e.g., `personaModelServing`, whose separation from `personaModelProvider` is well-defined) still needs questions a reader can answer to confirm the fit.
 
-**All non-deprecated personas should eventually have identification questions.** This is being phased in — currently three of eight non-deprecated personas have them (`personaModelProvider`, `personaAgenticProvider`, `personaEndUser`). The remaining five are gaps to be addressed in future PRs. Personas whose scope is unambiguously distinct from all adjacent personas may omit questions, but this should be a documented decision, not a default.
+**Every active (non-deprecated) persona carries identification questions.** This is now a requirement, not an aspiration: all eight active personas have them, and the schema requires the field on active personas ([ADR-021](../../../docs/adr/021-personas-and-self-assessment-schema.md) D8). The two deprecated personas (`personaModelCreator`, `personaModelConsumer`) are exempt. Adding a new active persona means adding its identification questions in the same change.
 
 ---
 
@@ -21,9 +23,13 @@ Questions are most valuable for personas with fuzzy or emerging boundaries. Pers
 
 ### Count
 
+> **Machine-enforced.** The hook blocks a persona with fewer than 5 or more than 7 questions.
+
 Write 5–7 questions per persona. Fewer than 5 may leave gaps; more than 7 creates redundancy and reader fatigue.
 
 ### Format
+
+> **Machine-enforced (opener).** The hook blocks any question that does not start with one of the approved second-person openers (`Do you `, `Are you `, `Does your ` — case-sensitive, trailing space required). Yes/no answerability is editorial.
 
 All questions must be answerable with yes or no. Use second-person framing:
 
@@ -72,6 +78,8 @@ When a technical term may be unfamiliar or has multiple interpretations, add a p
 > Do you modify, extend, or wrap existing models **(e.g., distillation, quantization, adaptation, or adding guardrails)** for use by others as a distributable model artifact?
 
 Keep examples to 2–4 items. Longer lists obscure the point; shorter lists may seem exclusive. Use "e.g." (not "i.e.") to signal that the list is illustrative, not exhaustive.
+
+> **Machine-enforced.** The hook blocks any parenthetical with more than 4 list items, and any parenthetical opening with `i.e.` (use `e.g.`). A leading `e.g.,` is not counted as an item.
 
 ### Use "including" to widen scope intentionally
 
@@ -137,16 +145,41 @@ Two to four examples are enough. Longer lists distract from the question and imp
 
 When reviewing a PR that adds or modifies `identificationQuestions`:
 
-- [ ] Count is between 5 and 7
+Items marked **(hook)** are blocked at commit by `validate-identification-questions`; the rest are editorial and rely on reviewer judgment.
+
+- [ ] Count is between 5 and 7 **(hook)**
+- [ ] All questions use second-person framing (`Do you`, `Are you`, `Does your`) **(hook)**
+- [ ] Parenthetical example lists are 2–4 items **(hook)**
+- [ ] Parentheticals use "e.g.", not "i.e." **(hook)**
 - [ ] Every question is answerable yes or no
-- [ ] All questions use second-person framing (`Do you`, `Are you`, `Does your`)
 - [ ] Technical terms have parenthetical examples where needed
 - [ ] "including" is used where the base term might be read too narrowly
 - [ ] Each question asks about an activity, not a job title or organizational label
 - [ ] Any activity shared with an adjacent persona has a scoping clause distinguishing between them
 - [ ] Questions are ordered: most distinguishing first, boundary-clarifying last
 - [ ] No two questions are effectively asking the same thing
-- [ ] Parenthetical example lists are 2–4 items using "e.g."
+
+---
+
+## Rule enforcement summary
+
+Per [ADR-021](../../../docs/adr/021-personas-and-self-assessment-schema.md) D7, the structural rules are machine-enforced; the editorial rules require judgment a regex cannot supply.
+
+| Rule | Mechanism | Status |
+|------|-----------|--------|
+| Count 5–7 questions per active persona | `validate-identification-questions` hook (block) | Machine-enforced |
+| Second-person opener (`Do you `/`Are you `/`Does your `) | `validate-identification-questions` hook (block) | Machine-enforced |
+| Parenthetical lists ≤ 4 items | `validate-identification-questions` hook (block) | Machine-enforced |
+| `e.g.` not `i.e.` in parentheticals | `validate-identification-questions` hook (block) | Machine-enforced |
+| `identificationQuestions` present on active personas | schema (ADR-021 D8) | Machine-enforced |
+| Each question non-empty | schema (`minLength: 1`) | Machine-enforced |
+| Yes/no answerability | content-reviewer + `audit-identification-questions` skill | Editorial |
+| Activities not titles | content-reviewer + skill | Editorial |
+| Scoping clauses for shared activities | content-reviewer + skill | Editorial |
+| Question ordering (distinguishing first, boundary last) | content-reviewer + skill | Editorial |
+| Anti-patterns (leading, embedded conditionals, overlapping) | content-reviewer + skill | Editorial |
+
+The hook is the machine-enforcement layer; the `audit-identification-questions` skill remains authoritative for the editorial rules. The two overlap on the structural rules by design — either can flag a violation.
 
 ---
 

--- a/risk-map/docs/contributing/issue-templates-guide.md
+++ b/risk-map/docs/contributing/issue-templates-guide.md
@@ -150,7 +150,7 @@ The template includes inline links to:
 
 - **Component Changes** - Use `+` to add, `-` to remove (e.g., `+ componentModelEvaluation`, `- componentDataSources`)
 - **Risk Changes** - Same syntax (e.g., `+ riskModelSourceTampering`, `- riskPromptInjection`)
-- **Framework Changes** - Same syntax (e.g., `+ mitre-atlas: AML.M0015`, `- nist-ai-rmf: GV-6.2`)
+- **Framework Changes** - Same syntax (e.g., `+ mitre-atlas: AML.M0015`, `- nist-ai-rmf: GOVERN-6.2`)
 - **Supporting Evidence** - Links to discussions, standards, references
 
 **Example Walkthrough:**
@@ -207,8 +207,7 @@ This provides exact context for maintainers to see what you're changing.
 
 **Optional Fields:**
 
-- Examples (real-world scenarios)
-- Relevant questions (for risk assessment)
+- Examples (real-world scenarios, with sources cited via `externalReferences`)
 - Framework mappings (MITRE ATLAS, STRIDE, OWASP Top 10 for LLM)
 - Lifecycle stages
 - Impact types
@@ -241,12 +240,20 @@ controlModelAndDataIntegrityManagement
 controlAdversarialTrainingAndTesting
 
 Examples:
-<a href="https://arxiv.org/abs/1708.06733" target="_blank" rel="noopener">BadNets: Identifying Vulnerabilities in the Machine Learning Model Supply Chain (Gu et al., 2017)</a>
+  - The BadNets work ({{ref:gu-2017-badnets}}) demonstrated trojaned models in the ML supply chain.
+
+External References:
+  - type: paper
+    id: gu-2017-badnets
+    title: "BadNets: Identifying Vulnerabilities in the Machine Learning Model Supply Chain (Gu et al., 2017)"
+    url: https://arxiv.org/abs/1708.06733
 
 Framework Mappings:
 mitre-atlas: AML.T0018
-stride: tampering
+stride: Tampering
 ```
+
+Prose fields carry no inline URLs or HTML. Each source is a structured `externalReferences` entry referenced from prose by a `{{ref:identifier}}` sentinel ([ADR-016](../../../docs/adr/016-reference-strategy.md), [ADR-017](../../../docs/adr/017-yaml-prose-authoring-subset.md)). Framework-mapping IDs use the canonical form — `Tampering`, not `tampering`. See [`yaml-authoring-subset.md`](../yaml-authoring-subset.md) and [`framework-mappings-style-guide.md`](./framework-mappings-style-guide.md).
 
 **Reference Links:**
 
@@ -274,8 +281,7 @@ stride: tampering
 
 - **Control Changes** - `+`/`-` syntax
 - **Framework Changes** - `+`/`-` syntax
-- **Examples Updates** - Add/modify real-world scenarios
-- **Assessment Questions** - Add/modify relevant questions
+- **Examples Updates** - Add/modify real-world scenarios (sources cited via `externalReferences`)
 - **Tour Content** - Updates for interactive risk tour
 - **Supporting Evidence** - Research, CVEs, standards
 
@@ -647,7 +653,7 @@ Update templates support quick actions using familiar git diff syntax:
 
 ```
 - componentOldItem
-- nist-ai-rmf: GV-6.2
+- nist-ai-rmf: GOVERN-6.2
 ```
 
 **Benefits:**

--- a/risk-map/docs/contributing/risk-titles-style-guide.md
+++ b/risk-map/docs/contributing/risk-titles-style-guide.md
@@ -28,6 +28,8 @@ Write titles of 2-5 words. Shorter titles are preferred when they capture the ri
 | 5 | Excessive Data Handling During Inference | Upper bound — only when scoping is essential |
 | 6+ | — | Avoid — rephrase or split |
 
+The schema also caps risk titles at **120 characters** (`risks.schema.json` `title.maxLength`, per [ADR-022](../../../docs/adr/022-supporting-schemas.md) / C1 #322). The 2-5 word guidance keeps you well inside that limit; the character cap is a hard backstop a conformant title never reaches.
+
 ### Form
 
 Titles must be **noun phrases** that name the threat, vulnerability, or attack vector. They are not sentences, not descriptions of missing controls, and not explanations of consequences.

--- a/risk-map/docs/contributing/submission-readiness-guide.md
+++ b/risk-map/docs/contributing/submission-readiness-guide.md
@@ -26,8 +26,9 @@ Work through this list before opening an issue. Every item maps to a section bel
 - [ ] **Classical security equivalent is named** — the long description maps to a pre-AI risk/defense, then explains the AI-specific amplifier.
 - [ ] **Personas use the correct model** — risks list _impacted_ personas; controls list _implementer_ personas.
 - [ ] **No universal controls on risks** — the 7 universal controls apply to all risks implicitly.
-- [ ] **Examples are real** — incidents, research, or vulnerability disclosures with verifiable URLs.
-- [ ] **Framework mappings use valid IDs from the correct framework** — no parent + sub-technique, no wrong entity type.
+- [ ] **Examples are real** — incidents, research, or vulnerability disclosures, each backed by an `externalReferences` entry cited with a `{{ref:identifier}}` sentinel (no inline URLs).
+- [ ] **Prose uses the authoring subset** — `**bold**` / `*italic*` only, no raw HTML, no inline URLs; cross-references and citations use `{{…}}` sentinels.
+- [ ] **Framework mappings use canonical IDs from the correct framework** — no parent + sub-technique, no wrong entity type, canonical form (e.g., `Tampering`, `GOVERN-1.1`, `LLM01:2025`).
 - [ ] **No overlap with existing entries** — searched `risks-summary.md` / `controls-summary.md` and found nothing close.
 - [ ] **Short description is 1-2 sentences** — the long-form detail belongs in the description field.
 
@@ -125,9 +126,9 @@ The `examples` field anchors a risk or control to observable reality. Reviewers 
 
 1. **Real, not hypothetical.** Published incidents, academic research, vulnerability disclosures, or documented bugs qualify. Thought experiments and "what if an attacker..." scenarios do not.
 2. **Not a vendor product announcement.** A blog post announcing a new defensive product is not evidence of a risk or control. A post-mortem describing how that product caught an incident is.
-3. **Verifiable URLs.** Every example must cite a source the reader can open. Format examples as HTML anchors matching existing entries in the YAML files.
+3. **Verifiable source, structured citation.** Every example must cite a source the reader can open. The source URL does **not** go inline in the prose — it lives in the entry's `externalReferences` array (`type`, `id`, `title`, `url`), and the example references it with a `{{ref:identifier}}` sentinel. Raw HTML anchors and inline URLs are rejected at commit ([ADR-016](../../../docs/adr/016-reference-strategy.md), [ADR-017](../../../docs/adr/017-yaml-prose-authoring-subset.md)). See [`yaml-authoring-subset.md`](../yaml-authoring-subset.md) for the two-step flow.
 
-When in doubt, browse existing `examples` fields in `risks.yaml` or `controls.yaml` to calibrate.
+When in doubt, browse existing `examples` fields in `risks.yaml` or `controls.yaml` to calibrate — they use the sentinel + `externalReferences` form.
 
 ---
 
@@ -135,15 +136,16 @@ When in doubt, browse existing `examples` fields in `risks.yaml` or `controls.ya
 
 Different entity types map to different external frameworks. See [`framework-mappings-style-guide.md`](./framework-mappings-style-guide.md) for the full rules.
 
-| Entity  | STRIDE                 | MITRE ATLAS               | OWASP LLM Top 10 | NIST AI RMF           |
-| ------- | ---------------------- | ------------------------- | ---------------- | --------------------- |
-| Risk    | ✓ (lowercase category) | Techniques (`AML.T####`)  | ✓ (`LLM##`)      | —                     |
-| Control | —                      | Mitigations (`AML.M####`) | —                | ✓ (subcategory level) |
+| Entity  | STRIDE                  | MITRE ATLAS               | OWASP LLM Top 10  | NIST AI RMF             |
+| ------- | ----------------------- | ------------------------- | ----------------- | ----------------------- |
+| Risk    | ✓ (`Tampering`)         | Techniques (`AML.T####`)  | ✓ (`LLM01:2025`)  | —                       |
+| Control | —                       | Mitigations (`AML.M####`) | ✓ (`LLM01:2025`)  | ✓ (`GOVERN-1.1`)        |
 
 **Rules of thumb:**
 
 - Risks map to **techniques**; controls map to **mitigations**. Do not mix.
 - Never map a parent technique **and** one of its sub-techniques. Pick the most specific applicable ID.
+- Use the **canonical** identifier form: PascalCase STRIDE (`Tampering`), full-word NIST prefixes (`GOVERN-1.1`), versioned OWASP (`LLM01:2025`). See [`framework-mappings-style-guide.md`](./framework-mappings-style-guide.md).
 - Verify every mapping ID exists in the referenced framework before submitting.
 
 ---
@@ -192,6 +194,8 @@ See [`common-review-findings.md`](./common-review-findings.md) for the full list
   - [`component-titles-style-guide.md`](./component-titles-style-guide.md)
   - [`identification-questions-style-guide.md`](./identification-questions-style-guide.md)
   - [`framework-mappings-style-guide.md`](./framework-mappings-style-guide.md)
+- **Authoring conventions:**
+  - [`yaml-authoring-subset.md`](../yaml-authoring-subset.md) — prose subset (allowed tokens), the no-inline-URL rule, and the `externalReferences` + `{{ref:…}}` citation flow
 - **Process:**
   - [`issue-templates-guide.md`](./issue-templates-guide.md) — which template to use and when
   - [`common-review-findings.md`](./common-review-findings.md) — top reviewer findings with fix guidance

--- a/risk-map/docs/persona-pages.md
+++ b/risk-map/docs/persona-pages.md
@@ -99,16 +99,36 @@ The workflow at `.github/workflows/persona-pages.yml` handles the explorer:
 - If additional personas gain full `identificationQuestions`, they will automatically move from the manual-fallback section into the guided question flow.
 - `AI System Governance` currently has control mappings but no direct risk mappings in the framework data. The site therefore shows governance controls and a clear risks empty-state note.
 
-## YAML Prose Allowed HTML
+## YAML Prose Rendering
 
-Prose fields (`longDescription`, `shortDescription`, `examples`, `description`) render as HTML without sanitization. Contributors may use:
+Prose fields (`longDescription`, `shortDescription`, `examples`, `description`) carry a
+small markdown subset, **not** raw HTML. Contributors author:
 
-- `<a href="..." target="_blank" rel="noopener">…</a>` — for citations and references
-- `<strong>`, `<em>`, `<code>` — for emphasis and inline code
+- `**bold**` and `*italic*` / `_italic_` — for emphasis (never `<strong>`/`<em>`).
+- `{{<entity-id>}}` sentinels — for intra-framework references (resolve to an in-page link).
+- `{{ref:identifier}}` sentinels — for external citations, backed by an `externalReferences` entry.
 
-Reviewers must reject YAML containing any other tags. A future allowlist validator may codify this in automation.
+Raw HTML tags, inline URLs (any scheme), and bare entity IDs are **rejected at commit**
+by the `validate-yaml-prose-subset` and `validate-prose-references` hooks
+([ADR-017](../../docs/adr/017-yaml-prose-authoring-subset.md),
+[ADR-016](../../docs/adr/016-reference-strategy.md)). The full authoring rules and the
+`externalReferences` citation flow live in
+[yaml-authoring-subset.md](./yaml-authoring-subset.md).
 
-Nested list syntax (`- - >`) encodes a logical sub-group within a prose field and renders as a visually distinct `<div class="subsection">`. Empty list entries (`- ""`) are silently dropped — do not use them as spacing hacks.
+**Render-time sanitization.** The builder expands sentinels to structured prose items
+(`{type:"ref"}` / `{type:"link"}`), and the renderer routes every paragraph through
+`renderProse` (`site/assets/sanitizer.mjs`), which emits a bounded HTML allowlist —
+`<strong>`, `<em>`, and `<a>` whose attributes are constructed (`https:`-only `href`,
+`rel="noopener noreferrer"`, `target="_blank"`), never copied from input
+([ADR-015](../../docs/adr/015-site-content-sanitization-invariants.md) D1/D3a). Anything
+outside the allowlist is **escaped** (rendered as visible `&lt;…&gt;`) with a console
+warning, not silently dropped — so a contributor who bypassed the upstream lint sees
+that their markup did not land. Authors cannot widen the allowlist from YAML; growing it
+is an ADR-015 revisit, not a content change.
+
+Nested list syntax (`- - >`) encodes a logical sub-group within a prose field and
+renders as a visually distinct `<div class="subsection">`. Empty list entries (`- ""`)
+are silently dropped — do not use them as spacing hacks.
 
 ## Accessibility
 
@@ -133,4 +153,5 @@ Known gap: focus is not preserved across full-app re-renders (answering a questi
 - [Developing the framework](./developing.md)
 - [Frontend test conventions](../../site/tests/README.md)
 - [Identification Questions Style Guide](./contributing/identification-questions-style-guide.md)
+- [YAML Prose Authoring Subset](./yaml-authoring-subset.md)
 - [Repository CONTRIBUTING.md](../../CONTRIBUTING.md)

--- a/risk-map/docs/reuse-contract.md
+++ b/risk-map/docs/reuse-contract.md
@@ -1,0 +1,106 @@
+# Reuse Contract
+
+The CoSAI Risk Map is published for wide reuse. Third parties ingest the raw YAML under
+`risk-map/yaml/**` into LLM tooling, prompt libraries, vendor products, and downstream
+frameworks. This page is the human-readable engineering contract for that reuse: what the
+framework guarantees, what it does not, and what a downstream consumer is responsible for.
+
+It implements [ADR-014](../../docs/adr/014-yaml-content-security-posture.md) P5 in
+consumer-facing terms. ADR-014 is the policy decision; this page is its documentation.
+For legal terms, see [`LICENSE.md`](../../LICENSE.md) — this page does not restate them.
+
+---
+
+## What the framework guarantees
+
+**Shape.** Every field in `risk-map/yaml/**` is described by a JSON Schema under
+`risk-map/schemas/*.schema.json`, and cross-file integrity (control↔risk references,
+component edges, framework applicability, sentinel resolution) is enforced by the
+validators in `scripts/hooks/`. A consumer that validates the YAML against the published
+schemas gets the same shape guarantee the repository's own tooling relies on. This is the
+load-bearing guarantee — write your parser against the schemas.
+
+**Prose content.** Prose fields carry a small, fixed vocabulary: `**bold**`,
+`*italic*`/`_italic_`, and `{{…}}` reference sentinels — and **no URLs at all**. Every
+outbound URL lives in a typed, schema-validated `externalReferences` entry; prose
+references it by sentinel. A redistributor parsing the YAML knows that any URL it ingests
+came through a structured field, not free prose. The full rule is in
+[yaml-authoring-subset.md](./yaml-authoring-subset.md) and
+[ADR-017](../../docs/adr/017-yaml-prose-authoring-subset.md).
+
+**Provenance.** Every change to `risk-map/yaml/**` lands through a reviewed pull request,
+attributed to identifiable contributors, with AI-assisted contributions tagged per
+[ADR-004](../../docs/adr/004-ai-assistant-trailer.md). The git history is the provenance
+record; there is no separate signing or attestation surface.
+
+**Identifiers are stable references.** Entity IDs (`riskPromptInjection`,
+`controlInputValidationAndSanitization`, …) are closed schema enums. A rename updates the
+enum, which re-validates every cross-reference and every prose sentinel across the
+framework at once. An ID that resolves today resolves consistently across the YAML, the
+generated tables, and the site.
+
+## What the framework does NOT guarantee
+
+The framework cannot tell you "this content is safe for your pipeline," because it does
+not know what your pipeline is. It explicitly does **not** guarantee:
+
+- **Safety in any specific rendering surface.** The YAML is untrusted input at every
+  consumer boundary ([ADR-014](../../docs/adr/014-yaml-content-security-posture.md) P1).
+  HTML escaping, prompt-injection defense, and markup stripping are the consumer's job at
+  the consumer's boundary — see "What you are responsible for" below.
+- **Semantic stability of mappings.** Framework cross-walks (`mappings` to MITRE ATLAS,
+  NIST AI RMF, OWASP, etc.) are the working group's best-effort interpretation. No
+  external framework maintainer has reviewed or endorsed them, and they may change as the
+  source frameworks evolve.
+- **Backwards-compatible schema evolution as a hard promise.** Schemas are maintained for
+  best-effort backwards compatibility, but the YAML files carry no per-file `version`
+  field today and there is no SemVer contract on the schemas. Treat the git history (and
+  any future CHANGELOG) as the change record. Breaking shape changes are called out in the
+  PR that makes them, not guaranteed absent.
+- **Completeness.** The risk, control, component, and persona catalogs are not exhaustive
+  and are not a substitute for a threat model of your own system.
+
+## What you are responsible for (downstream sanitization)
+
+Relative to your surface, treat the YAML prose as **untrusted input** and sanitize at your
+own boundary before rendering or embedding it:
+
+- **Web/HTML consumers** — HTML-escape or run an allowlist transform before writing prose
+  into the DOM. The reference implementation is `site/assets/sanitizer.mjs` (`renderProse`),
+  which emits a bounded `<strong>`/`<em>`/`<a>` allowlist with constructed attributes
+  ([ADR-015](../../docs/adr/015-site-content-sanitization-invariants.md)). The on-disk YAML
+  is subset-compliant, but you should still defend your own render boundary.
+- **LLM consumers** — sanitize prose before embedding it in prompts. Content review screens
+  for evident injection intent, but the framework cannot defend a prompt it does not
+  control. Treat the content as data, not instructions.
+- **Export consumers (PDF, docs, etc.)** — apply the markup transform appropriate to your
+  output format. The prose vocabulary is small and documented in
+  [yaml-authoring-subset.md](./yaml-authoring-subset.md); transform from that, not from an
+  assumption of arbitrary markdown.
+
+The honest summary: the framework makes the content **shape-safe and provenance-tracked**;
+it does not make it **pipeline-safe**. That boundary is the contract.
+
+## Versioning and cadence
+
+- The YAML carries no per-file version metadata today. A future revision may add a
+  top-level `_meta` block; **consumers should ignore unknown top-level keys** so that
+  addition does not break them.
+- Schema changes that alter shape are visible in the git history of `risk-map/schemas/`.
+  Until a published CHANGELOG exists, the commit history is the change record.
+
+## Attribution and endorsement
+
+Attribution follows the terms in [`LICENSE.md`](../../LICENSE.md). Reuse of the content
+does not imply endorsement by the Coalition for Secure AI or its member organizations, and
+redistributed copies should not represent themselves as authoritative CoSAI publications.
+
+---
+
+## Related
+
+- [ADR-014](../../docs/adr/014-yaml-content-security-posture.md) — YAML content security posture (P5 is the source of this contract)
+- [ADR-017](../../docs/adr/017-yaml-prose-authoring-subset.md) — Prose authoring subset (the "no URLs in prose" guarantee)
+- [ADR-015](../../docs/adr/015-site-content-sanitization-invariants.md) — Site render-time sanitization (reference implementation)
+- [yaml-authoring-subset.md](./yaml-authoring-subset.md) — What prose strings carry
+- [`LICENSE.md`](../../LICENSE.md) — Legal terms

--- a/risk-map/docs/yaml-authoring-subset.md
+++ b/risk-map/docs/yaml-authoring-subset.md
@@ -1,0 +1,164 @@
+# YAML Prose Authoring Subset
+
+This page is the consumer-facing summary of what prose strings in the CoSAI Risk Map
+YAML may contain. It covers the three allowed token forms, the two sentinel forms,
+the categorical no-inline-URL rule, and the `externalReferences` citation flow.
+
+It is a summary of the decisions in [ADR-017](../../docs/adr/017-yaml-prose-authoring-subset.md)
+(authoring subset), [ADR-016](../../docs/adr/016-reference-strategy.md) (references), and
+[ADR-014](../../docs/adr/014-yaml-content-security-posture.md) (security posture). Where
+this page and an ADR disagree, the ADR is authoritative — drift here is a documentation
+defect.
+
+**Who this is for**
+
+- **Contributors** authoring `risk-map/yaml/{components,controls,risks,personas}.yaml`.
+- **Redistributors** ingesting the YAML directly, who need to know what tokens the prose
+  fields carry.
+
+Prose fields are: `description`, `shortDescription`, `longDescription`, `examples`,
+`responsibilities`, `tourContent.*`, and equivalents. Identifiers, enums, and
+structured-reference fields are not prose and are not covered here.
+
+---
+
+## The three allowed forms
+
+A prose string may contain exactly these token forms. Everything else is rejected at
+commit time by the `validate-yaml-prose-subset` and `validate-prose-references`
+pre-commit hooks (both in block mode).
+
+| Form | Syntax | Notes |
+|------|--------|-------|
+| **Bold** | `**bold**` | Asterisk delimiter only. `__bold__` is not recognized. One nesting level; no nested `**…**`. |
+| **Italic** | `*italic*` or `_italic_` | Both delimiters recognized. No nested italic. |
+| **Sentinels** | `{{<entity-id>}}` / `{{ref:identifier}}` | Reference tokens — see below. The braces carry an identifier only. |
+
+Bold and italic may compose: `**emphatically *not* this**` is valid. Sentinels are
+atomic identifier tokens; they do not nest into bold or italic. Paragraph and
+hard-break structure is carried by the YAML **array** shape (one array item per
+paragraph), not by markup in the string.
+
+---
+
+## The two sentinel forms
+
+References — to another framework entity, or to an external source — are written as
+double-brace sentinels. There is no other syntax for a reference, and no inline URL or
+HTML anchor form.
+
+### Intra-document — `{{<entity-id>}}`
+
+Mentions another framework entity by its canonical camelCase ID. The generator resolves
+it to the entity's title (in tables) or an in-page link (on the site); authors never
+hand-write the display title.
+
+```yaml
+description:
+  - "This compounds {{riskPromptInjection}} when the tool output is unsanitized."
+```
+
+The ID must resolve against the schema's identifier enum (risk, control, component,
+persona). An unknown ID is blocked at commit and fails the build.
+
+### External — `{{ref:identifier}}`
+
+Cites an external source — a paper, advisory, CWE, CVE, spec, or editorial pointer. The
+`ref:` prefix is literal; `identifier` matches an `id` in the entry's own
+`externalReferences` array.
+
+```yaml
+description:
+  - "The SQL-injection pattern ({{ref:cwe-89}}) applies to query construction in agent tooling."
+```
+
+---
+
+## No inline URLs — the categorical rule
+
+**A prose string carries no URL of any scheme.** Not `https://…`, not `[text](url)`
+markdown links, not `<a href>` HTML, not `mailto:` / `tel:` / `javascript:` / `data:`.
+The rule is categorical: if a token carries a URI scheme, the linter rejects it.
+
+This is deliberate. The editorial line between "this URL is a citation" and "this URL is
+color" is not machine-testable, so every URL moves into a structured field and prose
+references it by sentinel. A redistributor parsing the YAML then knows every URL it
+ingests came through a typed, schema-validated field — not free prose.
+
+## The `externalReferences` flow (two steps)
+
+Adding a link is a two-step move. **Add the structured entry first, then reference it by
+sentinel.**
+
+```yaml
+# Step 1 — add the structured entry
+externalReferences:
+  - type: paper
+    id: zhou-2023-poisoning
+    title: "Poisoning Language Models During Instruction Tuning"
+    url: https://arxiv.org/abs/2305.00944
+
+# Step 2 — reference it from prose by sentinel
+description:
+  - "Zhou et al. ({{ref:zhou-2023-poisoning}}) demonstrated instruction-tuning poisoning at scale."
+```
+
+Each `externalReferences` entry has four required fields:
+
+- **`type`** — one of `cwe`, `cve`, `atlas`, `attack`, `advisory`, `paper`, `news`,
+  `spec`, `editorial`, `other`. Use `editorial` for a non-citation "see also" / color
+  pointer — the relief valve that keeps the citation types clean.
+- **`id`** — the sentinel target; unique within the entry. For canonical references
+  (`cwe`, `cve`, `atlas`, `attack`) mirror the canonical ID in lowercase-kebab form
+  (`cwe-89`, `cve-2024-0001`); otherwise pick a stable shorthand (`zhou-2023-poisoning`).
+- **`title`** — the display string generators and the site renderer use.
+- **`url`** — must be `https://` (HTTP is rejected). Empty arrays are rejected; omit the
+  field entirely if there are no references.
+
+---
+
+## Disallowed constructions
+
+All blocked at commit. Each has an actionable alternative.
+
+| Disallowed | Use instead |
+|------------|-------------|
+| Raw HTML (`<a>`, `<strong>`, `<em>`, `<br>`, `<p>`, `<div>`, `<script>`, `on*=`, …) | `**bold**`, `*italic*`, array items for breaks, sentinels for links |
+| Inline URLs (any scheme), `[text](url)` markdown links | `externalReferences` entry + `{{ref:identifier}}` sentinel |
+| Bare camelCase IDs (`riskPromptInjection` in a sentence) | `{{riskPromptInjection}}` sentinel |
+| Markdown headings (`#`, `##`) | YAML structure expresses hierarchy |
+| Markdown list markers (`- `, `* `, `1. `) | The prose-array shape is the list primitive |
+| Code fences / inline code (`` `code` ``) | Out of scope for the subset |
+| Images (`![alt](url)`) | Not embedded in prose |
+| Blockquotes (`>`), pipe tables | Out of scope; tables are generated artifacts |
+
+---
+
+## The redistribution contract for prose
+
+After the conformance sweep, the YAML carries a stronger guarantee than "some URLs you
+must sanitize" ([ADR-017](../../docs/adr/017-yaml-prose-authoring-subset.md) D6):
+
+> **YAML prose contains no URLs at all.** Every URL lives in a typed, schema-validated
+> `externalReferences` entry; prose references them by sentinel only.
+
+A redistributor parsing the YAML can rely on a three-form prose vocabulary (bold,
+italic, sentinels) and a fully-typed reference surface. This is part of the broader
+reuse contract — see [reuse-contract.md](./reuse-contract.md).
+
+The framework guarantees the **shape** of this content (via the schemas and the
+authoring lint); it does **not** guarantee safety in any specific downstream pipeline.
+A consumer embedding this content in HTML, a prompt, or a PDF still sanitizes at its own
+boundary. See [reuse-contract.md](./reuse-contract.md) and
+[ADR-014](../../docs/adr/014-yaml-content-security-posture.md) P5.
+
+---
+
+## Related
+
+- [ADR-017](../../docs/adr/017-yaml-prose-authoring-subset.md) — Canonical prose authoring subset (source of truth)
+- [ADR-016](../../docs/adr/016-reference-strategy.md) — Sentinel grammar + `externalReferences` field
+- [ADR-014](../../docs/adr/014-yaml-content-security-posture.md) — YAML content security posture
+- [reuse-contract.md](./reuse-contract.md) — What the framework guarantees to downstream consumers
+- [contributing/framework-mappings-style-guide.md](./contributing/framework-mappings-style-guide.md) — Framework-mapping identifier forms
+- [contributing/submission-readiness-guide.md](./contributing/submission-readiness-guide.md) — Preparing a content proposal

--- a/scripts/agents/code-reviewer.md
+++ b/scripts/agents/code-reviewer.md
@@ -75,6 +75,38 @@ Evaluate every submission across these axes, in this order:
 
 ---
 
+## CoSAI-RM content-enforcement boundaries
+
+The conformance sweep (ADRs 014–022) added a layer of pre-commit hooks that enforce
+content rules mechanically. When a PR touches these hooks, their wrappers, or the prose
+they validate, hold it to these boundaries:
+
+- **Shared tokenizer is the single source of grammar.** `validate-yaml-prose-subset`
+  (ADR-017) and `validate-prose-references` (ADR-016) both import the shared tokenizer
+  at `scripts/hooks/precommit/_prose_tokens.py`, and read the prose-field list from
+  `scripts/hooks/precommit/_prose_fields.py` (derived from the schemas, not hardcoded).
+  **Flag any PR that re-implements prose tokenization, the markdown-subset grammar, or
+  the URL/HTML rejection in a second place** instead of importing the shared module
+  (ADR-017 D5). Two grammars that can disagree is the defect.
+- **The site sanitizer's emission surface is bounded and ADR-gated.** `site/assets/sanitizer.mjs`
+  emits a hard-coded `ALLOWED_TAGS` literal (`strong`, `em`, `a`) with constructed
+  attribute values (ADR-015 D3a). A PR that grows `ALLOWED_TAGS`, lets an attribute
+  value flow from input, or adds a render path that bypasses `renderProse` is **critical**
+  and is an ADR-015 revisit — not a routine change. The D3b meta-test
+  (`ALLOWED_TAGS` ↔ fixtures) and the `<a>` attack-corpus must be updated in the same PR;
+  a sanitizer change without matching fixtures is incomplete.
+- **Content rules are machine-enforced, not editorial.** The relevant hooks (all block):
+  `validate-yaml-prose-subset`, `validate-prose-references`, `validate-identification-questions`
+  (ADR-021 D7), `validate-framework-references`, `validate-lifecycle-stage`,
+  `validate-component-edges`, `validate-control-risk-references`. A PR that disables a
+  hook, narrows its `files:` pattern, or adds a `# noqa`-style bypass to dodge a rule is
+  **major** unless an ADR amendment justifies it.
+- **Trigger ↔ read-set invariant (ADR-005 addendum).** A validator's pre-commit `files:`
+  trigger must cover every file it actually reads. If a hook reads `frameworks.yaml` or a
+  schema but only triggers on one content file, flag the silent-skip risk.
+
+---
+
 ## Boundaries
 
 - **Do:** identify issues, explain rationale, propose fixes, assign severity, decide the next-agent handoff.

--- a/scripts/agents/content-reviewer.md
+++ b/scripts/agents/content-reviewer.md
@@ -127,6 +127,37 @@ If provided, use them to supplement (not override) the embedded schema awareness
 
 **Category IDs** follow `{typePlural}{Domain}` in camelCase. Examples: `risksRuntimeInputSecurity`, `controlsInfrastructure`, `componentsModel` (personas have no category enum). Authoritative enums live in the per-type `*.schema.json` files; consult those rather than inferring.
 
+### Machine-enforcement boundary (ADRs 014–022)
+
+The conformance sweep moved a set of content rules from prose-only guidance into
+**block-mode pre-commit hooks**. Know the boundary: do not spend review effort
+re-deriving what a hook already blocks, and **cite the boundary** when a finding is
+machine-enforced (so the contributor knows it will fail at commit, not just in review).
+
+Machine-enforced (hooks block at commit — a PR cannot merge while violating these):
+
+| Rule | Hook | ADR |
+|------|------|-----|
+| Prose markdown subset; no raw HTML; no inline URLs (any scheme) | `validate-yaml-prose-subset` | 017 |
+| `{{<entity-id>}}` / `{{ref:identifier}}` sentinels resolve; no bare IDs; no inline URLs | `validate-prose-references` | 016 |
+| Identification-questions structural rules (count 5–7, second-person opener, parenthetical ≤4, `e.g.` not `i.e.`) | `validate-identification-questions` | 021 D7 |
+| Framework `applicableTo` + mapping-ID shape (strict for MITRE ATLAS / EU AI Act / ISO 22989; canonical-but-fall-through for STRIDE / NIST / OWASP) | `validate-framework-references` + schema | 022 D5b |
+| Lifecycle-stage enum | `validate-lifecycle-stage` | 019 |
+| Component edge bidirectionality; control↔risk integrity | `validate-component-edges`, `validate-control-risk-references` | 018/020 |
+| Schema shape, enums, `additionalProperties: false`, `title.maxLength` | `check-jsonschema` | 018–022 |
+
+Editorial (your domain — judgment a regex cannot supply): activities-not-titles and
+scoping-clause appropriateness on identification questions; citation-vs-`editorial` typing
+of `externalReferences`; mapping *selection* quality (is this the right technique?);
+under/over-specification; scope creep; classical-equivalent framing; persona-model
+correctness. The hooks check *shape*; you check *substance*.
+
+**Canonical-but-not-yet-enforced caveat.** STRIDE, NIST AI RMF, and OWASP mapping IDs
+fall through to a loose schema pattern pending content migration, but the **canonical**
+form (PascalCase `Tampering`, `GOVERN-1.1`, `LLM01:2025`) is the one to require in review
+(ADR-022 D5b, ADR-026 D4b). Flag a legacy-form mapping as a WARN even though the schema
+currently accepts it.
+
 ---
 
 ## Review Checks
@@ -140,6 +171,10 @@ If provided, use them to supplement (not override) the embedded schema awareness
 | Dangling reference (points to nonexistent ID) | **FAIL** | Agent asserts |
 | Bidirectional inconsistency (risk↔control)    | **FAIL** | Agent asserts |
 | Unknown/invalid field names                   | **WARN** | Agent asserts |
+| Raw HTML or inline URL in a prose field       | **FAIL** | Hook-enforced (`validate-yaml-prose-subset`) — cite the boundary |
+| Bare entity ID in prose (use a `{{…}}` sentinel) | **FAIL** | Hook-enforced (`validate-prose-references`) |
+| Unresolved `{{…}}` sentinel or missing `externalReferences` entry | **FAIL** | Hook-enforced (`validate-prose-references`) |
+| Retired field (e.g., `relevantQuestions` on a risk) | **FAIL** | Hook-enforced (`additionalProperties: false`, ADR-019 D6) |
 
 ### 2. Duplication Detection
 
@@ -189,6 +224,7 @@ When reviewed content includes fields governed by a style guide, load the guide 
 | ------------------------- | -------------------------------------------------------------------- | --------------------------------------------------- |
 | `identificationQuestions` | `risk-map/docs/contributing/identification-questions-style-guide.md` | Any persona with `identificationQuestions` in scope |
 | `mappings`                | `risk-map/docs/contributing/framework-mappings-style-guide.md`       | Any entity with `mappings` in scope                 |
+| prose / `examples` / `externalReferences` | `risk-map/docs/yaml-authoring-subset.md`                | Any entity with prose, sentinels, or citations in scope |
 
 **Procedure:**
 

--- a/scripts/agents/issue-response-reviewer.md
+++ b/scripts/agents/issue-response-reviewer.md
@@ -67,9 +67,10 @@ Key conventions that anchor field-by-field analysis:
 - `personaGovernance` is **controls-only** — never valid on a risk.
 - Seven controls carry `risks: all` (universal controls). Risks must not list universal controls explicitly.
 - Risks map to MITRE ATLAS **techniques** (`AML.T####`); controls map to MITRE ATLAS **mitigations** (`AML.M####`).
-- STRIDE categories are lowercase. OWASP LLM IDs are `LLM##`. NIST AI RMF mappings on controls use subcategory-level IDs.
+- Framework-mapping IDs use the **canonical** form (ADR-022 D5b): STRIDE PascalCase (`Tampering`), NIST AI RMF full-word prefixes (`GOVERN-1.1`), OWASP versioned (`LLM01:2025`), EU AI Act `Article N`. NIST mappings on controls are subcategory-level.
+- **Prose carries no raw HTML and no inline URLs** (ADR-017). Emphasis is `**bold**`/`*italic*`; intra-framework mentions are `{{<entity-id>}}` sentinels; external citations are `{{ref:identifier}}` sentinels backed by an `externalReferences` entry (ADR-016).
 
-See `risk-map/docs/contributing/submission-readiness-guide.md` for the contributor-facing statement of these rules.
+See `risk-map/docs/contributing/submission-readiness-guide.md` and `risk-map/docs/yaml-authoring-subset.md` for the contributor-facing statement of these rules.
 
 ---
 
@@ -100,8 +101,9 @@ For each field present in the proposal, evaluate the following. Missing fields t
 | `personas`                             | Correct model: risks list **impacted** personas; controls list **implementer** personas. `personaGovernance` is controls-only. `personaEndUser` expected on most risks. |
 | `controls` / `risks`                   | Referenced IDs exist. Universal controls not listed on risks.                                                                                                           |
 | `components`                           | Referenced IDs exist. `all` / `none` sentinels flagged for review.                                                                                                      |
-| `examples`                             | Real incidents/research/vulnerabilities; verifiable URLs; not vendor announcements or hypotheticals.                                                                    |
-| `mappings`                             | Valid framework IDs; correct entity-type alignment (technique vs. mitigation); no parent + sub-technique duplication.                                                   |
+| `examples`                             | Real incidents/research/vulnerabilities; not vendor announcements or hypotheticals. Sources cited via `externalReferences` + `{{ref:identifier}}` sentinel — no inline URLs or HTML in prose.                                            |
+| `externalReferences`                   | Each entry has `type`/`id`/`title`/`url` (`https://`); `id` unique within the entry and matches every `{{ref:…}}` sentinel; `editorial` used for non-citation pointers.                                                                  |
+| `mappings`                             | Valid framework IDs in **canonical** form (PascalCase STRIDE, `GOVERN-` NIST, `LLM##:YYYY` OWASP); correct entity-type alignment (technique vs. mitigation); no parent + sub-technique duplication. Taxonomy IDs only — no rationale/URLs. |
 | `identificationQuestions` (personas)   | Yes/no answerable; second-person framing; activity-based; scoping clauses when overlap with another persona exists.                                                     |
 | `lifecycle` / `impact` / `actorAccess` | Schema enum values.                                                                                                                                                     |
 
@@ -127,15 +129,15 @@ Apply the gates below as **declarative checks**. Each gate yields PASS / FAIL / 
 **Gate 2 — Example Validation**
 
 - Every example cites a real incident, research finding, vulnerability disclosure, or documented bug.
-- Every example includes a verifiable URL.
+- Every cited source is a structured `externalReferences` entry referenced from prose by a `{{ref:identifier}}` sentinel — no inline URLs or HTML anchors in the example prose.
 - No vendor product launches and no hypothetical scenarios.
 
 **Gate 3 — Framework Mapping Validation**
 
-- STRIDE categories are valid lowercase values.
+- STRIDE categories use the canonical PascalCase values (`Tampering`, not `tampering`).
 - MITRE ATLAS IDs match the entity type: techniques (`AML.T####`) on risks, mitigations (`AML.M####`) on controls.
-- OWASP LLM IDs are valid `LLM##` entries from the current edition.
-- NIST AI RMF mappings (controls only) are at subcategory level.
+- OWASP LLM IDs are versioned (`LLM01:2025`, not `LLM01`) from the current edition.
+- NIST AI RMF mappings (controls only) use full-word function prefixes (`GOVERN-1.1`, not `GV-1.1`) at subcategory level.
 - No parent + sub-technique pair listed together.
 - No mapping to the wrong entity type (e.g., a mitigation listed under a risk).
 
@@ -156,6 +158,8 @@ When the proposal is fit to proceed with minor corrections, draft a proposed YAM
 
 - Apply the corrections identified in field-by-field analysis.
 - Preserve the contributor's wording where possible; flag any reviewer rewrites in the proposal.
+- **Draft prose in the authoring subset.** Emphasis is `**bold**`/`*italic*` — never raw HTML. Intra-framework mentions use `{{<entity-id>}}` sentinels. Any source the contributor supplied as an inline URL or `<a>` anchor is converted: add a structured `externalReferences` entry (`type`, `id`, `title`, `url`) and reference it from prose with a `{{ref:identifier}}` sentinel. The drafted YAML must contain no inline URLs and no HTML (ADR-016/017), or it will fail the prose hooks at commit.
+- **Use canonical framework-mapping forms** (ADR-022 D5b): PascalCase STRIDE, `GOVERN-` NIST, `LLM##:YYYY` OWASP, `Article N` EU AI Act.
 - If the proposal introduces a new control, draft a **companion YAML** block showing the control entry with inferred `risks`, `components`, and `personas`.
 - Do not include fields the contributor did not provide unless they are required by schema — in that case, include the field with a clear `TODO:` placeholder and flag it as a GAP.
 

--- a/scripts/agents/swe.md
+++ b/scripts/agents/swe.md
@@ -63,6 +63,28 @@ Produce:
 4. **DRY with judgment.** Three similar lines is better than a premature abstraction. Wait for the third duplication before generalizing.
 5. **YAGNI.** Do not add features, config knobs, or abstractions beyond what the task requires. No "future flexibility" code.
 6. **Fail fast.** Validate inputs at system boundaries with specific, actionable error messages. Trust internal code; do not re-validate what the caller already guaranteed.
+7. **Reuse the shared content-enforcement modules.** When implementing or extending a
+   prose-related hook, import the shared tokenizer at
+   `scripts/hooks/precommit/_prose_tokens.py` and the prose-field discovery at
+   `_prose_fields.py` — never re-implement the markdown-subset grammar or the URL/HTML
+   rejection in a second place (ADR-017 D5). When touching the site renderer, route prose
+   through `renderProse` (`site/assets/sanitizer.mjs`); do not interpolate prose into
+   `innerHTML` directly, and do not widen the sanitizer's `ALLOWED_TAGS` or copy attribute
+   values from input — that is an ADR-015 revisit, not an implementation choice.
+
+---
+
+## Content-enforcement context (ADRs 014–022)
+
+For content-touching work, these hooks block at commit and must stay green:
+`validate-yaml-prose-subset` (ADR-017 — markdown subset, no raw HTML, no inline URLs),
+`validate-prose-references` (ADR-016 — `{{…}}` sentinels resolve, no bare IDs),
+`validate-identification-questions` (ADR-021 D7), `validate-framework-references`,
+`validate-lifecycle-stage`, `validate-component-edges`, `validate-control-risk-references`.
+When YAML prose needs a URL, the structured `externalReferences` entry + `{{ref:identifier}}`
+sentinel is the only path — there is no inline-URL form. Framework-mapping IDs use the
+canonical form (ADR-022 D5b). Do not disable a hook or narrow its `files:` trigger to make
+a change pass; surface the conflict instead.
 
 ---
 

--- a/scripts/agents/testing.md
+++ b/scripts/agents/testing.md
@@ -74,6 +74,35 @@ Every feature touches most of these:
 
 ---
 
+## Sanitizer and prose-linter test discipline (ADR-015 D3b)
+
+The site sanitizer (`site/assets/sanitizer.mjs`) and the prose-enforcement hooks carry
+structural test requirements that are not optional — the test suite *is* the mechanism
+that keeps the sanitizer's bounded-emission safety property from drifting.
+
+- **Per-tag fixtures are mandatory.** Every entry in the sanitizer's `ALLOWED_TAGS`
+  literal has at least one **positive** fixture (input → expected safe output) and one
+  **negative** fixture (a related disallowed input → escaped output). A tag added to the
+  allowlist without matching fixtures is a *test-suite failure*, not a runtime one.
+- **Allowlist ↔ fixture meta-test.** The suite asserts the allowlist constant matches the
+  fixture set (`ALLOWED_TAGS.every(tag => fixtures.has(tag))`). Adding a tag without a
+  fixture fails CI. Do not weaken or skip this meta-test.
+- **`<a>` attack-corpus.** The corpus covers `javascript:`, `data:`, `vbscript:`,
+  mixed-case schemes, schemeless/relative URLs, IDN homographs, attribute-injection via
+  quote handling, and whitespace tricks — each with an expected escaped/stripped output.
+  Fixtures live under `site/tests/fixtures/sanitizer/` (one file per category); a
+  contributor adds a vector by adding a data file, not a test function.
+- **Prose-hook fixtures share a corpus.** `validate-yaml-prose-subset` and
+  `validate-prose-references` share the tokenizer (`_prose_tokens.py`) and a shared
+  edge-case corpus at `scripts/hooks/tests/fixtures/prose_subset/` so the two hooks
+  cannot disagree on what a token *is* (ADR-017 D5). New token rules add fixtures there.
+
+**Reject sanitizer or prose-hook PRs that lack matching fixture updates.** There is no
+"fix it in a follow-up" path; a change to the emission surface without test coverage is
+incomplete (ADR-015 D3b).
+
+---
+
 ## Boundaries
 
 - **Do:** author tests, fixtures, and test documentation. Calculate and report coverage. Flag untestable requirements back to the caller.


### PR DESCRIPTION
## Align Arm 1 documentation with the post-sweep ADRs 014–022 (Phase C C4)

Closes: #336 


## Summary
Brings the contributor guides, consumer-facing docs, and agent definitions in line with the post-sweep state of ADRs 014–022 (the schema tightenings, prose subset/sentinels, reference strategy, persona model, and block-mode enforcement that landed across Phases A–C). Documentation only — no schema, validator, or framework-content changes.

## What changed (16 files, +617/−81)

**Contributing guides (Track 1.1)**
- `framework-mappings-style-guide.md` — canonical per-framework ID forms per ADR-022 D5b (PascalCase STRIDE, `GOVERN-/MAP-/MEASURE-/MANAGE-`, `LLM01:2025`, `Article N`, `AML.(T|M)####`); new **Identifier Enforcement** table separating schema-enforced (ATLAS / EU-AI-Act / ISO-22989) from canonical-but-fall-through (STRIDE / NIST / OWASP); `externalReferences` principle.
- `identification-questions-style-guide.md` — rules tagged **machine-enforced vs editorial** per ADR-021 D7 (now block-enforced post-C2); enforcement-summary table; corrected stale "3 of 8" → required on all 8 active personas.
- `common-review-findings.md` — 4 new block-mode findings (raw HTML / inline URL, bare ID, unresolved sentinel, retired `relevantQuestions`).
- `submission-readiness-guide.md`, `issue-templates-guide.md`, `risk-titles-style-guide.md`, `control-titles-style-guide.md` — examples → `externalReferences`/sentinels, canonical mappings, `title.maxLength` (120/100).

**Consumer docs + new authored docs (Tracks 1.3, 1.4)**
- `persona-pages.md` — "Allowed HTML" section rewritten to the ADR-015/017 bounded set.
- **NEW** `yaml-authoring-subset.md` — the contributor-facing prose subset (3 tokens, 2 sentinel forms, no-inline-URL, `externalReferences` flow) per ADR-014/016/017.
- **NEW** `reuse-contract.md` — downstream reuse contract per ADR-014 P5 (shape guarantees, provenance, non-guarantees, sanitization expectations) + README "Reusing This Content" nav.

**Agent definitions (Track 1.3, canonical `scripts/agents/` only)**
- `content-reviewer.md`, `code-reviewer.md`, `swe.md`, `testing.md`, `issue-response-reviewer.md` — updated for post-sweep enforcement boundaries (machine-enforcement table, shared `_prose_tokens.py`, ADR-015 D3b test discipline).

## Notes / boundaries
- **ADR-026 D4c (Track 1.1.5):** every issue-template "Style guide" link resolves to a page that teaches what the template solicits; the final helper-text cross-ref pass completes once #327 (template content) also lands on main.
- **Framework-mapping VALUES are not migrated here** — the guides teach the canonical forms and explicitly flag that stride/nist-ai-rmf/owasp-top10-llm content still uses legacy forms (the schema's loose catch-all). 
  - That migration is tracked under epic **#342** (Framework-identifier canonicalization & mapping conformance completion)
  - Architect-gated decision chain 
    - #303
    - #318
    - #319) 
  - feeding the value-migration + schema strict-flip
    - #343
  - Out of scope for docs.
- The legacy "Model Creator/Model Consumer" naming in `README.md` is framework-content description, left for a separate content fix (out of Arm 1 scope).

## Verification
- `pytest scripts/hooks/tests/` → 2646 passed, 6 skipped.
- `pre-commit run --all-files` → exit 0 (the pre-existing `prettier-yaml` `--all-files` index-lock flake is unrelated; no YAML staged in this commit).
