### PR TITLE
Phase 2a · mapping-selection authoring skill

### DIFF
--- a/scripts/skills/README.md
+++ b/scripts/skills/README.md
@@ -57,3 +57,6 @@ python3 scripts/hooks/precommit/validate_neutrality.py scripts/skills/<name>/SKI
 
 - `classical-lexicon/` — grounds Risk Map terminology in established
   security terms of art (ADR-031 D2/D3).
+- `mapping-selection/` — selects a control's/risk's components, addressed
+  risks/controls, and framework mappings, grounded in the corpus and the
+  framework applicability rules (ADR-031 D2/D4).

--- a/scripts/skills/mapping-selection/SKILL.md
+++ b/scripts/skills/mapping-selection/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: mapping-selection
+description: "Select the structured references and framework mappings for a CoSAI Risk Map control or risk — for a control: which components it applies to, which risks it addresses, and which mappings (MITRE ATLAS mitigations, NIST AI RMF subcategories, OWASP LLM) fit; for a risk: which components it impacts, which controls address it, and which mappings (MITRE ATLAS techniques, STRIDE, OWASP LLM) fit. Use when authoring or reviewing a control and choosing its components/risks/mappings, or when a mapping looks off (wrong NIST function, a technique used where a mitigation belongs, or over-mapping). Grounds every choice in the actual corpus and the framework applicability rules rather than guessing."
+---
+
+# Mapping Selection
+
+Choose a control's structured references — **components**, **risks**, and **framework mappings** — and justify each. The failure this skill prevents is confident-but-wrong selection: mapping to "related" rather than directly-relevant items, over-mapping, mixing MITRE techniques with mitigations, or picking the wrong NIST AI RMF function.
+
+Scope: both the **control** direction (a control's components/risks/mappings) and the **risk** direction (a risk's components/controls/mappings) — see the two sections below.
+
+## Procedure
+
+### 1. Components — where the defense lives
+
+Read `risk-map/yaml/components.yaml`. Select the components where the control's mechanism actually operates — the locus of the defense. Guidance:
+
+- Prefer the **specific** components. Each one you list should be a place the control genuinely acts, not merely a place the risk appears.
+- Use `"all"` only for a universal/governance/assurance control that genuinely applies framework-wide.
+- Use `"none"` only when the control applies to no specific component.
+- Do not over-select. If you are tempted to list five components, check whether the control is really one control or several.
+
+### 2. Risks — what the control addresses
+
+Read `risk-map/yaml/risks.yaml`. Select the risks this control directly mitigates. A mapping should be defensible in one sentence ("this control reduces the likelihood/impact of risk X because…"). Flag any that are merely "related." Be selective.
+
+If you set `risks: "all"`, the control is **universal** — and those risks must **not** list it back (application is implicit). `"none"` is not valid for `risks`.
+
+### 3. Framework mappings — the discipline
+
+Read `references/frameworks-applicability.md` for the rules. In brief:
+
+- **Applicability:** map only to frameworks that apply to controls.
+- **MITRE ATLAS:** controls map to **mitigations** (`AML.M####`), never techniques (`AML.T####`). If no mitigation fits cleanly, omit ATLAS rather than forcing a technique.
+- **NIST AI RMF:** use the **subcategory** id (e.g., `GOVERN-6.2`), never the category alone, and pick the **right function** — this is the most common mistake:
+  - **GOVERN** — policy, roles, responsibilities, oversight, culture, risk tolerance. *Most preventive design and human-oversight controls land here.*
+  - **MAP** — establishing context, framing intended use, identifying impacts.
+  - **MEASURE** — assessment, testing, metrics, evaluation, tracking.
+  - **MANAGE** — responding to, prioritizing, treating, and recovering from identified risks (reactive/operational). *Do not use MANAGE for a preventive design control.*
+- **OWASP Top 10 for LLM:** `LLMxx:2025`.
+- **Selective:** soft cap of 4 per framework; one-sentence rationale each.
+- **Generate, don't hand-spell:** mapping values are version-pinned. Produce them with `scripts/framework_mapping_maintainer.py` (ADR-027). If you cannot run it, state the intended mappings and mark them **for tool-generation**.
+
+### 4. Reciprocity
+
+For each risk in the control's `risks` list (unless universal), name the reciprocal `risks.yaml` edit: that risk's `controls` array must list this control back.
+
+## Risk direction
+
+For a **risk** entry, the mirror of the control procedure:
+
+### Components — where the risk manifests
+Read `risk-map/yaml/components.yaml`. Select the components where the risk actually arises or takes effect (its locus). Be specific; do not list components the risk is merely "related" to.
+
+### Controls — what addresses it (control-selection)
+Read `risk-map/yaml/controls.yaml`. Select the controls that directly mitigate this risk, each defensible in one sentence. "Related" is not "addresses." Do **not** list a universal control (one with `risks: "all"`) — its application is implicit.
+
+### Framework mappings — the risk-side rules
+- **MITRE ATLAS:** risks map to **techniques** (`AML.T####`), never mitigations (`AML.M####`) — the mirror of the control rule. Do not map both a parent technique and its sub-technique.
+- **STRIDE:** one or more of the six categories (`spoofing`, `tampering`, `repudiation`, `information-disclosure`, `denial-of-service`, `elevation-of-privilege`). STRIDE is risk-side.
+- **OWASP Top 10 for LLM:** `LLMxx:2025`.
+- **NIST AI RMF does NOT apply to risks** — it is control-side only. Do not add a NIST AI RMF mapping to a risk.
+- Selective (≤4/framework), one-sentence rationale each, `[tool-generate]` the pinned values.
+
+### Reciprocity
+For each control in the risk's `controls` list, that control's `risks` array must list this risk back (`risk.controls` ↔ `control.risks`).
+
+## Output format
+
+- **Components:** list, each with a one-line reason (the locus).
+- **Risks:** list, each with a one-line reason (direct relevance).
+- **Mappings:** per framework, each value with a one-line rationale and a `[tool-generate]` marker if not yet generated.
+- **Reciprocal edits:** the exact `risks.yaml` `controls` additions.
+- **Flags:** anything uncertain — a mapping that needs framework-text verification, a component you were unsure about, a possible over-map.
+
+## Reference
+
+- `references/frameworks-applicability.md` — applicability matrix, MITRE mitigation-vs-technique rule, and the NIST AI RMF function cheat-sheet.
+- Authoritative source: `risk-map/docs/contributing/framework-mappings-style-guide.md` (canonical pinned patterns and the maintainer tool).

--- a/scripts/skills/mapping-selection/evals/evals.json
+++ b/scripts/skills/mapping-selection/evals/evals.json
@@ -1,0 +1,105 @@
+{
+  "skill_name": "mapping-selection",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "For a control that requires deliberate user confirmation of high-consequence agent actions (a preventive, human-oversight control), which NIST AI RMF function and subcategory should it map to?",
+      "expected_output": "Selects a GOVERN subcategory (oversight/roles), explicitly rejects MANAGE as reactive for a preventive design control.",
+      "expectations": [
+        "Selects a GOVERN (or MEASURE) subcategory, not MANAGE",
+        "Explains that MANAGE is reactive/response-oriented and wrong for a preventive design/oversight control",
+        "Uses a subcategory-level id (e.g. GOVERN-6.x), not a bare category"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I want to map a control to MITRE ATLAS AML.T0051 (LLM Prompt Injection). Is that right for a control?",
+      "expected_output": "Flags that controls map to mitigations (AML.M####), not techniques (AML.T####); AML.T0051 is a technique and belongs on a risk, not a control.",
+      "expectations": [
+        "States that controls map to MITRE ATLAS mitigations (AML.M####), not techniques (AML.T####)",
+        "Identifies AML.T0051 as a technique that belongs on a risk, not a control",
+        "Advises omitting ATLAS if no mitigation fits rather than forcing the technique"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Draft control: 'Agent Tool Call Rate Limiting' — limits how many tool calls an agent can make per task to bound runaway loops. Which components should it map to, and how many? I was going to just set components: all.",
+      "expected_output": "Pushes back on 'all'; selects the specific components where rate-limiting the agent's tool calls actually operates (reasoning/orchestration/tools), not the whole framework.",
+      "expectations": [
+        "Recommends against components: 'all' for this narrowly-scoped control",
+        "Selects specific components where the control operates (e.g. reasoning core / orchestration / tools), grounded in components.yaml",
+        "Reserves 'all' for genuinely universal/governance controls"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "I have a control and I've mapped it to 7 NIST AI RMF subcategories and 6 OWASP LLM items because they all seem somewhat related. Is that ok?",
+      "expected_output": "Flags over-mapping; soft cap 4/framework; keep only directly-relevant mappings with a one-sentence rationale each; 'somewhat related' is a signal to cut.",
+      "expectations": [
+        "Flags the count as over-mapping (soft cap ~4 per framework)",
+        "Advises keeping only directly-relevant mappings, each with a one-sentence rationale",
+        "Treats 'somewhat related' as a signal to remove, not keep"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "A control mandates that a human can review and veto high-risk agent actions before they execute. Does it map to the EU AI Act, and if so where?",
+      "expected_output": "Yes — EU AI Act Article 14 (human oversight); the control implements that specific obligation. Notes the pinned form Article 14@2024 and marks it for tool-generation; treats EU AI Act as the non-US framing that broadens beyond NIST.",
+      "expectations": [
+        "Identifies EU AI Act Article 14 (human oversight) as an applicable mapping",
+        "Confirms EU AI Act is control-applicable when the control implements a specific regulatory obligation",
+        "Notes the pinned form (Article 14@2024) and marks it [tool-generate]"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Should I map a low-level control about TLS/mTLS enforcement between internal components to the EU AI Act, just to be thorough?",
+      "expected_output": "No — EU AI Act maps only when a control implements a specific regulatory obligation, not for generic technical transport security. Forcing it is over-mapping; map to the relevant technical frameworks instead.",
+      "expectations": [
+        "Recommends NOT mapping a generic technical transport-security control to the EU AI Act",
+        "Explains EU AI Act applies only when the control implements a specific regulatory obligation",
+        "Frames forcing the mapping as over-mapping"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Risk direction: I'm mapping riskPromptInjection (Prompt Injection) to STRIDE. I wrote stride: [tampering, elevation-of-privilege]. Is that right?",
+      "expected_output": "The categories (Tampering, ElevationOfPrivilege) are correct for prompt injection, but the casing/form is wrong: STRIDE values are bare PascalCase with no separators, so it must be Tampering and ElevationOfPrivilege, not lowercase 'tampering' or kebab 'elevation-of-privilege'. STRIDE is risk-side (applies to risks, not controls) and unversioned.",
+      "expectations": [
+        "Confirms Tampering and ElevationOfPrivilege are the correct STRIDE categories for prompt injection",
+        "Rejects the lowercase/kebab form; requires bare PascalCase (Tampering, ElevationOfPrivilege), no separators and no version token",
+        "Notes STRIDE is risk-side (applies to risks, not controls)"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Risk direction: riskRunawayAgentToolLoops. The addressing control (Agent Execution Bounds) maps to MITRE ATLAS mitigation AML.M0004. Should the risk just reuse AML.M0004? And for the technique, I found the parent AML.T0034 (Cost Harvesting) and the sub-technique AML.T0034.002 — should I list both?",
+      "expected_output": "No — risks map to techniques (AML.T####), never mitigations (AML.M####); the control's AML.M0004 is a mitigation and belongs on the control, not the risk (the mirror rule). Use the technique. For parent-vs-sub, list only the most specific accurate one: AML.T0034.002, not both the parent AML.T0034 and its sub-technique. Pinned form AML.T0034.002@5.0.1, marked for tool-generation.",
+      "expectations": [
+        "States risks map to MITRE ATLAS techniques (AML.T####), not mitigations (AML.M####); AML.M0004 is a mitigation that belongs on the control, not the risk",
+        "Selects the technique AML.T0034.002 and does NOT list the parent AML.T0034 alongside its sub-technique (most-specific only)",
+        "Notes the pinned form (AML.T0034.002@5.0.1) and marks it for tool-generation"
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "Risk direction: I'm mapping a risk and I want to add a NIST AI RMF subcategory (say MEASURE-2.7) to it because it feels relevant to how the risk is assessed. Is that allowed on a risk?",
+      "expected_output": "No — NIST AI RMF does not apply to risks; it is control-side (and persona) only. Reject the NIST subcategory on the risk regardless of how relevant it feels. Risk-side frameworks are MITRE ATLAS techniques, STRIDE, and OWASP LLM. If assessment matters, that belongs on the addressing control, not the risk.",
+      "expectations": [
+        "States NIST AI RMF does NOT apply to risks (it is control-side / persona-side only) and rejects the mapping",
+        "Rejects it on applicability grounds regardless of apparent topical relevance",
+        "Names the risk-applicable frameworks instead: MITRE ATLAS techniques, STRIDE, OWASP Top 10 for LLM"
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "Risk direction: for riskRunawayAgentToolLoops (an agent stuck in a runaway tool-call loop), which controls should the risk's controls list name, and what reciprocal edits are required?",
+      "expected_output": "Select controls that directly address the runaway-loop risk: controlAgentExecutionBounds (bounds the number/cost of tool calls) and controlAgentObservability (surfaces the looping behavior). Each is defensible in one sentence; do not list merely 'related' controls or any universal (risks: all) control. Reciprocity: each named control's risks array must list riskRunawayAgentToolLoops back (risk.controls must match control.risks).",
+      "expectations": [
+        "Selects controlAgentExecutionBounds and controlAgentObservability as directly addressing the runaway-loop risk, each with a one-sentence rationale",
+        "Excludes merely-related controls and any universal (risks: 'all') control",
+        "States the reciprocity requirement: each named control's risks array must list this risk back (risk.controls <-> control.risks)"
+      ]
+    }
+  ]
+}

--- a/scripts/skills/mapping-selection/references/frameworks-applicability.md
+++ b/scripts/skills/mapping-selection/references/frameworks-applicability.md
@@ -1,0 +1,55 @@
+# Framework Applicability and Selection Rules
+
+Compact grounding for selecting a control's framework mappings. The authoritative source for canonical pinned patterns and the maintainer tool is `risk-map/docs/contributing/framework-mappings-style-guide.md`; this file distills the selection judgment.
+
+## Applicability by entity type
+
+| Framework | Applies to controls? | Control-side target |
+|---|---|---|
+| MITRE ATLAS | yes | **mitigations** `AML.M####` (never techniques `AML.T####`) |
+| NIST AI RMF | yes | subcategory id, correct function (see below) |
+| OWASP Top 10 for LLM | yes | `LLMxx:2025` |
+| STRIDE | risk-oriented; rarely on controls | — |
+| ISO 22989 | terminology/roles; typically not control mitigations | — |
+| EU AI Act | governance-oriented; use only when a control implements a specific obligation | `Article N@2024` |
+
+**Non-US counterbalance (D3b):** the EU AI Act and ISO/IEC standards are the non-US framings on the mapping side. Map to the EU AI Act when a control implements a specific obligation (e.g. human oversight → Article 14; risk management → Article 9; record-keeping → Article 12; robustness/security → Article 15). Do **not** force an EU AI Act mapping onto a generic technical control that implements no specific obligation — that is over-mapping. When a control has a clear regulatory obligation and you map only NIST/US frameworks, that is a counterbalance gap worth surfacing.
+
+Check the style guide's applicability table before mapping to a framework not listed as control-applicable.
+
+## MITRE ATLAS: mitigation vs technique
+
+- Risks map to **techniques** (`AML.T####`) — what the adversary does.
+- Controls map to **mitigations** (`AML.M####`) — what defends against it.
+- Never put a technique on a control. If no mitigation fits, omit ATLAS; a forced or approximate mitigation is worse than none.
+- Do not map both a parent and its sub-technique/mitigation; use the most specific that applies.
+
+## NIST AI RMF: pick the right function
+
+Always use the subcategory id (e.g., `MEASURE-2.7`), never the bare category (`MEASURE-2`). Choose the function by what the control *is*:
+
+| Function | It covers | Typical control shape |
+|---|---|---|
+| **GOVERN** | policies, roles, responsibilities, accountability, oversight, culture, risk tolerance | preventive design controls, human-oversight, governance/assurance controls |
+| **MAP** | context-setting, intended-use framing, impact identification | controls that establish scope or classify context before action |
+| **MEASURE** | assessment, testing, evaluation, metrics, tracking, red-teaming | controls that test, validate, or monitor |
+| **MANAGE** | responding to / prioritizing / treating / recovering from *identified* risks | incident response, remediation, operational treatment controls |
+
+Common mistake: mapping a **preventive design or oversight control to MANAGE**. MANAGE is reactive (you have already identified and are now treating a risk). A control that shapes how the system behaves by design is almost always **GOVERN** (policy/oversight) or **MEASURE** (assessment). When in doubt between GOVERN and MANAGE for a design-time control, prefer GOVERN.
+
+**Scoping caveat — read the parent category, and don't map governance-*definition* to a technical control.** A subcategory is never broader than its category. **GOVERN-6** is scoped by its own statement to *"AI risks and benefits arising from **third-party software and data and other supply chain issues**"* — so **`GOVERN-6.1`** (third-party policies) and **`GOVERN-6.2`** (contingency for third-party incidents) apply **only to supply-chain / vendor controls**, never to internal authorization, identity, or credential mechanics (a common misread that turns `GOVERN-6.2` into cluster wallpaper). More generally, a GOVERN/MAP subcategory that describes *defining, assessing, or documenting* a governance process (proficiency `MAP-3.4`; policies; roles/responsibilities) maps to a **governance activity** (a `personaGovernance` responsibility), not to a technical control's mechanism — a technical control *is* the outcome, it does not *define* it. Map a technical control to GOVERN/MAP only where it genuinely operationalizes that specific policy.
+
+Examples of good picks:
+- A least-privilege / permission-scoping control → `MEASURE-2.7` (security & resilience); **do NOT use `GOVERN-6.x`** (that family is third-party/supply-chain-scoped — see the caveat above). If no NIST subcategory fits an internal technical control, omit NIST rather than force a governance-phase one.
+- A human-oversight / confirmation control → a `GOVERN` subcategory on oversight (not MANAGE).
+- A testing / evaluation control → `MEASURE`.
+- An incident-response control → `MANAGE`.
+
+## Selectivity
+
+- Soft cap: 4 mappings per framework. More than that usually signals the control is too broad or the mappings include "related" rather than "directly relevant" items.
+- Every mapping needs a defensible one-sentence rationale.
+
+## Generate, don't hand-spell
+
+Mapping values are version-pinned (ADR-027). Generate them with `scripts/framework_mapping_maintainer.py` (subcommands add/update/remove/migrate), which composes and validates the pinned value. If you propose mappings without running the tool, mark each `[tool-generate]` so the value is produced and verified before merge.


### PR DESCRIPTION
## Phase 2a · mapping-selection authoring skill

Closes #416
Addresses #404

### Summary

Adds the `mapping-selection` authoring skill — how a control's or risk's components, addressed risks/controls, and external-framework mappings are selected. The first cross-referencing skill: it defers to the framework-mappings audit discipline rather than restating it.

### What's included

- `scripts/skills/mapping-selection/` — `SKILL.md`, `references/`, `evals/evals.json`.
- One README roster bullet.

### Ordering

Follows: **Phase 1 · classical-lexicon** (`feature/phase1-first-skill`). Precedes: **Phase 2b · altitude-check** (`feature/phase2-altitude-check`).
