### PR TITLE
tooling: harden sanitizer structured-item rendering

### DIFF
--- a/site/assets/sanitizer.mjs
+++ b/site/assets/sanitizer.mjs
@@ -21,6 +21,13 @@
 // this pattern exists. Adding a tag here requires a matching fixture update.
 const ALLOWED_TAGS = ["strong", "em", "a"];
 
+// Bounded-dispatch literal for structured-item types — same posture as
+// ALLOWED_TAGS. Adding a type here without extending renderProse's dispatch
+// arms OR without adding a per-type positive test fails the meta-tests in
+// sanitizer.test.mjs. This is the structural fail-loud guarantee for new
+// structured-item types alongside the per-call inert-marker fallback.
+const STRUCTURED_ITEM_TYPES = ["link", "ref"];
+
 // ---------------------------------------------------------------------------
 // HTML character escaping
 // ---------------------------------------------------------------------------
@@ -65,6 +72,29 @@ function escapeHtml(text) {
  */
 function escapeStructuredTitle(text) {
   return escapeHtml(text).replaceAll("=", "&#61;");
+}
+
+/**
+ * Reduce an unknown structured-item `type` value to a short label for the
+ * inert-marker diagnostic. Avoids two regression classes:
+ *   1. Non-string `type` (object/array) producing literal "[object Object]"
+ *      via String() coercion — the bleed-thru gate would trip on that.
+ *   2. Null bytes in a string `type` surviving into the rendered innerHTML
+ *      string; HTML5 parsers replace U+0000 with U+FFFD inside comments at
+ *      parse time, but the raw innerHTML carries the null and confuses
+ *      programmatic grep-based regression scans.
+ *
+ * @param {unknown} value - The `type` field of an unrecognised structured item
+ * @returns {string} Short label safe to feed through escapeHtml
+ */
+function describeUnsupportedType(value) {
+  if (typeof value === "string") {
+    return value.replace(/\x00/g, "\uFFFD");
+  }
+  if (value === null) return "<null>";
+  if (value === undefined) return "<undefined>";
+  if (Array.isArray(value)) return "<array>";
+  return `<non-string:${typeof value}>`;
 }
 
 // ---------------------------------------------------------------------------
@@ -428,9 +458,13 @@ export function renderProse(input) {
       return escaped;
     }
 
-    // Unknown structured type — emit an inert marker instead of leaking
-    // String(object) as "[object Object]" into rendered prose.
-    const escaped = `<!-- renderProse: unsupported prose-item type: ${escapeHtml(String(input.type))} -->`;
+    // Unknown structured type — emit an inert marker. describeUnsupportedType
+    // keeps the marker free of "[object Object]" (which would trip the bleed-
+    // thru gate when input.type is itself an object) and strips null bytes
+    // before escapeHtml so the raw innerHTML stays greppable. The marker is
+    // wrapped in an HTML comment; escapeHtml neutralises `>` so a hostile
+    // input.type cannot close the comment early.
+    const escaped = `<!-- renderProse: unsupported prose-item type: ${escapeHtml(describeUnsupportedType(input.type))} -->`;
     console.warn("renderProse: escaped unexpected markup", { input, escaped });
     return escaped;
   }

--- a/site/assets/sanitizer.mjs
+++ b/site/assets/sanitizer.mjs
@@ -1,8 +1,8 @@
 /**
  * sanitizer.mjs — render-time prose sanitizer for the CoSAI Risk Map site.
  *
- * Exports renderProse(input) which accepts either a plain string or a
- * structured link object ({type: "link", title, url}) and returns an
+ * Exports renderProse(input) which accepts a plain string, a structured link
+ * object ({type: "link", title, url}), or a structured ref object and returns an
  * HTML-safe string suitable for assignment to innerHTML.
  *
  * Design: ADR-015 D3 (hand-rolled, bounded emission), D3a (ALLOWED_TAGS
@@ -50,7 +50,7 @@ function escapeHtml(text) {
 }
 
 /**
- * Escape a string for use as anchor text content.
+ * Escape a string for use as structured-item anchor text content.
  * Extends escapeHtml by also encoding `=` as `&#61;` so that attribute-
  * injection patterns like `onclick=` cannot appear as a raw substring in the
  * rendered HTML output, even inside text content where they are already
@@ -60,10 +60,10 @@ function escapeHtml(text) {
  * the serialised output, which is the requirement the attack-corpus fixture
  * for attribute-injection-quote-in-text asserts.
  *
- * @param {string} text - Raw title text from a structured link item
+ * @param {string} text - Raw title text from a structured prose item
  * @returns {string} HTML-escaped text safe for anchor inner content
  */
-function escapeLinkTitle(text) {
+function escapeStructuredTitle(text) {
   return escapeHtml(text).replaceAll("=", "&#61;");
 }
 
@@ -375,7 +375,7 @@ function emit(tokens, originalInput) {
  *     fragment anchor (<a href="#id">title</a>) per ADR-015 D1 and
  *     ADR-016 D5. No rel/target — those are link-only.
  *
- * Any other input shape is coerced to string, escaped, and warned about.
+ * Any other structured type emits an HTML-inert diagnostic marker and warns.
  *
  * Per ADR-015 D4, disallowed markup is escaped (not stripped) and exactly one
  * console.warn("renderProse: escaped unexpected markup", {input, escaped}) is
@@ -389,7 +389,7 @@ export function renderProse(input) {
   if (input !== null && typeof input === "object") {
     if (input.type === "link") {
       const { valid, trimmedUrl } = validateUrl(input.url ?? "");
-      const escapedTitle = escapeLinkTitle(String(input.title ?? ""));
+      const escapedTitle = escapeStructuredTitle(String(input.title ?? ""));
 
       if (valid) {
         // Construct the <a> with renderer-owned attributes only.
@@ -417,7 +417,7 @@ export function renderProse(input) {
       // with HTML-breakout characters is rejected and the title is escaped
       // and emitted as plain text, matching the link-item invalid-URL path.
       const id = String(input.id ?? "");
-      const escapedTitle = escapeLinkTitle(String(input.title ?? ""));
+      const escapedTitle = escapeStructuredTitle(String(input.title ?? ""));
 
       if (/^[A-Za-z][A-Za-z0-9_-]*$/.test(id)) {
         return `<a href="#${escapeHtml(id)}">${escapedTitle}</a>`;
@@ -428,8 +428,9 @@ export function renderProse(input) {
       return escaped;
     }
 
-    // Unknown structured type — escape and warn.
-    const escaped = escapeHtml(String(input));
+    // Unknown structured type — emit an inert marker instead of leaking
+    // String(object) as "[object Object]" into rendered prose.
+    const escaped = `<!-- renderProse: unsupported prose-item type: ${escapeHtml(String(input.type))} -->`;
     console.warn("renderProse: escaped unexpected markup", { input, escaped });
     return escaped;
   }

--- a/site/tests/app-render-rich-paragraphs.test.mjs
+++ b/site/tests/app-render-rich-paragraphs.test.mjs
@@ -22,6 +22,16 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
+const UNSUPPORTED_PROSE_ITEM_MARKER = "renderProse: unsupported prose-item type";
+
+function assertNoStructuredItemBleedThrough(output) {
+  assert.ok(!output.includes("[object Object]"), `renderRichParagraphs leaked [object Object]: ${output}`);
+  assert.ok(
+    !output.includes(UNSUPPORTED_PROSE_ITEM_MARKER),
+    `renderRichParagraphs emitted unsupported structured-item marker: ${output}`,
+  );
+}
+
 // Minimal DOM/window/fetch shim — app.mjs touches all three during module load
 // (document.querySelector for the app root, event-listener registration on
 // that element, renderApp() writing innerHTML, loadSiteData() calling fetch).
@@ -125,10 +135,7 @@ test("nested array containing an object never produces '[object Object]'", () =>
   const out = renderRichParagraphs([
     ["Prefix (", { type: "link", title: "T", url: "https://example.com/" }, ") suffix."],
   ]);
-  assert.ok(
-    !out.includes("[object Object]"),
-    `renderRichParagraphs leaked [object Object] for a structured-item input: ${out}`,
-  );
+  assertNoStructuredItemBleedThrough(out);
 });
 
 test("regression: riskRetrievalVectorStorePoisoning shape from persona-site-data.json", () => {
@@ -168,8 +175,8 @@ test("regression: riskRetrievalVectorStorePoisoning shape from persona-site-data
       '<a href="https://arxiv.org/abs/2402.13532" rel="noopener noreferrer" target="_blank">Backdoor Attacks on Dense Retrieval via Public and Unintentional Triggers</a>',
     ),
   );
-  // No [object Object] leak.
-  assert.ok(!out.includes("[object Object]"));
+  // No structured-item bleed-through.
+  assertNoStructuredItemBleedThrough(out);
 });
 
 test("nested array with {type:'ref'} item renders as in-page fragment anchor", () => {
@@ -203,7 +210,7 @@ test("ref item with invalid id (breakout chars) escapes title instead of emittin
   ]);
   assert.ok(!out.includes('<a href="#risk"'));
   assert.ok(!out.includes("<script>"));
-  assert.ok(!out.includes("[object Object]"));
+  assertNoStructuredItemBleedThrough(out);
 });
 
 test("regression: bleed-thru — riskAgentDelegationChainOpacity longDescription shape with ref items", () => {
@@ -217,7 +224,7 @@ test("regression: bleed-thru — riskAgentDelegationChainOpacity longDescription
   ];
   const out = renderRichParagraphs([longDescriptionPara]);
   assert.ok(out.includes('<a href="#riskAgenticDelegationConfusedDeputy">Agentic Delegation Confused Deputy</a>'));
-  assert.ok(!out.includes("[object Object]"));
+  assertNoStructuredItemBleedThrough(out);
 });
 
 test("mixed item types: string + nested-with-object + plain nested array", () => {

--- a/site/tests/sanitizer.test.mjs
+++ b/site/tests/sanitizer.test.mjs
@@ -31,7 +31,7 @@
  * ADR-015 D1 and ADR-016 D5. See ADR-016 D5 Addendum (2026-05-14).
  *
  * Ref-rendering shape:
- *   {type: "ref", id, title}  ->  <a href="#${escapeHtml(id)}">${escapeLinkTitle(title)}</a>
+ *   {type: "ref", id, title}  ->  <a href="#${escapeHtml(id)}">${escapeStructuredTitle(title)}</a>
  *
  * id is validated against ^[A-Za-z][A-Za-z0-9_-]*$ before emission. An id
  * that fails validation triggers the escape-with-warn path identically to
@@ -293,6 +293,26 @@ test("negative — structured link with http:// scheme does not produce <a>", ()
   // ADR-015 D3a: href validated against ^https:// before insertion.
   const output = callRenderProse({ type: "link", title: "Insecure", url: "http://example.com" });
   assert.ok(!output.includes('<a href="http://'), `http:// link must not produce <a>: ${output}`);
+});
+
+test("negative — unknown structured item emits inert marker instead of object string", () => {
+  const originalWarn = console.warn;
+  const spy = { calls: [] };
+  console.warn = (...args) => spy.calls.push(args);
+
+  try {
+    const output = callRenderProse({ type: "alien", title: "Unknown Type" });
+
+    assert.equal(output, "<!-- renderProse: unsupported prose-item type: alien -->");
+    assert.ok(!output.includes("[object Object]"), `Unknown structured item must not leak object string: ${output}`);
+    assert.equal(
+      spy.calls.length,
+      1,
+      `Unknown structured item must produce exactly one warning, got ${spy.calls.length}`,
+    );
+  } finally {
+    console.warn = originalWarn;
+  }
 });
 
 test("negative — raw <a href=...> in prose is escaped, not passed through", () => {

--- a/site/tests/sanitizer.test.mjs
+++ b/site/tests/sanitizer.test.mjs
@@ -62,6 +62,26 @@ import { renderProse } from "../assets/sanitizer.mjs";
 // ---------------------------------------------------------------------------
 const ALLOWED_TAGS = ["strong", "em", "a"];
 
+// Local reference copy of STRUCTURED_ITEM_TYPES. Same contract-check posture:
+// source of truth is the literal const in sanitizer.mjs; this copy is checked
+// against the source in the bounded-dispatch meta-test below.
+const STRUCTURED_ITEM_TYPES = ["link", "ref"];
+
+// Marker substring emitted by renderProse on unrecognised structured-item
+// types. Duplicated from app-render-rich-paragraphs.test.mjs so the bleed-thru
+// gate exists at this layer too — a regression that causes a known-type path
+// (link or ref) to emit the marker must fail the sanitizer unit tests as well
+// as the integration-layer tests, not only one of them.
+const UNSUPPORTED_PROSE_ITEM_MARKER = "renderProse: unsupported prose-item type";
+
+function assertNoStructuredItemBleedThrough(output) {
+  assert.ok(!output.includes("[object Object]"), `Output leaked [object Object]: ${output}`);
+  assert.ok(
+    !output.includes(UNSUPPORTED_PROSE_ITEM_MARKER),
+    `Output emitted unsupported structured-item marker on a known-type path: ${output}`,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Fixture loading helpers
 // ---------------------------------------------------------------------------
@@ -213,6 +233,18 @@ test("positive — structured link item renders <a> with href, rel, target const
   // rel and target are constructed by the renderer (ADR-015 D3a)
   assert.ok(output.includes('rel="noopener noreferrer"'), `Expected rel=noopener noreferrer: ${output}`);
   assert.ok(output.includes('target="_blank"'), `Expected target=_blank: ${output}`);
+
+  // Bleed-thru gate at the unit layer: a known-type path must never emit the
+  // unsupported-type marker nor leak String(object).
+  assertNoStructuredItemBleedThrough(output);
+});
+
+test("positive — structured ref item renders in-page <a href='#id'> with no rel/target", () => {
+  // Known-type path for the second STRUCTURED_ITEM_TYPES entry. Bleed-thru
+  // gate at the unit layer mirrors the link-item assertion above.
+  const output = callRenderProse({ type: "ref", id: "riskPromptInjection", title: "Prompt Injection" });
+  assert.equal(output, '<a href="#riskPromptInjection">Prompt Injection</a>');
+  assertNoStructuredItemBleedThrough(output);
 });
 
 test("positive — _italic_ underscore delimiter also renders <em>", () => {
@@ -312,6 +344,97 @@ test("negative — unknown structured item emits inert marker instead of object 
     );
   } finally {
     console.warn = originalWarn;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial unknown-`type` sweep (PR #350 review items 1+6, 7-9).
+//
+// The inert-marker fallback is the load-bearing defence against future builder
+// changes that introduce a structured-item type without simultaneously extending
+// renderProse. The marker is wrapped in an HTML comment, so its containment
+// depends on:
+//   1. escapeHtml neutralising `>` so a hostile `type` cannot close the
+//      comment early (HTML5 § 8.2.4.44 — comments end on `-->` or `--!>`).
+//   2. describeUnsupportedType reducing non-string `type` to a label that
+//      does not re-introduce "[object Object]".
+//   3. describeUnsupportedType stripping null bytes so the raw innerHTML
+//      stays greppable for the bleed-thru gate.
+//
+// Each fixture below pins one of those invariants. Failure means a future
+// change to escapeHtml or describeUnsupportedType silently regressed the
+// containment guarantee.
+// ---------------------------------------------------------------------------
+
+const ADVERSARIAL_TYPE_FIXTURES = [
+  { label: "raw script tag in type", input: { type: "<script>alert(1)</script>" } },
+  { label: "HTML comment terminator in type", input: { type: "-->" } },
+  { label: "HTML comment opener in type", input: { type: "<!--" } },
+  { label: "alternate comment terminator --!> in type", input: { type: "--!>" } },
+  { label: "bare double-dash in type", input: { type: "--" } },
+  { label: "quote-injection in type", input: { type: '"; alert(1); //' } },
+  { label: "null byte in type", input: { type: "alien\x00js" } },
+  { label: "object-valued type", input: { type: { nested: "ref" } } },
+  { label: "array-valued type", input: { type: ["alien"] } },
+  { label: "numeric type", input: { type: 42 } },
+  { label: "boolean type", input: { type: true } },
+  { label: "null type", input: { type: null } },
+  { label: "missing type key", input: { foo: "bar" } },
+  // Array as the whole input: enters the structured-item branch (typeof []
+  // === "object", arr !== null) with input.type === undefined, so hits the
+  // unknown-type path.
+  { label: "array as input", input: ["a", "b"] },
+];
+
+test("adversarial — every unknown-type fixture stays HTML-inert and free of regression strings", () => {
+  const originalWarn = console.warn;
+  console.warn = () => {}; // silence per-fixture warns — assertion is on output, not stdout
+
+  try {
+    for (const { label, input } of ADVERSARIAL_TYPE_FIXTURES) {
+      const output = callRenderProse(input);
+
+      // Comment containment: exactly one `-->` terminator, opening `<!--`.
+      assert.ok(output.startsWith("<!--"), `[${label}] marker must open as HTML comment: ${output}`);
+      assert.ok(output.endsWith("-->"), `[${label}] marker must close as HTML comment: ${output}`);
+      assert.equal(
+        (output.match(/-->/g) ?? []).length,
+        1,
+        `[${label}] marker must contain exactly one comment terminator: ${output}`,
+      );
+      assert.equal(
+        (output.match(/<!--/g) ?? []).length,
+        1,
+        `[${label}] marker must contain exactly one comment opener: ${output}`,
+      );
+
+      // No raw script, no live HTML, no embedded null byte.
+      assert.ok(!output.includes("<script>"), `[${label}] marker must not contain raw <script>: ${output}`);
+      assert.ok(!output.includes("<script "), `[${label}] marker must not contain raw <script attr: ${output}`);
+      assert.ok(
+        !output.includes("\x00"),
+        `[${label}] marker must not contain raw null byte: ${JSON.stringify(output)}`,
+      );
+
+      // Bleed-thru gate: the marker itself must not carry the regression
+      // string the marker was introduced to prevent.
+      assert.ok(!output.includes("[object Object]"), `[${label}] marker must not contain [object Object]: ${output}`);
+    }
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test("adversarial — null / primitive top-level inputs are not structured items (no marker)", () => {
+  // These fall through the structured-item guard (input === null or typeof
+  // input !== "object") and reach the plain-string path. They must not emit
+  // the unsupported-type marker; they pass through as escaped plain text.
+  for (const input of [null, undefined, 42, true, false, ""]) {
+    const output = callRenderProse(input);
+    assert.ok(
+      !output.includes(UNSUPPORTED_PROSE_ITEM_MARKER),
+      `Primitive input ${JSON.stringify(input)} must not emit the unsupported-type marker: ${output}`,
+    );
   }
 });
 
@@ -472,6 +595,80 @@ test("bounded-emission — ALLOWED_TAGS is declared as a literal const array in 
   // Also assert ALLOWED_TAGS includes all three required tags.
   assert.ok(source.includes("'em'") || source.includes('"em"'), "ALLOWED_TAGS must include 'em'");
   assert.ok(source.includes("'a'") || source.includes('"a"'), "ALLOWED_TAGS must include 'a'");
+});
+
+// ---------------------------------------------------------------------------
+// Bounded-dispatch contract test (PR #350 review item 5).
+// Mirrors the ALLOWED_TAGS bounded-emission test for structured-item types.
+// Reads sanitizer.mjs source text and asserts:
+//   1. STRUCTURED_ITEM_TYPES is declared as a literal const array
+//   2. For each entry, a corresponding `input.type === "<type>"` dispatch arm
+//      exists in source
+// Adding a type to the const without extending the dispatch arms fails here.
+// ---------------------------------------------------------------------------
+
+test("bounded-dispatch — STRUCTURED_ITEM_TYPES is a literal const array in sanitizer.mjs source", () => {
+  const sanitizerPath = path.join(__dirname, "../assets/sanitizer.mjs");
+  const source = fs.readFileSync(sanitizerPath, "utf8");
+
+  const literalConstPattern = /const\s+STRUCTURED_ITEM_TYPES\s*=\s*\[\s*['"]link['"]/;
+  assert.ok(
+    literalConstPattern.test(source),
+    "sanitizer.mjs must declare STRUCTURED_ITEM_TYPES as a literal const array starting with 'link'. " +
+      "It must not be a parameter, derived from input, or mutable.",
+  );
+
+  // Confirm the local copy in this test file matches the source-of-truth shape.
+  for (const type of STRUCTURED_ITEM_TYPES) {
+    assert.ok(
+      source.includes(`'${type}'`) || source.includes(`"${type}"`),
+      `STRUCTURED_ITEM_TYPES literal in source must include '${type}'`,
+    );
+  }
+});
+
+test("bounded-dispatch — every STRUCTURED_ITEM_TYPES entry has a matching dispatch arm in source", () => {
+  // Structural enforcement of the fail-loud guarantee: adding a type to the
+  // registry without extending renderProse's dispatch leaves the type
+  // catch-all marker as the only handler — this meta-test catches that.
+  const sanitizerPath = path.join(__dirname, "../assets/sanitizer.mjs");
+  const source = fs.readFileSync(sanitizerPath, "utf8");
+
+  for (const type of STRUCTURED_ITEM_TYPES) {
+    const dispatchPattern = new RegExp(`input\\.type\\s*===\\s*['"]${type}['"]`);
+    assert.ok(
+      dispatchPattern.test(source),
+      `sanitizer.mjs must contain a dispatch arm 'input.type === "${type}"' for STRUCTURED_ITEM_TYPES entry '${type}'.`,
+    );
+  }
+});
+
+// Per-type positive-coverage map. Each STRUCTURED_ITEM_TYPES entry must have
+// at least one positive test case here. Adding a type without an entry fails
+// the meta-test below — the test-coverage analogue of ADR-015 D3b.
+const structuredTypePositiveCases = new Map([
+  ["link", () => callRenderProse({ type: "link", title: "Sample", url: "https://example.com/" })],
+  ["ref", () => callRenderProse({ type: "ref", id: "riskPromptInjection", title: "Prompt Injection" })],
+]);
+
+test("bounded-dispatch — every STRUCTURED_ITEM_TYPES entry has a positive test case", () => {
+  for (const type of STRUCTURED_ITEM_TYPES) {
+    const positiveCase = structuredTypePositiveCases.get(type);
+    assert.ok(
+      typeof positiveCase === "function",
+      `STRUCTURED_ITEM_TYPES entry '${type}' must have a positive test case in structuredTypePositiveCases.`,
+    );
+
+    // Run the positive case and confirm it does NOT emit the unsupported-
+    // type marker — i.e., the dispatch arm actually handles the type.
+    const output = positiveCase();
+    assert.ok(
+      !output.includes(UNSUPPORTED_PROSE_ITEM_MARKER),
+      `Positive case for '${type}' must not emit the unsupported-type marker; ` +
+        `dispatch arm is missing or broken. Output: ${output}`,
+    );
+    assertNoStructuredItemBleedThrough(output);
+  }
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Rename `escapeLinkTitle` to `escapeStructuredTitle` now that the helper is shared by link and ref structured items.
- Emit an HTML-inert unsupported-type marker for unknown structured prose items instead of rendering `[object Object]`.
- Extend sanitizer and rich-paragraph regression tests to catch unknown structured-item bleed-through.

## Why

Issue #308 identified a forward-looking sanitizer gap: if a future builder introduces a new structured prose item type before `renderProse` supports it, the fallback path could reproduce the `[object Object]` regression class. This keeps production output inert while making the marker easy for CI regression scans to catch.

Closes #308.

## Validation

- `node --test site/tests/*.test.mjs` -- 54/54 passing
- `node_modules/.bin/prettier --check site/assets/sanitizer.mjs site/tests/sanitizer.test.mjs site/tests/app-render-rich-paragraphs.test.mjs`
- `git diff --check`
- `git grep escapeLinkTitle` returned no matches
