### PR TITLE
Fix class-scoped pytest fixture deprecation

### DIFF
--- a/scripts/hooks/tests/test_frameworks_schema_v027.py
+++ b/scripts/hooks/tests/test_frameworks_schema_v027.py
@@ -1283,7 +1283,8 @@ class TestExistingEntriesStillValidate:
     """
 
     @pytest.fixture(scope="class")
-    def framework_entries(self, frameworks_yaml_data: dict) -> list:
+    @classmethod
+    def framework_entries(cls, frameworks_yaml_data: dict) -> list:
         """Individual framework entries from frameworks.yaml."""
         entries = frameworks_yaml_data.get("frameworks", [])
         if not entries:


### PR DESCRIPTION
## Summary
- Convert the class-scoped `framework_entries` fixture to pytest's `@classmethod` pattern.
- Keep the fixture return value and all three consuming tests unchanged.

Closes #383

## Validation
- `PYTHONPATH=./scripts/hooks python -m pytest scripts/hooks/tests/test_frameworks_schema_v027.py -W error::pytest.PytestRemovedIn10Warning -q` (140 passed)
- `python -m ruff check scripts/hooks/tests/test_frameworks_schema_v027.py`
- `python -m ruff format --check scripts/hooks/tests/test_frameworks_schema_v027.py`
- `git diff --check`

## Notes
- Local Python is 3.12 while the repo's mise config requests Python 3.14; the targeted deprecation test still passed with pytest 9.1.0 from `requirements.txt`.
- A broader `pytest scripts/hooks/tests -q` run is not clean in this Windows shell due unrelated local-environment failures, including GBK decoding of UTF-8 files and direct execution of `.sh` scripts producing WinError 193.