### PR TITLE
Fix pytest class-scoped fixture deprecation

### DIFF
--- a/scripts/hooks/tests/test_frameworks_schema_v027.py
+++ b/scripts/hooks/tests/test_frameworks_schema_v027.py
@@ -1283,7 +1283,8 @@ class TestExistingEntriesStillValidate:
     """
 
     @pytest.fixture(scope="class")
-    def framework_entries(self, frameworks_yaml_data: dict) -> list:
+    @classmethod
+    def framework_entries(cls, frameworks_yaml_data: dict) -> list:
         """Individual framework entries from frameworks.yaml."""
         entries = frameworks_yaml_data.get("frameworks", [])
         if not entries:


### PR DESCRIPTION
## Summary
- Convert the class-scoped `framework_entries` fixture to a classmethod.
- Avoid the pytest 10 deprecation warning for class-scoped fixtures defined as instance methods.

## Validation
- `PYTHONPATH=./scripts/hooks .venv/bin/pytest scripts/hooks/tests/test_frameworks_schema_v027.py -W error::pytest.PytestRemovedIn10Warning -q`
- Result: 140 passed

Addresses #383.