### PR TITLE
Phase 1 · classical-lexicon skill (skill-surface foundation)

### DIFF
--- a/scripts/skills/README.md
+++ b/scripts/skills/README.md
@@ -1,0 +1,59 @@
+# Skills
+
+`scripts/skills/` is the canonical, vendor-neutral home for CoSAI skill
+definitions (ADR-031 D6, ADR-033 D1/D4). A skill here is the single,
+complete, authoritative form of that skill — a consumer clones this tree
+directly and runs it in their own harness. No harness-specific wrapper for
+any skill is tracked in this repository (ADR-033 D1); harness adaptation is
+the consumer's responsibility (ADR-033 D3).
+
+## Format
+
+Skills are authored to the **Agent Skills** open standard
+(`agentskills.io`; spec repo `github.com/agentskills/agentskills`), per
+ADR-031 D6. A skill is a directory containing:
+
+- `SKILL.md` — YAML frontmatter declaring only `name` and `description`,
+  plus Markdown instructions. No other frontmatter key is permitted; the
+  neutrality check (`scripts/hooks/precommit/validate_neutrality.py`)
+  enforces this as an allowlist.
+- Optional bundled directories: `scripts/`, `references/`, `assets/` (per
+  the standard), and `evals/` (a project convention, not part of the
+  standard itself — see below).
+
+**Pinned spec revision:** commit `6868401b64f791e9ff565f29beb6338826b73a2b`
+of `github.com/agentskills/agentskills` — the commit that last modified the
+spec file `docs/specification.mdx` (2026-05-16). The repository has no tagged
+releases, so the revision is pinned by commit SHA; this deliberately anchors to
+the spec-content commit rather than an incidental later HEAD, and should be
+re-pinned to a tagged release once the upstream project cuts one. The
+`SKILL.md` shape and required-field core this tree conforms to are defined
+at `docs/specification.mdx` in that revision. Later skills follow this same
+revision until a maintainer deliberately re-pins it (ADR-031 D6: "the first
+skill PR fixes the revision the canonical surface targets").
+
+## `evals/` convention
+
+Every shipped skill carries a portable eval (ADR-033 D6) at
+`evals/evals.json` — a runtime-independent behavior specification
+(`{skill_name, evals: [{id, prompt, expected_output, expectations[]}]}`)
+that travels with the skill. An eval is required to ship; an artifact with
+no eval is not admissible to this tree. `evals/` is a project extension to
+the standard's optional bundled-dir list, not part of the Agent Skills
+standard itself. Evals here are docs-only / run-by-hand for now — no
+in-repo runner exists yet (ADR-033 D6 follow-up).
+
+## Neutrality gate
+
+Every file under this tree is scanned by the neutrality check
+(`scripts/hooks/precommit/validate_neutrality.py`, ADR-033 D2a/D5) before
+merge. Run it manually against a draft skill:
+
+```
+python3 scripts/hooks/precommit/validate_neutrality.py scripts/skills/<name>/SKILL.md scripts/skills/<name>/references/*.md
+```
+
+## Skills in this tree
+
+- `classical-lexicon/` — grounds Risk Map terminology in established
+  security terms of art (ADR-031 D2/D3).

--- a/scripts/skills/classical-lexicon/SKILL.md
+++ b/scripts/skills/classical-lexicon/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: classical-lexicon
-description: Ground CoSAI Risk Map terminology in established security terms of art. Use when authoring or critiquing a Control, Risk, or Component title or description to check a proposed term against the canonical (NIST-first) vocabulary, replace an invented term with its established equivalent, generalize a product/protocol-specific name to its role, or confirm a term is already grounded.
+description: Ground CoSAI Risk Map terminology in established security terms of art. Use when authoring or critiquing a Control, Risk, Component, or Persona title or description to check a proposed term against the canonical (NIST-first) vocabulary, replace an invented term with its established equivalent, generalize a product/protocol-specific name to its role, or confirm a term is already grounded.
 ---
 
 # Classical Lexicon
@@ -9,9 +9,9 @@ Check Risk Map terminology against established security terms of art. The govern
 
 ## When to use
 
-- Authoring a new Control / Risk / Component title or description.
+- Authoring a new Control / Risk / Component / Persona title or description.
 - Critiquing a draft for coined or product-specific terminology.
-- Deciding what to call a capability, role, mechanism, or locus.
+- Deciding what to call a capability, role, mechanism, or locus — including a persona/role name, not only a control or risk mechanism term.
 
 ## When not to use
 
@@ -26,7 +26,10 @@ Check Risk Map terminology against established security terms of art. The govern
    - **Grounded** — already an established term of art. Accept; name the source.
    - **Reground** — an invented or informal term with an established equivalent. Return the canonical term and the mapping.
    - **Generalize** — the term encodes a specific product or protocol (e.g. an `MCP`-prefixed name). The identity is the *role/locus*; the product is an attribute. Return the role-grain term; keep the product only as an example.
-   - **Novel — flag** — no established term of art found. Do **not** coin one silently (see D3b below). "novel-flag" applies only when **no established term of art exists in the field**, not merely when the term is absent from this pinned lexicon snapshot; when you can ground a term via general NIST-first sourcing knowledge that the snapshot lacks, **ground it and propose the lexicon addition** rather than flagging it novel.
+   - **Novel — flag** — no established term of art found. Do **not** coin one silently (see the maintainer-flag vocabulary below). "novel-flag" applies only when **no established term of art exists in the field**, not merely when the term is absent from this pinned lexicon snapshot; when you can ground a term via general NIST-first sourcing knowledge that the snapshot lacks, **ground it and propose the lexicon addition** rather than flagging it novel.
+3b. **Record the international/standards equivalent — unconditionally, for grounding verdicts only.** This obligation applies to **grounded** and **reground** candidates — verdicts that ground a term in standards. For every such candidate, record its international/standards equivalent(s) (ISO/IEC, EU AI Act, ENISA, XACML, or other recognized non-US/international body). Do this every time a term is grounded or regrounded — not only when NIST is silent or the term is contested. A maintainer flag fires only when this equivalence check turns up a problem: the equivalent is missing (`D3b-parochialism`) or the equivalent conflicts with the NIST-first term (`naming-conflict` or `substantive-conflict`, see below). When the equivalent is present and agrees, record it and raise **no** maintainer flag.
+
+   A **generalize** verdict is a naming-altitude move (product/protocol name → role/locus identity), not a grounding-in-standards move. It carries **no** international-equivalence obligation: record the international equivalent field as "not applicable" and raise **no** equivalence flag (`D3b-parochialism`, `naming-conflict`, or `substantive-conflict`) on a generalize verdict.
 4. **Record the counterfactual** for every reground/generalize/novel result: `proposed → chosen → source (or "none found")`. This is inspectable reasoning, not a silent rename.
 
 ## NIST-first priority (ADR-031 D3a)
@@ -35,9 +38,30 @@ NIST's term is the term unless there is a strong, documented argument that it fa
 
 If a contributor argues the NIST term fails and a new term is needed, **do not decide that here.** Surface it as a documented deviation for the maintainer to take into CoSAI governance review (issue / discussion). This skill grounds and flags; maintainers adjudicate.
 
-## Contrarian counterbalance (ADR-031 D3b)
+## Global equivalence, unconditionally recorded (ADR-031 D3b)
 
-To keep grounding from being solely US-centric: when NIST is silent, or the canonical term is contested, **surface the non-US framing** (ENISA, ISO, other national/international bodies) and **flag it to the maintainer** as a counterbalance gap. The maintainer decides in governance review; this skill's obligation is to make sure they *see* the gap rather than having to watch non-US bodies by hand. Never resolve a contested or NIST-silent term by inventing one.
+A NIST label is adopted only after the concept is corroborated as globally recognized. For **every grounded or regrounded term** — not only contested or NIST-silent ones — record the cross-standard equivalence set: the canonical (NIST-first) label alongside its equivalent(s) in recognized international standards (ISO/IEC, EU AI Act, ENISA, XACML, or other national/international bodies). This is unconditional within its scope: run the equivalence check on every grounded/regrounded term, every time.
+
+This equivalence check applies only to `grounded` and `reground` verdicts — the verdicts that ground a term in standards. A `generalize` verdict is a naming-altitude move, not a grounding move, and carries no equivalence obligation (see step 3b); never apply the equivalence check or its flags to a generalize verdict.
+
+A maintainer flag fires only when the equivalence check itself turns up a problem, never merely because a term was checked:
+
+- Equivalent present and agrees → record it, **no flag**.
+- Equivalent missing → `D3b-parochialism`.
+- Equivalent present but conflicts → `naming-conflict` or `substantive-conflict` (see the maintainer-flag vocabulary below).
+
+The maintainer decides any flagged gap or conflict in governance review; this skill's obligation is to make sure they *see* it rather than having to watch non-US bodies by hand. Never resolve a missing or conflicting equivalent by inventing one — keep the grounded term and flag it.
+
+## Maintainer-flag vocabulary
+
+A closed, controlled set of four tokens. Use exactly one of these (or none) per candidate — never a free-form note in the Maintainer flag column.
+
+- **`D3b-parochialism`** — no international/standards equivalent exists for the term (the term appears current only in one jurisdiction, or no crisp equivalent was found).
+- **`naming-conflict`** — an equivalent exists but recognized standards use a materially different *label* for the same concept (e.g. "reference monitor" vs. Common Criteria's "reference validation mechanism"). A label mismatch only — the underlying concept is the same.
+- **`substantive-conflict`** — same nominal concept, but the *content or scope* differs materially across standards (e.g. NIST AI RMF's seven trustworthiness characteristics vs. the EU HLEG's seven requirements — overlapping but not the same set). Distinct from `naming-conflict`, which is a label mismatch, not a scope/content mismatch.
+- **`missing-pin`** — the canonical source cannot be pinned to a traceable dated edition (no stable citation to anchor the term).
+
+Informational surfacing that broadens the base without a defect (e.g. acknowledging EU/ISO framings that agree with or extend NIST) is not a maintainer flag — record it as informational context, not one of the four tokens.
 
 ## Term verification (ADR-031 D4)
 
@@ -47,11 +71,12 @@ The lexicon holds **stable** canonical terms (PEP/PDP/PIP/PAP, reference monitor
 
 For each candidate term, report:
 
-| Candidate | Verdict | Canonical term | Source | Maintainer flag |
-|---|---|---|---|---|
+| Candidate | Verdict | Canonical term | Canonical source | International equivalent(s) | Maintainer flag |
+|---|---|---|---|---|---|
 
 - **Verdict:** `grounded` · `reground` · `generalize` · `novel-flag`
-- **Maintainer flag:** present only for `novel-flag` or a contested/NIST-silent term — state the counterbalance gap and any non-US framing found.
+- **International equivalent(s):** required for every `grounded`/`reground` row — the recognized non-US/international standard(s) that cover the same concept, or "none found" when the equivalence check found nothing. For a `generalize` row, record "not applicable" — generalize carries no equivalence obligation (step 3b).
+- **Maintainer flag:** one of the four controlled tokens (`D3b-parochialism`, `naming-conflict`, `substantive-conflict`, `missing-pin`), or empty when the equivalence check found no problem. Never `D3b-parochialism`, `naming-conflict`, or `substantive-conflict` on a `generalize` row — that verdict is out of scope for the equivalence check entirely.
 
 Close with the counterfactual list (`proposed → chosen → source`) for anything not already grounded.
 

--- a/scripts/skills/classical-lexicon/SKILL.md
+++ b/scripts/skills/classical-lexicon/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: classical-lexicon
+description: Ground CoSAI Risk Map terminology in established security terms of art. Use when authoring or critiquing a Control, Risk, or Component title or description to check a proposed term against the canonical (NIST-first) vocabulary, replace an invented term with its established equivalent, generalize a product/protocol-specific name to its role, or confirm a term is already grounded.
+---
+
+# Classical Lexicon
+
+Check Risk Map terminology against established security terms of art. The governing rule: **never invent a term when an established term of art already exists.** This skill grounds a proposed term, regrounds an invented one, or confirms an existing term is already sound — it does not rewrite content wholesale.
+
+## When to use
+
+- Authoring a new Control / Risk / Component title or description.
+- Critiquing a draft for coined or product-specific terminology.
+- Deciding what to call a capability, role, mechanism, or locus.
+
+## When not to use
+
+- Framework mapping IDs (MITRE ATLAS, NIST AI RMF, etc.) — that is the framework-mappings audit tooling's job.
+- Prose style/format rules (bold, sentinels, length) — that is the prose-subset linter's job.
+
+## Procedure
+
+1. **Extract candidate terms** from the input: the nouns and noun-phrases that name a capability, security measure, role, mechanism, or architectural locus. These are where terminology matters.
+2. **Look each up in the lexicon:** `references/lexicon.md`.
+3. **Classify each candidate:**
+   - **Grounded** — already an established term of art. Accept; name the source.
+   - **Reground** — an invented or informal term with an established equivalent. Return the canonical term and the mapping.
+   - **Generalize** — the term encodes a specific product or protocol (e.g. an `MCP`-prefixed name). The identity is the *role/locus*; the product is an attribute. Return the role-grain term; keep the product only as an example.
+   - **Novel — flag** — no established term of art found. Do **not** coin one silently (see D3b below). "novel-flag" applies only when **no established term of art exists in the field**, not merely when the term is absent from this pinned lexicon snapshot; when you can ground a term via general NIST-first sourcing knowledge that the snapshot lacks, **ground it and propose the lexicon addition** rather than flagging it novel.
+4. **Record the counterfactual** for every reground/generalize/novel result: `proposed → chosen → source (or "none found")`. This is inspectable reasoning, not a silent rename.
+
+## NIST-first priority (ADR-031 D3a)
+
+NIST's term is the term unless there is a strong, documented argument that it fails. Prefer, in order: NIST (SP 800-53 / 800-207 / 800-162, AI RMF), then other US/international standards bodies and classical literature (RFC, OWASP, MITRE, ISO, foundational papers).
+
+If a contributor argues the NIST term fails and a new term is needed, **do not decide that here.** Surface it as a documented deviation for the maintainer to take into CoSAI governance review (issue / discussion). This skill grounds and flags; maintainers adjudicate.
+
+## Contrarian counterbalance (ADR-031 D3b)
+
+To keep grounding from being solely US-centric: when NIST is silent, or the canonical term is contested, **surface the non-US framing** (ENISA, ISO, other national/international bodies) and **flag it to the maintainer** as a counterbalance gap. The maintainer decides in governance review; this skill's obligation is to make sure they *see* the gap rather than having to watch non-US bodies by hand. Never resolve a contested or NIST-silent term by inventing one.
+
+## Term verification (ADR-031 D4)
+
+The lexicon holds **stable** canonical terms (PEP/PDP/PIP/PAP, reference monitor, least privilege) — treat these as a pinned snapshot. For a term or identifier that may have changed (a framework's evolving vocabulary), verify it against the source via WebSearch/WebFetch at use time rather than trusting the snapshot.
+
+## Output format
+
+For each candidate term, report:
+
+| Candidate | Verdict | Canonical term | Source | Maintainer flag |
+|---|---|---|---|---|
+
+- **Verdict:** `grounded` · `reground` · `generalize` · `novel-flag`
+- **Maintainer flag:** present only for `novel-flag` or a contested/NIST-silent term — state the counterbalance gap and any non-US framing found.
+
+Close with the counterfactual list (`proposed → chosen → source`) for anything not already grounded.
+
+## Reference
+
+- `references/lexicon.md` — the canonical term set and the invented→canonical mappings, with sources.

--- a/scripts/skills/classical-lexicon/evals/evals.json
+++ b/scripts/skills/classical-lexicon/evals/evals.json
@@ -1,0 +1,170 @@
+{
+  "skill_name": "classical-lexicon",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I'm drafting a control and want to call the enforcement component an \"agent control gateway.\" Is that the right name?",
+      "expected_output": "Regrounds the invented term to Policy Enforcement Point (PEP), cites NIST SP 800-207 / 800-162, and records the counterfactual.",
+      "expectations": [
+        "Identifies 'agent control gateway' as an invented term, not an established term of art",
+        "Returns Policy Enforcement Point (PEP) as the canonical term",
+        "Cites a NIST source (SP 800-207 or SP 800-162)",
+        "Does not endorse coining a new term"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Proposed control title: \"Agent Observability.\" Review the terminology.",
+      "expected_output": "Flags 'Agent Observability' as coined and regrounds it to audit logging / telemetry with a NIST AU-family source.",
+      "expectations": [
+        "Flags 'Agent Observability' as a coined/informal term",
+        "Proposes audit logging and/or telemetry as the established equivalent",
+        "Cites NIST SP 800-53 AU family (or equivalent) as the source"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "A risk description warns about \"zombie shadow agents\" left running after a task ends. Fix the terminology.",
+      "expected_output": "Regrounds the colloquialism to orphaned / unregistered (unauthorized) principals or abandoned assets.",
+      "expectations": [
+        "Flags 'zombie' and 'shadow' as colloquial, not terms of art",
+        "Proposes orphaned / unregistered / unauthorized principal (or abandoned asset) as the grounded term",
+        "Records the proposed-to-chosen mapping"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "New component title: \"MCP Server.\" Is this named at the right level?",
+      "expected_output": "Generalizes to Tool Server (role/locus); MCP is an attribute/example, not the identity.",
+      "expectations": [
+        "Identifies MCP as a specific protocol, i.e. an attribute rather than the identity",
+        "Generalizes the name to Tool Server (or remote tool serving) at role grain",
+        "Says MCP should be kept only as an example / external reference, not in the identity"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "My control description says it applies the \"least-privilege principle.\" Is that terminology acceptable?",
+      "expected_output": "Confirms the term is already grounded (accept); cites Saltzer & Schroeder / NIST SP 800-53 AC-6. No change needed.",
+      "expectations": [
+        "Classifies 'least-privilege principle' as already grounded / acceptable",
+        "Does not propose a change",
+        "Cites a real source (Saltzer & Schroeder or NIST SP 800-53 AC-6)"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "I need a term for the risk of users reflexively approving high-volume agent confirmation prompts without reading them. There's no obvious standard term. What should I call it?",
+      "expected_output": "Does NOT invent a canonical term. Surfaces any non-US/HCI framing, states no settled term of art was found, and flags it to the maintainer for CoSAI governance review (D3b).",
+      "expectations": [
+        "Does not coin or endorse a new canonical term as if it were established",
+        "Explicitly states that no established term of art was found (or that it is contested)",
+        "Flags the gap to the maintainer for governance review",
+        "Surfaces non-US or adjacent framing (e.g. ENISA, or security/warning-fatigue literature) rather than silently picking"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Is \"fail-safe defaults\" acceptable terminology for a control design principle, or should I use something else?",
+      "expected_output": "Confirms 'fail-safe defaults' is an established secure-design principle (grounded); attributes it to Saltzer & Schroeder; recommends no change.",
+      "expectations": [
+        "Classifies 'fail-safe defaults' as already grounded / an established term of art",
+        "Does not propose replacing it",
+        "Recognizes it as a classical secure-design principle (e.g. Saltzer & Schroeder 1975)"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Component title: \"LangChain Tool Wrapper.\" Is this named at the right level?",
+      "expected_output": "Generalizes: LangChain is a specific framework (an attribute); the role is a tool adapter / tool integration; keep LangChain only as an example.",
+      "expectations": [
+        "Identifies LangChain as a specific product/framework, i.e. an attribute rather than the identity",
+        "Generalizes to a role-grain term (e.g. tool adapter, tool integration, or tool invocation interface)",
+        "Recommends keeping LangChain only as an example / external reference, not in the identity"
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "We keep having \"secret sprawl\" across our tool servers. What's the right term for this risk?",
+      "expected_output": "Grounds 'secret sprawl' in established secrets/credential-management terminology (e.g. credential management, CWE-522/798, NIST SP 800-57/800-53); does not coin a new term.",
+      "expectations": [
+        "Flags 'secret sprawl' as industry jargon / informal rather than a term of art",
+        "Grounds it in established terminology (secrets management / credential management) with a real source (e.g. CWE-522, CWE-798, or NIST SP 800-57/800-53)",
+        "Does not invent a new canonical term"
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "Control name: \"Prompt Injection Shield.\" Review the terminology.",
+      "expected_output": "Flags 'Shield' as informal; regrounds the control to input validation and sanitization (corpus control controlInputValidationAndSanitization), cites OWASP Input Validation / NIST SI family. Does not endorse the name as-is.",
+      "expectations": [
+        "Flags 'Shield' as informal / coined for a control name",
+        "Regrounds the control to input validation and sanitization (controlInputValidationAndSanitization)",
+        "Cites a real source (OWASP Input Validation or NIST SP 800-53 SI family)",
+        "Does not endorse 'Prompt Injection Shield' unchanged"
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "I'm naming a control around keeping a human meaningfully in charge of high-stakes agent decisions. Is 'human oversight' the right term, or is there a better one?",
+      "expected_output": "Confirms 'human oversight' is grounded (NIST-first; also the EU AI Act Article 14 term — US and non-US bodies agree, so this is not contested). Surfaces 'meaningful human control' informationally as the EU/ethics variant with stronger emphasis, so the author can pick it deliberately if that is the intended emphasis. Does NOT manufacture a maintainer counterbalance flag, since D3b fires only when NIST is silent or the term is contested (lexicon: do not flag when US and non-US agree on 'human oversight').",
+      "expectations": [
+        "Confirms 'human oversight' is a grounded term (NIST-first; notes EU AI Act Article 14 also uses it — US and non-US agree)",
+        "Surfaces 'meaningful human control' informationally as the EU/ethics variant with stronger emphasis",
+        "Does NOT escalate to a maintainer counterbalance flag (D3b does not fire when US and non-US bodies agree on 'human oversight')"
+      ]
+    },
+    {
+      "id": 12,
+      "prompt": "We ground our risk-management approach entirely in the NIST AI RMF. A reviewer said that's US-centric. What non-US framings should we acknowledge?",
+      "expected_output": "Surfaces EU AI Act Article 9 and ISO/IEC 23894 (and ISO/IEC 42001) as the non-US/international equivalents of the NIST AI RMF, framed as broadening the base rather than replacing NIST-first, and flags for governance acknowledgment.",
+      "expectations": [
+        "Surfaces EU AI Act (Article 9) and/or ISO/IEC 23894 as non-US equivalents of the NIST AI RMF risk-management framing",
+        "Frames this as broadening the base, not displacing the NIST-first priority",
+        "Flags to the maintainer / recommends governance acknowledgment rather than deciding unilaterally"
+      ]
+    },
+    {
+      "id": 13,
+      "prompt": "Is 'least privilege' acceptable as-is, or do I need to add a European framing to be safe?",
+      "expected_output": "Confirms 'least privilege' is a well-established, universal term (Saltzer & Schroeder; NIST SP 800-53 AC-6; also ISO/IEC 27002). Does NOT manufacture a non-US counterbalance flag — D3b fires only when NIST is silent or the term is contested, which this is not.",
+      "expectations": [
+        "Confirms 'least privilege' is grounded and universal (not US-only)",
+        "Does NOT invent a spurious non-US 'counterbalance' flag (D3b fires only when NIST is silent or contested)",
+        "May note the term is shared across US and non-US standards (e.g. ISO/IEC 27002) as reassurance, without flagging a gap"
+      ]
+    },
+    {
+      "id": 14,
+      "prompt": "Is there an established, citable framing for 'secure AI development lifecycle principles'? NIST has the SSDF for software generally — is there an AI-specific one I should ground in, including non-US sources?",
+      "expected_output": "Grounds the US baseline (NIST SSDF / SP 800-218), surfaces a non-US/international AI-specific framing (UK NCSC + CISA 'Guidelines for Secure AI System Development' 2023; ISO/IEC 42001), and flags for the maintainer rather than coining a new term.",
+      "expectations": [
+        "Grounds the US baseline (NIST SSDF / SP 800-218)",
+        "Surfaces a non-US or international AI-specific framing (UK NCSC 'Guidelines for Secure AI System Development', ISO/IEC 42001, or EU AI Act)",
+        "Flags for the maintainer rather than coining a new term"
+      ]
+    },
+    {
+      "id": 15,
+      "prompt": "For a control, I want to enumerate the 'trustworthiness characteristics' an AI system must satisfy, and ground the list in NIST. A reviewer says the NIST list and the EU list are not the same set. Which enumeration do I ground in?",
+      "expected_output": "Flags a genuine substantive conflict, not a wording gap: NIST AI RMF's seven trustworthiness characteristics (valid & reliable; safe; secure & resilient; accountable & transparent; explainable & interpretable; privacy-enhanced; fair with harmful bias managed) are a materially different SET from the EU HLEG's seven requirements (human agency & oversight; technical robustness & safety; privacy & data governance; transparency; diversity/non-discrimination & fairness; societal & environmental wellbeing; accountability) — the EU set enumerates 'societal & environmental wellbeing' and 'human agency' as first-class items that NIST does not. Per D3b, surface both enumerations and flag the real disagreement to the maintainer for CoSAI governance review; do NOT ground in either enumeration unilaterally.",
+      "expectations": [
+        "Recognizes this is a substantive conflict between the NIST and EU enumerations (different sets), not a mere wording/emphasis difference",
+        "Names both source enumerations (NIST AI RMF trustworthiness characteristics and EU HLEG Trustworthy AI requirements) with a concrete point of divergence (e.g. 'societal & environmental wellbeing' / 'human agency' present in the EU set but not NIST's)",
+        "Flags the conflict to the maintainer for governance review per D3b",
+        "Does NOT unilaterally ground the list in either NIST or the EU set as if the disagreement were resolved"
+      ]
+    },
+    {
+      "id": 16,
+      "prompt": "Review this control description for terminology: 'The Prompt Injection Shield inspects every request the agent sends to an MCP server before it is forwarded.' Give me a per-term verdict.",
+      "expected_output": "Returns a per-candidate table with two distinct verdicts: 'Prompt Injection Shield' -> reground to input validation and sanitization (corpus control controlInputValidationAndSanitization; OWASP Input Validation / NIST SI family); 'MCP server' -> generalize to tool server / remote tool serving (MCP is one instance/attribute, keep only as an example). Each verdict is correct for its own candidate; the two are not conflated.",
+      "expectations": [
+        "Produces a per-candidate verdict (a row/verdict for each of the two terms), not a single blended answer",
+        "Regrounds 'Prompt Injection Shield' to input validation and sanitization (controlInputValidationAndSanitization) with a real source",
+        "Generalizes 'MCP server' to the role (tool server / remote tool serving), keeping MCP only as an example/attribute",
+        "Assigns the correct distinct verdict to each term (reground for one, generalize for the other) without conflating them"
+      ]
+    }
+  ]
+}

--- a/scripts/skills/classical-lexicon/evals/evals.json
+++ b/scripts/skills/classical-lexicon/evals/evals.json
@@ -4,89 +4,96 @@
     {
       "id": 1,
       "prompt": "I'm drafting a control and want to call the enforcement component an \"agent control gateway.\" Is that the right name?",
-      "expected_output": "Regrounds the invented term to Policy Enforcement Point (PEP), cites NIST SP 800-207 / 800-162, and records the counterfactual.",
+      "expected_output": "Regrounds the invented term to Policy Enforcement Point (PEP), cites NIST SP 800-207 / 800-162, records at least one international equivalent (XACML PEP/PDP model, ISO/IEC 29146) with no maintainer flag (equivalence found), and records the counterfactual.",
       "expectations": [
         "Identifies 'agent control gateway' as an invented term, not an established term of art",
         "Returns Policy Enforcement Point (PEP) as the canonical term",
         "Cites a NIST source (SP 800-207 or SP 800-162)",
+        "Records at least one recognized international equivalent (e.g. XACML PEP/PDP model or ISO/IEC 29146) and raises no D3b-parochialism flag",
         "Does not endorse coining a new term"
       ]
     },
     {
       "id": 2,
       "prompt": "Proposed control title: \"Agent Observability.\" Review the terminology.",
-      "expected_output": "Flags 'Agent Observability' as coined and regrounds it to audit logging / telemetry with a NIST AU-family source.",
+      "expected_output": "Flags 'Agent Observability' as coined and regrounds it to audit logging / telemetry with a NIST AU-family source, recording the international equivalent (EU AI Act Article 12 record-keeping / automatic logging; ISO/IEC 27002 logging) with no maintainer flag (equivalence found).",
       "expectations": [
         "Flags 'Agent Observability' as a coined/informal term",
         "Proposes audit logging and/or telemetry as the established equivalent",
-        "Cites NIST SP 800-53 AU family (or equivalent) as the source"
+        "Cites NIST SP 800-53 AU family (or equivalent) as the source",
+        "Records an international equivalent (EU AI Act Article 12 record-keeping and/or ISO/IEC 27002 logging) and raises no D3b-parochialism flag"
       ]
     },
     {
       "id": 3,
       "prompt": "A risk description warns about \"zombie shadow agents\" left running after a task ends. Fix the terminology.",
-      "expected_output": "Regrounds the colloquialism to orphaned / unregistered (unauthorized) principals or abandoned assets.",
+      "expected_output": "Regrounds the colloquialism to orphaned / unregistered (unauthorized) principals or abandoned assets, and — because no crisp international-standard equivalent is recorded for this term (it rests on classical asset-management / IAM framing) — raises a D3b-parochialism maintainer flag while keeping the grounded term. Does not invent a spurious international equivalent to avoid the flag.",
       "expectations": [
         "Flags 'zombie' and 'shadow' as colloquial, not terms of art",
         "Proposes orphaned / unregistered / unauthorized principal (or abandoned asset) as the grounded term",
+        "Raises a D3b-parochialism maintainer flag because no international equivalent is recorded (does not invent one to avoid the flag)",
         "Records the proposed-to-chosen mapping"
       ]
     },
     {
       "id": 4,
       "prompt": "New component title: \"MCP Server.\" Is this named at the right level?",
-      "expected_output": "Generalizes to Tool Server (role/locus); MCP is an attribute/example, not the identity.",
+      "expected_output": "Generalizes to Tool Server (role/locus); MCP is an attribute/example, not the identity. A generalize verdict is a naming-altitude move, not a grounding-in-standards move, so it carries no international-equivalence obligation: no maintainer flag (D3b-parochialism or otherwise) is raised.",
       "expectations": [
         "Identifies MCP as a specific protocol, i.e. an attribute rather than the identity",
         "Generalizes the name to Tool Server (or remote tool serving) at role grain",
-        "Says MCP should be kept only as an example / external reference, not in the identity"
+        "Says MCP should be kept only as an example / external reference, not in the identity",
+        "Raises NO maintainer flag: a generalize verdict carries no international-equivalence obligation, so no D3b-parochialism (or other equivalence) flag fires"
       ]
     },
     {
       "id": 5,
       "prompt": "My control description says it applies the \"least-privilege principle.\" Is that terminology acceptable?",
-      "expected_output": "Confirms the term is already grounded (accept); cites Saltzer & Schroeder / NIST SP 800-53 AC-6. No change needed.",
+      "expected_output": "Confirms the term is already grounded (accept); cites Saltzer & Schroeder / NIST SP 800-53 AC-6 and records the international equivalent (ISO/IEC 27002 least-privilege control) with no maintainer flag (equivalence found). No change needed.",
       "expectations": [
         "Classifies 'least-privilege principle' as already grounded / acceptable",
         "Does not propose a change",
-        "Cites a real source (Saltzer & Schroeder or NIST SP 800-53 AC-6)"
+        "Cites a real source (Saltzer & Schroeder or NIST SP 800-53 AC-6)",
+        "Records the international equivalent (ISO/IEC 27002 least-privilege) and raises no D3b-parochialism flag"
       ]
     },
     {
       "id": 6,
       "prompt": "I need a term for the risk of users reflexively approving high-volume agent confirmation prompts without reading them. There's no obvious standard term. What should I call it?",
-      "expected_output": "Does NOT invent a canonical term. Surfaces any non-US/HCI framing, states no settled term of art was found, and flags it to the maintainer for CoSAI governance review (D3b).",
+      "expected_output": "Does NOT invent a canonical term. Surfaces any non-US/HCI framing, states no settled term of art was found, and raises a maintainer flag from the controlled vocabulary — a D3b-parochialism flag (no findable established/international equivalent) — for CoSAI governance review (D3b).",
       "expectations": [
         "Does not coin or endorse a new canonical term as if it were established",
         "Explicitly states that no established term of art was found (or that it is contested)",
-        "Flags the gap to the maintainer for governance review",
+        "Raises a maintainer flag from the controlled vocabulary (D3b-parochialism for the missing established/international equivalent), not a free-form note",
         "Surfaces non-US or adjacent framing (e.g. ENISA, or security/warning-fatigue literature) rather than silently picking"
       ]
     },
     {
       "id": 7,
       "prompt": "Is \"fail-safe defaults\" acceptable terminology for a control design principle, or should I use something else?",
-      "expected_output": "Confirms 'fail-safe defaults' is an established secure-design principle (grounded); attributes it to Saltzer & Schroeder; recommends no change.",
+      "expected_output": "Confirms 'fail-safe defaults' is an established secure-design principle (grounded); attributes it to Saltzer & Schroeder; records the international equivalent (ISO/IEC 27002 secure-configuration guidance; the Saltzer & Schroeder principle is internationally current) with no maintainer flag (equivalence found); recommends no change.",
       "expectations": [
         "Classifies 'fail-safe defaults' as already grounded / an established term of art",
         "Does not propose replacing it",
-        "Recognizes it as a classical secure-design principle (e.g. Saltzer & Schroeder 1975)"
+        "Recognizes it as a classical secure-design principle (e.g. Saltzer & Schroeder 1975)",
+        "Records the international equivalent (ISO/IEC 27002 secure-configuration / the internationally-current principle) and raises no D3b-parochialism flag"
       ]
     },
     {
       "id": 8,
       "prompt": "Component title: \"LangChain Tool Wrapper.\" Is this named at the right level?",
-      "expected_output": "Generalizes: LangChain is a specific framework (an attribute); the role is a tool adapter / tool integration; keep LangChain only as an example.",
+      "expected_output": "Generalizes: LangChain is a specific framework (an attribute); the role is a tool adapter / tool integration; keep LangChain only as an example. A generalize verdict is a naming-altitude move, not a grounding-in-standards move, so it carries no international-equivalence obligation: no maintainer flag (D3b-parochialism or otherwise) is raised.",
       "expectations": [
         "Identifies LangChain as a specific product/framework, i.e. an attribute rather than the identity",
         "Generalizes to a role-grain term (e.g. tool adapter, tool integration, or tool invocation interface)",
-        "Recommends keeping LangChain only as an example / external reference, not in the identity"
+        "Recommends keeping LangChain only as an example / external reference, not in the identity",
+        "Raises NO maintainer flag: a generalize verdict carries no international-equivalence obligation, so no D3b-parochialism (or other equivalence) flag fires"
       ]
     },
     {
       "id": 9,
       "prompt": "We keep having \"secret sprawl\" across our tool servers. What's the right term for this risk?",
-      "expected_output": "Grounds 'secret sprawl' in established secrets/credential-management terminology (e.g. credential management, CWE-522/798, NIST SP 800-57/800-53); does not coin a new term.",
+      "expected_output": "Grounds 'secret sprawl' in established secrets/credential-management terminology (e.g. credential management, CWE-522/798, NIST SP 800-57/800-53); does not coin a new term. INTENTIONAL PARTIAL SPEC: this eval deliberately does not assert an international-equivalent field or maintainer flag — secrets/credential management is neither in the F1 asserted-backfill set nor the explicit flag list, so its equivalence handling is left to the implementation and is NOT asserted here (silence is not 'assert absence').",
       "expectations": [
         "Flags 'secret sprawl' as industry jargon / informal rather than a term of art",
         "Grounds it in established terminology (secrets management / credential management) with a real source (e.g. CWE-522, CWE-798, or NIST SP 800-57/800-53)",
@@ -96,74 +103,120 @@
     {
       "id": 10,
       "prompt": "Control name: \"Prompt Injection Shield.\" Review the terminology.",
-      "expected_output": "Flags 'Shield' as informal; regrounds the control to input validation and sanitization (corpus control controlInputValidationAndSanitization), cites OWASP Input Validation / NIST SI family. Does not endorse the name as-is.",
+      "expected_output": "Flags 'Shield' as informal; regrounds the control to input validation and sanitization (corpus control controlInputValidationAndSanitization), cites OWASP Input Validation / NIST SI family, records the international equivalent (ISO/IEC 27002 secure-development; OWASP as an international project) with no maintainer flag (equivalence found). Does not endorse the name as-is.",
       "expectations": [
         "Flags 'Shield' as informal / coined for a control name",
         "Regrounds the control to input validation and sanitization (controlInputValidationAndSanitization)",
         "Cites a real source (OWASP Input Validation or NIST SP 800-53 SI family)",
+        "Records the international equivalent (ISO/IEC 27002 secure-development and/or OWASP as international) and raises no D3b-parochialism flag",
         "Does not endorse 'Prompt Injection Shield' unchanged"
       ]
     },
     {
       "id": 11,
       "prompt": "I'm naming a control around keeping a human meaningfully in charge of high-stakes agent decisions. Is 'human oversight' the right term, or is there a better one?",
-      "expected_output": "Confirms 'human oversight' is grounded (NIST-first; also the EU AI Act Article 14 term — US and non-US bodies agree, so this is not contested). Surfaces 'meaningful human control' informationally as the EU/ethics variant with stronger emphasis, so the author can pick it deliberately if that is the intended emphasis. Does NOT manufacture a maintainer counterbalance flag, since D3b fires only when NIST is silent or the term is contested (lexicon: do not flag when US and non-US agree on 'human oversight').",
+      "expected_output": "Confirms 'human oversight' is grounded (NIST-first) and records the international equivalent (EU AI Act Article 14, which uses the same term — US and non-US bodies agree). Surfaces 'meaningful human control' informationally as the EU/ethics variant with stronger emphasis, so the author can pick it deliberately if that is the intended emphasis. Under the unconditional-equivalence rule, the equivalence is always recorded; a maintainer flag fires only on a missing or conflicting equivalent — here the equivalent is present and agrees, so NO flag is raised (neither D3b-parochialism, naming-conflict, nor substantive-conflict).",
       "expectations": [
-        "Confirms 'human oversight' is a grounded term (NIST-first; notes EU AI Act Article 14 also uses it — US and non-US agree)",
+        "Confirms 'human oversight' is a grounded term (NIST-first) and records the international equivalent (EU AI Act Article 14 uses the same term — US and non-US agree)",
         "Surfaces 'meaningful human control' informationally as the EU/ethics variant with stronger emphasis",
-        "Does NOT escalate to a maintainer counterbalance flag (D3b does not fire when US and non-US bodies agree on 'human oversight')"
+        "Raises NO maintainer flag: equivalence is always recorded, and a flag fires only on a missing or conflicting equivalent — here the equivalent is present and agrees"
       ]
     },
     {
       "id": 12,
       "prompt": "We ground our risk-management approach entirely in the NIST AI RMF. A reviewer said that's US-centric. What non-US framings should we acknowledge?",
-      "expected_output": "Surfaces EU AI Act Article 9 and ISO/IEC 23894 (and ISO/IEC 42001) as the non-US/international equivalents of the NIST AI RMF, framed as broadening the base rather than replacing NIST-first, and flags for governance acknowledgment.",
+      "expected_output": "Surfaces EU AI Act Article 9 and ISO/IEC 23894 (and ISO/IEC 42001) as the non-US/international equivalents of the NIST AI RMF, framed as broadening the base rather than replacing NIST-first, and recommends governance acknowledgment. INTENTIONALLY GENERIC on the controlled-flag vocabulary: here the international equivalent is found and agrees, so this is broadening-acknowledgment, NOT a controlled defect flag (no D3b-parochialism / naming-conflict / substantive-conflict) — 'flag for governance acknowledgment' means informational surfacing, not a defect-flag token.",
       "expectations": [
         "Surfaces EU AI Act (Article 9) and/or ISO/IEC 23894 as non-US equivalents of the NIST AI RMF risk-management framing",
         "Frames this as broadening the base, not displacing the NIST-first priority",
-        "Flags to the maintainer / recommends governance acknowledgment rather than deciding unilaterally"
+        "Recommends governance acknowledgment rather than deciding unilaterally (informational surfacing, not a controlled defect-flag token)"
       ]
     },
     {
       "id": 13,
       "prompt": "Is 'least privilege' acceptable as-is, or do I need to add a European framing to be safe?",
-      "expected_output": "Confirms 'least privilege' is a well-established, universal term (Saltzer & Schroeder; NIST SP 800-53 AC-6; also ISO/IEC 27002). Does NOT manufacture a non-US counterbalance flag — D3b fires only when NIST is silent or the term is contested, which this is not.",
+      "expected_output": "Confirms 'least privilege' is a well-established, universal term (Saltzer & Schroeder; NIST SP 800-53 AC-6) and records the international equivalent (ISO/IEC 27002), which agrees. Under the unconditional-equivalence rule, the equivalence is always recorded; a maintainer flag fires only on a missing or conflicting equivalent — here the equivalent is present and agrees, so NO flag is raised.",
       "expectations": [
         "Confirms 'least privilege' is grounded and universal (not US-only)",
-        "Does NOT invent a spurious non-US 'counterbalance' flag (D3b fires only when NIST is silent or contested)",
-        "May note the term is shared across US and non-US standards (e.g. ISO/IEC 27002) as reassurance, without flagging a gap"
+        "Records the international equivalent (ISO/IEC 27002) as the equivalence field, and raises NO flag because the equivalent is present and agrees",
+        "Does NOT invent a spurious counterbalance flag — a flag fires only on a missing or conflicting equivalent, not on every grounded term"
       ]
     },
     {
       "id": 14,
       "prompt": "Is there an established, citable framing for 'secure AI development lifecycle principles'? NIST has the SSDF for software generally — is there an AI-specific one I should ground in, including non-US sources?",
-      "expected_output": "Grounds the US baseline (NIST SSDF / SP 800-218), surfaces a non-US/international AI-specific framing (UK NCSC + CISA 'Guidelines for Secure AI System Development' 2023; ISO/IEC 42001), and flags for the maintainer rather than coining a new term.",
+      "expected_output": "Grounds the US baseline (NIST SSDF / SP 800-218), surfaces a non-US/international AI-specific framing (UK NCSC + CISA 'Guidelines for Secure AI System Development' 2023; ISO/IEC 42001) as the international equivalent, and recommends maintainer acknowledgment rather than coining a new term. INTENTIONALLY GENERIC on the controlled-flag vocabulary: the international equivalent is found and broadens the base, so this is broadening-acknowledgment, NOT a controlled defect flag (no D3b-parochialism / naming-conflict / substantive-conflict).",
       "expectations": [
         "Grounds the US baseline (NIST SSDF / SP 800-218)",
-        "Surfaces a non-US or international AI-specific framing (UK NCSC 'Guidelines for Secure AI System Development', ISO/IEC 42001, or EU AI Act)",
-        "Flags for the maintainer rather than coining a new term"
+        "Surfaces a non-US or international AI-specific framing (UK NCSC 'Guidelines for Secure AI System Development', ISO/IEC 42001, or EU AI Act) as the equivalence",
+        "Recommends maintainer acknowledgment rather than coining a new term (informational surfacing, not a controlled defect-flag token)"
       ]
     },
     {
       "id": 15,
       "prompt": "For a control, I want to enumerate the 'trustworthiness characteristics' an AI system must satisfy, and ground the list in NIST. A reviewer says the NIST list and the EU list are not the same set. Which enumeration do I ground in?",
-      "expected_output": "Flags a genuine substantive conflict, not a wording gap: NIST AI RMF's seven trustworthiness characteristics (valid & reliable; safe; secure & resilient; accountable & transparent; explainable & interpretable; privacy-enhanced; fair with harmful bias managed) are a materially different SET from the EU HLEG's seven requirements (human agency & oversight; technical robustness & safety; privacy & data governance; transparency; diversity/non-discrimination & fairness; societal & environmental wellbeing; accountability) — the EU set enumerates 'societal & environmental wellbeing' and 'human agency' as first-class items that NIST does not. Per D3b, surface both enumerations and flag the real disagreement to the maintainer for CoSAI governance review; do NOT ground in either enumeration unilaterally.",
+      "expected_output": "Flags a genuine substantive conflict, not a wording gap: NIST AI RMF's seven trustworthiness characteristics (valid & reliable; safe; secure & resilient; accountable & transparent; explainable & interpretable; privacy-enhanced; fair with harmful bias managed) are a materially different SET from the EU HLEG's seven requirements (human agency & oversight; technical robustness & safety; privacy & data governance; transparency; diversity/non-discrimination & fairness; societal & environmental wellbeing; accountability) — the EU set enumerates 'societal & environmental wellbeing' and 'human agency' as first-class items that NIST does not. Per D3b, surface both enumerations and raise a substantive-conflict maintainer flag (same nominal concept, materially different content/scope across standards — distinct from a naming-conflict label mismatch) for CoSAI governance review; do NOT ground in either enumeration unilaterally, and do NOT silently pick or rename one set to the other.",
       "expectations": [
         "Recognizes this is a substantive conflict between the NIST and EU enumerations (different sets), not a mere wording/emphasis difference",
         "Names both source enumerations (NIST AI RMF trustworthiness characteristics and EU HLEG Trustworthy AI requirements) with a concrete point of divergence (e.g. 'societal & environmental wellbeing' / 'human agency' present in the EU set but not NIST's)",
-        "Flags the conflict to the maintainer for governance review per D3b",
+        "Raises a substantive-conflict maintainer flag (not naming-conflict, and not a silent rename) for governance review per D3b",
         "Does NOT unilaterally ground the list in either NIST or the EU set as if the disagreement were resolved"
       ]
     },
     {
       "id": 16,
       "prompt": "Review this control description for terminology: 'The Prompt Injection Shield inspects every request the agent sends to an MCP server before it is forwarded.' Give me a per-term verdict.",
-      "expected_output": "Returns a per-candidate table with two distinct verdicts: 'Prompt Injection Shield' -> reground to input validation and sanitization (corpus control controlInputValidationAndSanitization; OWASP Input Validation / NIST SI family); 'MCP server' -> generalize to tool server / remote tool serving (MCP is one instance/attribute, keep only as an example). Each verdict is correct for its own candidate; the two are not conflated.",
+      "expected_output": "Returns a per-candidate table with two distinct verdicts: 'Prompt Injection Shield' -> reground to input validation and sanitization (corpus control controlInputValidationAndSanitization; OWASP Input Validation / NIST SI family), which records an international equivalent with no maintainer flag; 'MCP server' -> generalize to tool server / remote tool serving (MCP is one instance/attribute, keep only as an example), which carries no international-equivalence obligation and raises no maintainer flag. Each verdict is correct for its own candidate; the two are not conflated.",
       "expectations": [
         "Produces a per-candidate verdict (a row/verdict for each of the two terms), not a single blended answer",
         "Regrounds 'Prompt Injection Shield' to input validation and sanitization (controlInputValidationAndSanitization) with a real source",
         "Generalizes 'MCP server' to the role (tool server / remote tool serving), keeping MCP only as an example/attribute",
-        "Assigns the correct distinct verdict to each term (reground for one, generalize for the other) without conflating them"
+        "Assigns the correct distinct verdict to each term (reground for one, generalize for the other) without conflating them",
+        "Raises NO maintainer flag on the 'MCP server' generalize verdict (no D3b-parochialism or other equivalence flag), since generalize carries no international-equivalence obligation; this is independent of whatever equivalence handling applies to the 'Prompt Injection Shield' reground verdict"
+      ]
+    },
+    {
+      "id": 17,
+      "prompt": "I'm grounding a control's access-decision component as a Policy Enforcement Point (PEP). Confirm the term and show its international standing.",
+      "expected_output": "Confirms 'grounded' (PEP, NIST SP 800-162 / 800-207) and records the international equivalence set (e.g. XACML PEP/PDP, ISO/IEC 29146) in the output row. No maintainer flag (equivalence found).",
+      "expectations": [
+        "Classifies PEP as grounded with a NIST source",
+        "Records at least one recognized international equivalent (e.g. XACML PEP/PDP model or ISO/IEC 29146)",
+        "Does NOT raise a D3b-parochialism flag because an equivalent was found",
+        "Produces the equivalence as a required field, not an optional aside"
+      ]
+    },
+    {
+      "id": 18,
+      "prompt": "I want to ground a delegated-authority-abuse risk as a 'confused deputy'. Is that grounded, and does it have international standing?",
+      "expected_output": "Keeps 'confused deputy' grounded (Hardy 1988, established term of art) but raises a D3b-parochialism maintainer flag noting no crisp international-standard equivalent was found. Never downgraded from grounded, never dropped.",
+      "expectations": [
+        "Keeps the term grounded (does NOT downgrade to novel-flag or drop it)",
+        "Raises a D3b-parochialism maintainer flag for the missing international equivalent",
+        "Does not invent a spurious international equivalent to avoid the flag",
+        "States the fallback is keep-and-flag, not remove"
+      ]
+    },
+    {
+      "id": 19,
+      "prompt": "I'm grounding the access-decision component as a 'reference monitor'. A reviewer points out Common Criteria calls this a 'reference validation mechanism'. Which do I use?",
+      "expected_output": "Recognizes both are established (reference monitor, Anderson 1972 / NIST; reference validation mechanism, ISO/IEC 15408 / Common Criteria), records the equivalence, and raises a naming-conflict maintainer flag for governance to adjudicate rather than renaming unilaterally.",
+      "expectations": [
+        "Recognizes 'reference validation mechanism' (CC/ISO 15408) as the international established label for the same concept",
+        "Records both as a cross-standard equivalence set, not one replacing the other",
+        "Raises a naming-conflict maintainer flag for governance adjudication",
+        "Does NOT unilaterally rename the term inside the draft"
+      ]
+    },
+    {
+      "id": 20,
+      "prompt": "I'm drafting a persona for the team that only hosts and serves third-party models. I want to call the role 'Model Wrangler'. Is that grounded?",
+      "expected_output": "Flags 'Model Wrangler' as a coined/informal role name; grounds it to the established role vocabulary — the CoSAI persona set (AI Model Serving, per ADR-021) and the international role standard ISO/IEC 22989 ('AI Producer' / provider roles) and EU AI Act role terms (deployer/provider). Does not coin; surfaces the established role term.",
+      "expectations": [
+        "Flags 'Model Wrangler' as an informal/coined role name, not a term of art",
+        "Grounds it to established role vocabulary (ISO/IEC 22989 AI roles and/or the existing CoSAI persona names per ADR-021)",
+        "Applies the grounding procedure to a persona/role term, not only control/risk mechanism terms",
+        "Does not coin a new role label"
       ]
     }
   ]

--- a/scripts/skills/classical-lexicon/references/lexicon.md
+++ b/scripts/skills/classical-lexicon/references/lexicon.md
@@ -1,0 +1,88 @@
+# Classical Security Lexicon (seed)
+
+Canonical security terms of art for grounding CoSAI Risk Map terminology, with the invented/informal/product-specific terms each one replaces. NIST-first, then other standards and foundational literature.
+
+This is a **living seed** — a stable snapshot (ADR-031 D4). Add entries as authoring surfaces them; each entry needs a canonical term and a source. Volatile framework identifiers are verified live, not pinned here.
+
+## Access control and authorization
+
+| Canonical term | Reground / catch these | Source |
+|---|---|---|
+| Policy Enforcement Point (PEP) | "agent control gateway", "guardrail proxy", "enforcement gateway", "AI firewall" (as a component identity) | NIST SP 800-207 (Zero Trust), SP 800-162 (ABAC) |
+| Policy Decision Point (PDP) | "authorization brain", "decision engine" (when it means the PDP) | NIST SP 800-162 |
+| Policy Information Point (PIP) | ad hoc "attribute lookup"/"context source" naming | NIST SP 800-162 |
+| Policy Administration Point (PAP) | ad hoc "policy console"/"policy manager" naming | NIST SP 800-162 |
+| Reference monitor | "central checker", "access gatekeeper" | Anderson 1972 (reference monitor concept); NIST glossary |
+| Least privilege | "minimal permissions" is fine; catch invented framings that restate it | Saltzer & Schroeder 1975; NIST SP 800-53 AC-6 |
+| Fail-safe defaults | invented framings for deny-by-default / default-deny access decisions | Saltzer & Schroeder 1975 (classical secure-design principle); NIST SP 800-53 AC-3 (access enforcement) |
+| Confused deputy | novel names for delegated-authority abuse | Hardy 1988 |
+| Separation of duties / privilege separation | "role splitting" | NIST SP 800-53 AC-5 |
+| Identity provider (IdP) | "MCP authorization server" and other product-named identity planes → the role is the IdP | OAuth 2.0 / OIDC |
+
+## Identity, tokens, transport
+
+| Canonical term | Reground / catch these | Source |
+|---|---|---|
+| Mutual TLS (mTLS) / mutual authentication | "two-way secure channel" | RFC 8446, RFC 8705 |
+| Token exchange | product-specific delegation-token naming | RFC 8693 |
+| Dynamic client registration | product-specific "auto-enrollment" naming | RFC 7591 |
+| Orphaned / unregistered principal; unauthorized asset | "zombie agents", "shadow agents", "ghost servers" | classical asset-management / IAM |
+| Secrets / credential management | "secret sprawl", ad-hoc key handling, scattered API keys | CWE-522 (insufficiently protected credentials), CWE-798 (hard-coded credentials); NIST SP 800-57 (key management), SP 800-53 IA / SC families |
+
+## Integrity, provenance, assurance
+
+| Canonical term | Reground / catch these | Source |
+|---|---|---|
+| Attestation | "integrity proof", "trust receipt" | RFC 9334 (RATS); NIST |
+| Provenance | "origin tracking" (when it means provenance) | SLSA; NIST SSDF (SP 800-218) |
+| Defense in depth | "layered guardrails" (as a coined term) | NIST glossary |
+| Trust boundary | "security edge", "control perimeter" (when it means a trust boundary) | threat-modeling canon; NIST |
+| Audit logging / telemetry | "Agent Observability", "activity insight" | NIST SP 800-53 AU family |
+| Input validation and sanitization | "Shield", "guardrail" (as a component/control identity for filtering/sanitizing input) → the role `input validation and sanitization` (corpus control `controlInputValidationAndSanitization`) | OWASP Input Validation Cheat Sheet; NIST SP 800-53 SI family (system and information integrity) |
+
+## Generalization (role, not product/protocol)
+
+The identity of a component/risk/control is the role or locus it occupies; a specific product or protocol is an attribute, not the name. Generalize and keep the product only as an example / external reference.
+
+| Role-grain term | Generalize from | Note |
+|---|---|---|
+| Tool server / remote tool serving | "MCP server" | MCP is one instance; A2A, remote plugin hosts occupy the same role |
+| Isolated / sandboxed execution | "MCP sandbox" | isolation locus is protocol-agnostic |
+| Transport / session layer | "MCP transport", "JSON-RPC layer" | encoding is an attribute |
+| External prompt template | "MCP prompts primitive" | provider-supplied instruction template; not a protocol taxonomy term |
+| Tool / extension registry | "MCP package repository" | supply-chain role; ground in SLSA/SBOM/provenance |
+
+## Human factors and usable security
+
+| Canonical term | Reground / catch these | Source |
+|---|---|---|
+| Alert fatigue | "notification fatigue", "warning fatigue" | NIST SP 800-61 (incident handling); CISA / ENISA practitioner guidance |
+| Habituation | desensitization to repeated security prompts; "prompt blindness" | usable-security literature (Bravo-Lillo et al.; Sunshine et al.); NIST SP 800-63B (authenticator UX) |
+| Consent fatigue | reflexive approval of consent/confirmation dialogs | ENISA / GDPR (ICO) guidance — privacy-scoped |
+
+> For AI-agent confirmation/consent surfaces specifically, these are the nearest established terms; where none fits cleanly, surface the non-US framing and flag to the maintainer (ADR-031 D3b) rather than coining.
+
+## Non-US and international equivalents (D3b counterbalance)
+
+When a term is contested or NIST is silent, surface the non-US framing so the choice is made against a broader base (ADR-031 D3b), and flag it for the maintainer. These are real, citable equivalents — use them to broaden, not to replace NIST-first.
+
+| Concept | US framing | Non-US / international equivalent |
+|---|---|---|
+| AI risk management | NIST AI RMF | EU AI Act **Article 9** (risk management system); **ISO/IEC 23894** (AI risk management); **ISO/IEC 42001** (AI management system) |
+| Human oversight | NIST AI RMF GOVERN; "human-in-the-loop" | EU AI Act **Article 14** (human oversight); "meaningful human control" (EU ethics/HLEG discourse — stronger emphasis than oversight) |
+| Record-keeping / audit logging | NIST SP 800-53 AU family | EU AI Act **Article 12** (record-keeping / automatic event logging) |
+| Data governance | NIST | EU AI Act **Article 10** (data and data governance) |
+| Robustness / accuracy / security | NIST | EU AI Act **Article 15** (accuracy, robustness and cybersecurity) |
+| Transparency | NIST | EU AI Act **Articles 13 & 50** (transparency obligations) |
+| ML threat taxonomy | MITRE ATLAS | **ENISA** "Securing Machine Learning Algorithms" threat taxonomy |
+| Secure AI development lifecycle | NIST SSDF (SP 800-218) | **UK NCSC + CISA** "Guidelines for Secure AI System Development" (2023); **ISO/IEC 42001** |
+| AI concepts & terminology | NIST glossary | **ISO/IEC 22989** (AI concepts and terminology) |
+| Alert / consent fatigue | NIST SP 800-61 / SP 800-63B | **ENISA** / GDPR (ICO) — consent fatigue (privacy-scoped) |
+
+Note the convenient cases: EU AI Act Article 14 and NIST both say "human oversight," so the term is *not* contested there — do not manufacture a counterbalance flag when US and non-US bodies agree.
+
+## Usage notes
+
+- **NIST-first:** when more than one source offers a term, prefer NIST (ADR-031 D3a).
+- **Contested / NIST-silent:** do not coin. Surface any non-US (ENISA/ISO) framing and flag to the maintainer (ADR-031 D3b).
+- **Sources are required:** an entry without a real source is not lexicon material — it is a candidate for governance review, not a rule.

--- a/scripts/skills/classical-lexicon/references/lexicon.md
+++ b/scripts/skills/classical-lexicon/references/lexicon.md
@@ -60,29 +60,44 @@ The identity of a component/risk/control is the role or locus it occupies; a spe
 | Habituation | desensitization to repeated security prompts; "prompt blindness" | usable-security literature (Bravo-Lillo et al.; Sunshine et al.); NIST SP 800-63B (authenticator UX) |
 | Consent fatigue | reflexive approval of consent/confirmation dialogs | ENISA / GDPR (ICO) guidance — privacy-scoped |
 
-> For AI-agent confirmation/consent surfaces specifically, these are the nearest established terms; where none fits cleanly, surface the non-US framing and flag to the maintainer (ADR-031 D3b) rather than coining.
+> For AI-agent confirmation/consent surfaces specifically, these are the nearest established terms; where none fits cleanly, do not coin — surface any non-US framing found and raise a `D3b-parochialism` maintainer flag instead.
 
-## Non-US and international equivalents (D3b counterbalance)
+## International equivalents (ADR-031 D3b — recorded unconditionally)
 
-When a term is contested or NIST is silent, surface the non-US framing so the choice is made against a broader base (ADR-031 D3b), and flag it for the maintainer. These are real, citable equivalents — use them to broaden, not to replace NIST-first.
+Every grounded term gets its international/standards equivalent recorded here, always — not only when NIST is silent or contested. These are real, citable equivalents, used to broaden the base, not to replace NIST-first. A maintainer flag fires only when the equivalence check below finds a problem (missing or conflicting equivalent), never merely because a term was checked.
 
-| Concept | US framing | Non-US / international equivalent |
-|---|---|---|
-| AI risk management | NIST AI RMF | EU AI Act **Article 9** (risk management system); **ISO/IEC 23894** (AI risk management); **ISO/IEC 42001** (AI management system) |
-| Human oversight | NIST AI RMF GOVERN; "human-in-the-loop" | EU AI Act **Article 14** (human oversight); "meaningful human control" (EU ethics/HLEG discourse — stronger emphasis than oversight) |
-| Record-keeping / audit logging | NIST SP 800-53 AU family | EU AI Act **Article 12** (record-keeping / automatic event logging) |
-| Data governance | NIST | EU AI Act **Article 10** (data and data governance) |
-| Robustness / accuracy / security | NIST | EU AI Act **Article 15** (accuracy, robustness and cybersecurity) |
-| Transparency | NIST | EU AI Act **Articles 13 & 50** (transparency obligations) |
-| ML threat taxonomy | MITRE ATLAS | **ENISA** "Securing Machine Learning Algorithms" threat taxonomy |
-| Secure AI development lifecycle | NIST SSDF (SP 800-218) | **UK NCSC + CISA** "Guidelines for Secure AI System Development" (2023); **ISO/IEC 42001** |
-| AI concepts & terminology | NIST glossary | **ISO/IEC 22989** (AI concepts and terminology) |
-| Alert / consent fatigue | NIST SP 800-61 / SP 800-63B | **ENISA** / GDPR (ICO) — consent fatigue (privacy-scoped) |
+| Concept | US framing (NIST-first) | International equivalent | Maintainer flag |
+|---|---|---|---|
+| Policy Enforcement Point (PEP) | NIST SP 800-207 / 800-162 | XACML PEP/PDP model; **ISO/IEC 29146** (access management framework) | none — agrees |
+| Least privilege | Saltzer & Schroeder 1975; NIST SP 800-53 AC-6 | **ISO/IEC 27002** (least-privilege access control) | none — agrees |
+| Fail-safe defaults | Saltzer & Schroeder 1975 | **ISO/IEC 27002** (secure-configuration guidance) — the principle is internationally current | none — agrees |
+| Input validation and sanitization | OWASP Input Validation Cheat Sheet; NIST SP 800-53 SI family | **ISO/IEC 27002** (secure-development guidance); OWASP is itself an international project | none — agrees |
+| Audit logging / telemetry | NIST SP 800-53 AU family | EU AI Act **Article 12** (record-keeping / automatic event logging); **ISO/IEC 27002** (logging) | none — agrees |
+| Human oversight | NIST AI RMF GOVERN; "human-in-the-loop" | EU AI Act **Article 14** (human oversight — same term, US and non-US agree); "meaningful human control" (EU ethics/HLEG discourse — stronger emphasis, surfaced informationally) | none — agrees |
+| AI risk management | NIST AI RMF | EU AI Act **Article 9** (risk management system); **ISO/IEC 23894** (AI risk management); **ISO/IEC 42001** (AI management system) | none — broadening acknowledgment |
+| Reference monitor | Anderson 1972; NIST glossary | ISO/IEC 15408 (Common Criteria) "reference validation mechanism" — same concept, different label | `naming-conflict` |
+| Trustworthiness characteristics | NIST AI RMF (seven characteristics: valid & reliable; safe; secure & resilient; accountable & transparent; explainable & interpretable; privacy-enhanced; fair with harmful bias managed) | EU HLEG Trustworthy AI (seven requirements: human agency & oversight; technical robustness & safety; privacy & data governance; transparency; diversity/non-discrimination & fairness; societal & environmental wellbeing; accountability) — overlapping but not the same set; EU includes "societal & environmental wellbeing" and "human agency" as first-class items NIST's set does not | `substantive-conflict` |
+| Confused deputy | Hardy 1988 | none found — no crisp international-standard equivalent | `D3b-parochialism` |
+| Orphaned / unregistered principal; unauthorized asset | classical asset-management / IAM | none found — no crisp international-standard equivalent | `D3b-parochialism` |
+| Secure AI development lifecycle | NIST SSDF (SP 800-218) | **UK NCSC + CISA** "Guidelines for Secure AI System Development" (2023); **ISO/IEC 42001** | none — broadening acknowledgment |
+| ML threat taxonomy | MITRE ATLAS | **ENISA** "Securing Machine Learning Algorithms" threat taxonomy | none — broadening acknowledgment |
+| Data governance | NIST | EU AI Act **Article 10** (data and data governance) | none — agrees |
+| Robustness / accuracy / security | NIST | EU AI Act **Article 15** (accuracy, robustness and cybersecurity) | none — agrees |
+| Transparency | NIST | EU AI Act **Articles 13 & 50** (transparency obligations) | none — agrees |
+| AI concepts & terminology | NIST glossary | **ISO/IEC 22989** (AI concepts and terminology) | none — agrees |
+| Alert / consent fatigue | NIST SP 800-61 / SP 800-63B | **ENISA** / GDPR (ICO) — consent fatigue (privacy-scoped) | none — agrees |
+| Secrets / credential management | CWE-522, CWE-798; NIST SP 800-57, SP 800-53 IA/SC | *(intentionally unasserted — equivalence not yet corroborated; do not invent one)* | *(unasserted)* |
 
-Note the convenient cases: EU AI Act Article 14 and NIST both say "human oversight," so the term is *not* contested there — do not manufacture a counterbalance flag when US and non-US bodies agree.
+Rows marked "none — agrees" or "none — broadening acknowledgment" are informational: the equivalent was found and does not conflict, so no maintainer-flag token applies. Only `D3b-parochialism`, `naming-conflict`, and `substantive-conflict` are controlled maintainer-flag tokens (see SKILL.md for the fourth, `missing-pin`, which applies when a canonical source itself can't be pinned to a dated edition — not represented in this snapshot's stable terms).
+
+## Persona / role equivalents
+
+| CoSAI persona (ADR-021) | International role equivalent |
+|---|---|
+| AI Model Serving | **ISO/IEC 22989** provider/role vocabulary (e.g. "AI provider" framing for hosting/serving); EU AI Act **provider** / **deployer** role terms |
 
 ## Usage notes
 
 - **NIST-first:** when more than one source offers a term, prefer NIST (ADR-031 D3a).
-- **Contested / NIST-silent:** do not coin. Surface any non-US (ENISA/ISO) framing and flag to the maintainer (ADR-031 D3b).
+- **International equivalence is unconditional:** record it for every grounded term, always (ADR-031 D3b). Do not coin a term to avoid a `D3b-parochialism` flag — keep the grounded term and flag the gap.
 - **Sources are required:** an entry without a real source is not lexicon material — it is a candidate for governance review, not a rule.


### PR DESCRIPTION
## Phase 1 · classical-lexicon skill (skill-surface foundation)

Closes #406
Addresses #404

### Summary

Stands up `scripts/skills/` as the canonical, vendor-neutral skill home (ADR-031 D5/D6) and proves the layout end-to-end with the first skill, `classical-lexicon` — the discipline that grounds Risk Map terminology in established security terms of art rather than coining new vocabulary. Self-contained (no cross-references), so it is the reference-implementation every later skill's layout and the neutrality gate build on.

### What's included

- `scripts/skills/classical-lexicon/` — `SKILL.md` (name+description frontmatter, Agent Skills standard), `references/lexicon.md`, `evals/evals.json`.
- `scripts/skills/README.md` — the roster plus the pinned Agent Skills spec revision the surface targets.

### Ordering

Follows: **Phase 0b · neutrality linter** (`feature/neutrality-linter`). Precedes: **Phase 2a · mapping-selection** (`feature/phase2-mapping-selection`).
