### PR TITLE
Flip ADR-029 to Accepted

### DIFF
--- a/docs/adr/029-dual-python-package-management.md
+++ b/docs/adr/029-dual-python-package-management.md
@@ -1,6 +1,6 @@
 # ADR-029: Dual Python package-management path with `uv` devcontainers
 
-**Status:** Draft
+**Status:** Accepted
 **Date:** 2026-06-06
 **Authors:** Architect agent, with maintainer review
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,7 +44,7 @@ If a decision is about *how the Risk Map content model is shaped*, it belongs in
 | [026](026-issue-template-domain.md) | Issue-template domain — generator scope, schema-derived enums, and ADR-content alignment contract | Accepted | 2026-05-20 |
 | [027](027-framework-versioning-and-mapping-convention.md) | Per-mapping framework version pinning | Accepted | 2026-05-22 |
 | [028](028-prose-linter-bracket-matching-architecture.md) | Prose-linter emphasis enforcement via bracket-matching depth pass over a Token-shape contract | Accepted | 2026-05-28 |
-| [029](029-dual-python-package-management.md) | Dual Python package-management path with `uv` devcontainers | Draft | 2026-06-06 |
+| [029](029-dual-python-package-management.md) | Dual Python package-management path with `uv` devcontainers | Accepted | 2026-06-06 |
 
 ## Conventions
 


### PR DESCRIPTION


  Flips ADR-029 (Dual Python package-management path with `uv` devcontainers) from `Status: Draft` to `Status: Accepted` following the merge of #371.

  - Updates the status header in `docs/adr/029-dual-python-package-management.md`.
  - Updates the matching status cell in the `docs/adr/README.md` index.

  No content or decision changes — this is the maintainer status flip only.

  Refs #159