### PR TITLE
Fix CoSAI website link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository is for the work of the **Coalition for Secure AI (CoSAI)**. CoSAI is an [OASIS Open Project](https://www.oasis-open.org/open-projects/) and an open ecosystem of AI and security experts from industry-leading organizations. We are dedicated to sharing best practices for secure AI deployment and collaborating on AI security research and tool development.
 
-For more information on CoSAI, please visit the [CoSAI website](https://www.oasis-open.org/projects/cosai/) and the [Open Project repository](https://github.com/cosai-oasis/oasis-open-project), which contains our governance information and project charter.
+For more information on CoSAI, please visit the [CoSAI website](https://www.coalitionforsecureai.org/) and the [Open Project repository](https://github.com/cosai-oasis/oasis-open-project), which contains our governance information and project charter.
 
 ---
 


### PR DESCRIPTION
Updated the CoSAI website link in the README.
Replaced value 'https://www.oasis-open.org/projects/cosai/' with https://www.coalitionforsecureai.org/