### PR TITLE
Replace apt-installed Git with devcontainer Git feature

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,8 +4,9 @@ ARG WORKSPACE=/workspaces
 ARG WORKSPACE_REPO=secure-ai-tooling
 
 # Install system packages: core utilities + Playwright Chromium system dependencies
-# Core: build-essential, bash-completion, vim, curl, wget, git, ca-certificates
+# Core: build-essential, bash-completion, vim, curl, wget, ca-certificates
 # Note: sudo is provided by the common-utils devcontainer feature, not installed here
+# Note: git is provided by the git devcontainer feature, not installed here
 # Playwright deps: 31 packages needed by Chromium on Ubuntu Noble (with t64 suffixes)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
@@ -13,7 +14,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     vim \
     curl \
     wget \
-    git \
     ca-certificates \
     libasound2t64 \
     libatk-bridge2.0-0t64 \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,10 @@
 			"installZsh": false,
 			"installOhMyZsh": false
 		},
+		"ghcr.io/devcontainers/features/git:1": {
+			"version": "latest",
+			"ppa": true
+		},
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
 	},
 

--- a/scripts/hooks/tests/test_devcontainer_json.py
+++ b/scripts/hooks/tests/test_devcontainer_json.py
@@ -9,18 +9,20 @@ installation from devcontainer features to install-deps.sh with mise.
 Test Coverage:
 ==============
 Total Test Classes: 7
-Total Test Methods: 28
+Total Test Methods: 33
 
 1. TestDevcontainerJsonExists (2): file exists, parses as valid JSON
-2. TestDevcontainerJsonFeatures (8): no Python feature, no Node feature,
+2. TestDevcontainerJsonFeatures (11): no Python feature, no Node feature,
    Docker-in-Docker feature present, common-utils feature present,
    common-utils username vscode, common-utils automatic uid,
-   common-utils automatic gid, common-utils no zsh
+   common-utils automatic gid, common-utils no zsh,
+   Git feature present, Git latest version, Git PPA enabled
 3. TestDevcontainerJsonCommands (4): onCreateCommand exists,
    onCreateCommand references install-deps.sh, no direct pip/npm in
    onCreateCommand, no postCreateCommand
-4. TestDevcontainerJsonPythonConfig (3): interpreter path exists, uses mise shims,
-   does not use /usr/local/python/current
+4. TestDevcontainerJsonPythonConfig (5): interpreter path exists, uses mise
+   install path, uses absolute path, does not use mise shims, does not use
+   /usr/local/python/current
 5. TestDevcontainerJsonVscodeExtensions (2): extensions array exists,
    required extensions present (including ms-python.python)
 6. TestDevcontainerJsonBuildConfig (4): remoteUser is vscode,
@@ -125,6 +127,7 @@ class TestDevcontainerJsonFeatures:
     After refactor:
     - No Python feature (ghcr.io/devcontainers/features/python)
     - No Node feature (ghcr.io/devcontainers/features/node)
+    - Git feature is present with latest version and PPA enabled
     - Docker-in-Docker feature is still present
     """
 
@@ -170,6 +173,46 @@ class TestDevcontainerJsonFeatures:
         features = devcontainer_json.get("features", {})
         found_docker = any("docker-in-docker" in key.lower() for key in features.keys())
         assert found_docker, "devcontainer.json should include Docker-in-Docker feature"
+
+    def test_git_feature_present(self, devcontainer_json):
+        """
+        Given: The devcontainer.json config
+        When: Checking for Git devcontainer feature
+        Then: Feature key is exactly ghcr.io/devcontainers/features/git:1
+
+        Git is installed through the official devcontainer feature so the
+        container gets the current stable Git without relying on Ubuntu
+        Noble's frozen apt package.
+        """
+        features = devcontainer_json.get("features", {})
+        assert "ghcr.io/devcontainers/features/git:1" in features, (
+            "devcontainer.json should include ghcr.io/devcontainers/features/git:1"
+        )
+
+    def test_git_feature_version_latest(self, devcontainer_json):
+        """
+        Given: The devcontainer.json config
+        When: Checking Git feature options
+        Then: version is set to "latest"
+        """
+        features = devcontainer_json.get("features", {})
+        git_config = features.get("ghcr.io/devcontainers/features/git:1", {})
+        assert git_config.get("version") == "latest", (
+            f"git feature version should be 'latest', got: {git_config.get('version')}"
+        )
+
+    def test_git_feature_ppa_enabled(self, devcontainer_json):
+        """
+        Given: The devcontainer.json config
+        When: Checking Git feature options
+        Then: ppa is true
+
+        The Git feature uses the git-core PPA on Ubuntu when this option is
+        enabled, which avoids the distro-frozen Git version.
+        """
+        features = devcontainer_json.get("features", {})
+        git_config = features.get("ghcr.io/devcontainers/features/git:1", {})
+        assert git_config.get("ppa") is True, f"git feature ppa should be true, got: {git_config.get('ppa')}"
 
     def test_common_utils_feature_present(self, devcontainer_json):
         """
@@ -672,17 +715,19 @@ class TestDevcontainerJsonRemoteEnv:
 Test Summary
 ============
 Total Test Classes: 7
-Total Test Methods: 28
+Total Test Methods: 33
 
 1. TestDevcontainerJsonExists (2): file exists, parses as valid JSON
-2. TestDevcontainerJsonFeatures (8): no Python feature, no Node feature,
-   Docker-in-Docker present, common-utils present, username vscode,
-   automatic uid, automatic gid, no zsh
+2. TestDevcontainerJsonFeatures (11): no Python feature, no Node feature,
+   Docker-in-Docker present, Git feature present with latest version and PPA
+   enabled, common-utils present, username vscode, automatic uid,
+   automatic gid, no zsh
 3. TestDevcontainerJsonCommands (4): onCreateCommand exists,
    onCreateCommand references install-deps.sh, no direct pip/npm,
    no postCreateCommand
-4. TestDevcontainerJsonPythonConfig (3): interpreter path exists, uses mise shims,
-   not /usr/local/python/current
+4. TestDevcontainerJsonPythonConfig (5): interpreter path exists, uses mise
+   install path, uses absolute path, does not use mise shims, not
+   /usr/local/python/current
 5. TestDevcontainerJsonVscodeExtensions (2): extensions array exists,
    required extensions present (including ms-python.python)
 6. TestDevcontainerJsonBuildConfig (4): remoteUser is vscode,
@@ -694,9 +739,9 @@ Total Test Methods: 28
 
 Coverage Areas:
 - File existence and JSON validity
-- Feature configuration (Python/Node removed, Docker-in-Docker kept, common-utils added)
+- Feature configuration (Python/Node removed, Git added, Docker-in-Docker kept, common-utils added)
 - Lifecycle commands (onCreateCommand uses install-deps.sh, postCreateCommand absent)
-- Python interpreter configuration (mise shims path)
+- Python interpreter configuration (mise install path, not the shim)
 - VSCode extensions (ms-python.python, markdown-mermaid, ruff, yaml)
 - Build configuration (remoteUser, build.args, context, dockerfile)
 - Remote environment (hardcoded /home/vscode paths, no broken ${containerEnv:HOME})

--- a/scripts/hooks/tests/test_dockerfile.py
+++ b/scripts/hooks/tests/test_dockerfile.py
@@ -9,11 +9,12 @@ to ensure it matches the devcontainer refactor spec.
 Test Coverage:
 ==============
 Total Test Classes: 8
-Total Test Methods: 26
+Total Test Methods: 27
 
 1. TestDockerfileExists (2): file exists, non-empty
 2. TestDockerfileBaseImage (2): uses ubuntu:noble, no playwright reference
-3. TestDockerfileSystemPackages (4): core packages, Playwright deps,
+3. TestDockerfileSystemPackages (5): core packages, Git absent from apt,
+   Playwright deps,
    --no-install-recommends, apt cache cleanup
 4. TestDockerfileUserManagement (5): no UID/GID ARGs, USERNAME ARG is vscode,
    creates vscode user, no sudoers, USER directives for build-time install
@@ -49,6 +50,25 @@ def dockerfile_content():
 def dockerfile_lines(dockerfile_content):
     """Split Dockerfile into lines for line-by-line analysis."""
     return dockerfile_content.splitlines()
+
+
+@pytest.fixture(scope="module")
+def apt_install_packages(dockerfile_lines):
+    """Return package tokens from the Dockerfile apt-get install block."""
+    packages = []
+    in_apt_install = False
+    for line in dockerfile_lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if not in_apt_install:
+            if "apt-get install" in stripped:
+                in_apt_install = True
+            continue
+        if stripped.startswith("&&"):
+            break
+        packages.append(stripped.removesuffix("\\").strip())
+    return packages
 
 
 # =============================================================================
@@ -127,21 +147,31 @@ class TestDockerfileSystemPackages:
     --no-install-recommends flag, and apt cache cleanup.
     """
 
-    def test_core_packages_present(self, dockerfile_content):
+    def test_core_packages_present(self, apt_install_packages):
         """
         Given: The Dockerfile content
         When: Checking for core system packages
-        Then: build-essential, curl, wget, git, ca-certificates are present
+        Then: build-essential, curl, wget, ca-certificates are present
         """
         core_packages = [
             "build-essential",
             "curl",
             "wget",
-            "git",
             "ca-certificates",
         ]
         for pkg in core_packages:
-            assert pkg in dockerfile_content, f"Core package '{pkg}' should be in Dockerfile"
+            assert pkg in apt_install_packages, f"Core package '{pkg}' should be installed by Dockerfile"
+
+    def test_git_not_installed_by_apt(self, apt_install_packages):
+        """
+        Given: The Dockerfile apt install block
+        When: Checking for Git
+        Then: git is not installed by apt in the Dockerfile
+
+        Git is installed by ghcr.io/devcontainers/features/git:1 so the
+        container can use the feature's current stable Git source.
+        """
+        assert "git" not in apt_install_packages, "Dockerfile should not install git via apt"
 
     def test_playwright_system_deps_present(self, dockerfile_content):
         """
@@ -535,11 +565,12 @@ class TestDockerfileBuildTimeToolInstall:
 Test Summary
 ============
 Total Test Classes: 8
-Total Test Methods: 26
+Total Test Methods: 27
 
 1. TestDockerfileExists (2): file exists, non-empty
 2. TestDockerfileBaseImage (2): uses ubuntu:noble, no playwright reference
-3. TestDockerfileSystemPackages (4): core packages, Playwright deps,
+3. TestDockerfileSystemPackages (5): core packages, Git absent from apt,
+   Playwright deps,
    --no-install-recommends, apt cache cleanup
 4. TestDockerfileUserManagement (5): no UID/GID ARGs, USERNAME ARG is vscode,
    creates vscode user, no sudoers, USER directives for build-time install
@@ -552,7 +583,8 @@ Total Test Methods: 26
 
 Coverage Areas:
 - Base image selection (ubuntu:noble, no Playwright)
-- Core system packages (build-essential, curl, wget, git, ca-certificates)
+- Core system packages (build-essential, curl, wget, ca-certificates)
+- Git installed by devcontainer feature, not Dockerfile apt
 - Playwright Chromium system dependencies (representative subset)
 - Image optimization (--no-install-recommends, apt cache cleanup)
 - User management for build-time tool install (vscode user, USER directives)


### PR DESCRIPTION
## Summary
- Add `ghcr.io/devcontainers/features/git:1` with `version: "latest"` and `ppa: true` to the devcontainer feature list.
- Remove `git` from the Dockerfile apt package list because the feature now owns Git installation.
- Update static devcontainer tests to assert the Git feature configuration and prevent apt-installed Git from returning.

Closes #249.

## Validation
- `python3 -m pytest scripts/hooks/tests/test_devcontainer_json.py scripts/hooks/tests/test_dockerfile.py` - 60 passed
- `python3 -m ruff check scripts/hooks/tests/test_devcontainer_json.py scripts/hooks/tests/test_dockerfile.py` - passed
- `python3 -m ruff format --check scripts/hooks/tests/test_devcontainer_json.py scripts/hooks/tests/test_dockerfile.py` - passed
- `git diff --check` - clean

## Notes
- Verified the upstream devcontainers Git feature install script uses a modern `signed-by` keyring path for the PPA.
- Fresh devcontainer rebuild and in-container `git --version` were not run locally because the `devcontainer` CLI is not installed and the Docker daemon is not running in this environment.
- A broader Python test run reported two unrelated local-environment failures: the shell Python is 3.12.10 while the repo requires 3.14, and one install-deps dry-run Chromium cache expectation failed outside the touched devcontainer tests.
