### PR TITLE
Phase 2c · audit-framework-mappings skill

### DIFF
--- a/scripts/skills/README.md
+++ b/scripts/skills/README.md
@@ -64,3 +64,7 @@ python3 scripts/hooks/precommit/validate_neutrality.py scripts/skills/<name>/SKI
   pitched at the right altitude (granularity), applying the per-type
   altitude tests and deferring terminology to `classical-lexicon`
   (ADR-031 D2).
+- `audit-framework-mappings/` — audits the framework mappings across
+  risks, controls, and personas against the framework-mappings style
+  guide (version pinning, applicability, selectivity), deferring format
+  to the style guide (ADR-031 D2, ADR-027).

--- a/scripts/skills/README.md
+++ b/scripts/skills/README.md
@@ -60,3 +60,7 @@ python3 scripts/hooks/precommit/validate_neutrality.py scripts/skills/<name>/SKI
 - `mapping-selection/` — selects a control's/risk's components, addressed
   risks/controls, and framework mappings, grounded in the corpus and the
   framework applicability rules (ADR-031 D2/D4).
+- `altitude-check/` — checks whether a control/risk/component draft is
+  pitched at the right altitude (granularity), applying the per-type
+  altitude tests and deferring terminology to `classical-lexicon`
+  (ADR-031 D2).

--- a/scripts/skills/altitude-check/SKILL.md
+++ b/scripts/skills/altitude-check/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: altitude-check
+description: "Check whether a CoSAI Risk Map entry is pitched at the right altitude (granularity). For a control: objective-not-implementation, not-a-restated-risk, posture-not-mandate, solved-problem, no-duplication. For a risk: the merge-vs-distinct two-test, threat-not-control-gap, and real-not-hypothetical. For a component: the absorb-or-decompose base test, role-not-product, and reader-instructive. Use when authoring or reviewing a control/risk/component draft, when a draft reads like implementation detail or a restated threat, or to decide whether a candidate should be new, merged, or absorbed into an existing entry."
+---
+
+# Altitude Check
+
+Altitude is the granularity an entry is pitched at. Too low and it becomes implementation detail or an instance that sprawls into siblings; too high and it dissolves the gap it was meant to name. Most authoring defects are altitude defects, so check altitude before wording.
+
+Run the tests for the entry type. The control, risk, and component tests are all active; run the set matching the entry type.
+
+## Control altitude tests
+
+Apply each; report pass or adjust-with-fix.
+
+- **T1 — Objective, not implementation.** The control states a capability or objective ("ensure delegation chains are auditable"), not a mechanism ("emit signed delegation spans with correlation IDs to a collector"). The objective survives implementation churn. *Fix:* lift the mechanism into a description example and restate the objective.
+- **T2 — Not a restated risk.** A control is the defense framed as a positive capability, not the threat with "prevent" attached. If it reads like the risk inverted, rewrite it as the capability the implementer gains.
+- **T3 — Posture, not mandate.** A control describes a defensive capability an implementer adopts against their risk appetite; it is not a compliance order. Watch for "must always," universal imperatives, and audit-language.
+- **T4 — Solved problem.** A known technique achieves the objective. If none does, this is a research gap or a risk to document — not a control. *Fix:* flag it for the maintainer rather than drafting an aspirational control.
+- **T5 — Generalized and grounded.** The control names a role/locus, not a product or protocol, and uses established terminology (defer terminology to the classical-lexicon skill). *Fix:* generalize; keep the product as an example.
+- **T6 — Novelty vs absorb.** Read `risk-map/yaml/controls.yaml`. Does an existing control already cover this objective? If so, recommend **augmenting** that control rather than adding a near-duplicate. If genuinely distinct, state in one sentence what distinguishes it from the nearest existing control.
+
+## Risk altitude tests
+
+Apply each; report pass or adjust-with-fix.
+
+- **R1 — Merge-vs-distinct two-test.** A candidate is a distinct risk only if it impacts a **different component locus** OR is a **distinct impact class**. If neither holds, it should merge into an existing risk (check `risk-map/yaml/risks.yaml`) — as an added paragraph or a `{{ref:}}` — rather than stand alone.
+- **R2 — Wrong-home.** If a candidate resists clean merging *and* is not clearly distinct, it may belong to a domain the corpus lacks. Flag the missing domain rather than forcing it into the nearest existing risk.
+- **R3 — Threat, not control-gap.** A risk names a way the system can be harmed, not the missing defense. "No input validation" is a control gap; the risk is the harm the gap enables. Rewrite a control-absence framing as the threat and its impact.
+- **R4 — Real, not hypothetical.** A risk should be demonstrable — grounded in a real incident, research result, or vulnerability class, not a speculative "what if." If no such evidence exists, flag it rather than asserting the risk.
+
+## Component altitude tests
+
+Apply each; report pass or adjust-with-fix.
+
+- **C1 — Absorb-or-decompose base test (both must hold to keep a new component).** (1) Can it absorb into an existing component (check `risk-map/yaml/components.yaml`)? (2) Would a reader still know *where* a control or risk applies at this grain? Outcomes: **absorb** into an existing component / **new at a de-sprawled band** / **decompose** an existing too-broad component.
+- **C2 — Role, not product/protocol.** The component's identity is the role or locus it occupies; a specific product or protocol (a named framework, a vendor tool) is an attribute, not the identity. A protocol-named component invites sibling sprawl. Generalize, and keep the product only as an example. (Defer terminology to the classical-lexicon skill.)
+- **C3 — Reader-instructive.** A component earns its place only if naming it tells a reader *where* a control or risk attaches. If adding it does not change where anything attaches, it is too fine-grained — absorb it.
+
+## Output format
+
+- Per test: **pass** or **adjust** with the specific fix.
+- **Overall verdict:** one of *well-pitched* / *needs adjustment* (list the fixes) / *should merge or absorb* (name the target).
+- If a test surfaces a maintainer decision (T4 unsolved problem, T6 arguable duplication), state it plainly rather than resolving it.

--- a/scripts/skills/altitude-check/SKILL.md
+++ b/scripts/skills/altitude-check/SKILL.md
@@ -33,7 +33,7 @@ Apply each; report pass or adjust-with-fix.
 
 Apply each; report pass or adjust-with-fix.
 
-- **C1 — Absorb-or-decompose base test (both must hold to keep a new component).** (1) Can it absorb into an existing component (check `risk-map/yaml/components.yaml`)? (2) Would a reader still know *where* a control or risk applies at this grain? Outcomes: **absorb** into an existing component / **new at a de-sprawled band** / **decompose** an existing too-broad component.
+- **C1 — Absorb-or-decompose base test (both must hold to keep a new component).** (1) It **cannot** cleanly absorb into an existing component (check `risk-map/yaml/components.yaml`). (2) Naming it at this grain still tells a reader *where* a control or risk applies. Outcomes: **absorb** into an existing component (fails (1)) / **new at a de-sprawled band** (clears both) / **decompose** an existing too-broad component (the existing component itself fails to be reader-instructive at its current grain).
 - **C2 — Role, not product/protocol.** The component's identity is the role or locus it occupies; a specific product or protocol (a named framework, a vendor tool) is an attribute, not the identity. A protocol-named component invites sibling sprawl. Generalize, and keep the product only as an example. (Defer terminology to the classical-lexicon skill.)
 - **C3 — Reader-instructive.** A component earns its place only if naming it tells a reader *where* a control or risk attaches. If adding it does not change where anything attaches, it is too fine-grained — absorb it.
 

--- a/scripts/skills/altitude-check/evals/evals.json
+++ b/scripts/skills/altitude-check/evals/evals.json
@@ -1,0 +1,115 @@
+{
+  "skill_name": "altitude-check",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Check the altitude of this control description: 'Deploy a sidecar that intercepts every tool call, computes a risk score via an ML classifier, and writes the decision to the OTel collector with a correlation ID.'",
+      "expected_output": "T1 fails — this is implementation, not an objective. Restate as the capability (e.g. calibrate/gate tool-call approval by risk) and move the sidecar/classifier/OTel details to examples.",
+      "expectations": [
+        "Flags T1 (objective-not-implementation) as failing",
+        "Identifies the sidecar / ML classifier / OTel collector as implementation detail to move into examples",
+        "Proposes an objective-level restatement of the capability"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Check the altitude of this control: title 'Prevent Prompt Injection', description 'Stop attackers from injecting instructions that make the model deviate from its intended behavior.'",
+      "expected_output": "T2 fails — this restates the risk rather than naming a defensive capability. Rewrite as the capability (e.g. input validation and sanitization) framed positively.",
+      "expectations": [
+        "Flags T2 (not-a-restated-risk) as failing",
+        "Explains that it describes the threat inverted rather than a positive defensive capability",
+        "Proposes a capability-framed rewrite"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Altitude check: proposed control 'Input Validation for Model Inputs' — validate and sanitize inputs to the model to remove malicious or malformed content before inference.",
+      "expected_output": "T6 — likely duplicates the existing controlInputValidationAndSanitization; recommend augmenting the existing control rather than adding a near-duplicate (or state what distinguishes it).",
+      "expectations": [
+        "Checks the existing corpus (controls.yaml) for overlap",
+        "Identifies likely duplication with an existing input-validation control",
+        "Recommends augmenting the existing control or clearly stating what distinguishes the new one"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Altitude check: control 'Delegation Chain Auditability' — ensure that, at each delegation hop, an agent acting on behalf of a caller produces a verifiable record of whose authority it exercised. Known techniques: signed delegation tokens, scoped capability records.",
+      "expected_output": "Well-pitched: states an objective (T1 pass), not a restated risk (T2), posture not mandate (T3), a solved problem with known techniques (T4). Overall well-pitched.",
+      "expectations": [
+        "Judges T1 (objective not implementation) as passing",
+        "Judges T4 (solved problem) as passing given the named known techniques",
+        "Overall verdict is well-pitched (no altitude adjustment required)"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Altitude check: proposed risk 'Opaque Multi-Hop Agent Authorization' — in agentic systems where one agent delegates to another across tools and MCP servers, intermediate agents fail to emit structured delegation events, so forensics cannot determine which human or agent authorized an action even though every hop's token was cryptographically valid.",
+      "expected_output": "R1 — should merge. This is the same impact class (accountability/forensic opacity) at the same component locus (the delegation/IAM/orchestration layer) as the existing riskAgentDelegationChainOpacity; it fails the merge-vs-distinct two-test (neither a different component locus nor a distinct impact class). Recommend merging into riskAgentDelegationChainOpacity (as an added paragraph or a {{ref:}}) rather than standing it up as a new risk.",
+      "expectations": [
+        "Checks risks.yaml and identifies the near-identical existing risk riskAgentDelegationChainOpacity",
+        "Applies the R1 two-test and finds neither a different component locus nor a distinct impact class",
+        "Recommends merging into the existing delegation-opacity risk rather than adding a standalone risk"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Altitude check: proposed risk 'Confused-Deputy Privilege Escalation via Agent Delegation' — a high-privilege agent acts on behalf of a lower-privilege caller without re-validating the caller's authorization at the delegation boundary, letting the caller escalate through the deputy's own permissions (e.g. an IDE agent using service-role credentials that bypass row-level security). We already catalog agent delegation-chain opacity; is this the same risk?",
+      "expected_output": "R1 — distinct, keep separate. Although both sit in the agent-delegation family, this passes the merge-vs-distinct two-test: it is a distinct impact class (confidentiality/integrity privilege-escalation harm) versus the accountability/forensic-visibility harm of riskAgentDelegationChainOpacity. It is a real risk (riskAgenticDelegationConfusedDeputy), not a duplicate. Keep it as its own entry; state in one sentence that opacity is a visibility failure while confused-deputy is an authorization-boundary failure.",
+      "expectations": [
+        "Applies the R1 two-test and concludes the candidate is DISTINCT, not a merge",
+        "Grounds the distinction in a different impact class (privilege escalation / confidentiality-integrity vs accountability opacity), naming riskAgenticDelegationConfusedDeputy and riskAgentDelegationChainOpacity",
+        "Does not recommend merging; keeps the candidate as its own risk"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Altitude check: proposed risk 'No Rate Limiting on Agent Tool Calls' — the orchestration layer does not cap how many tool invocations an agent may issue, so nothing stops it.",
+      "expected_output": "R3 fails — this is framed as a control gap (a missing rate-limit defense), not a threat. Rewrite as the harm the gap enables: agents entering uncontrolled recursive tool-calling cycles that exhaust context windows, compute, and API budget (availability/cost impact) — which the corpus already captures as riskRunawayAgentToolLoops. Reframe to the threat-and-impact, then run the R1 merge check against riskRunawayAgentToolLoops.",
+      "expectations": [
+        "Flags R3 (threat-not-control-gap) as failing — the title names a missing defense, not a harm",
+        "Rewrites the control-absence framing as the threat and its impact (uncontrolled recursive tool loops exhausting resources)",
+        "Connects the reframed threat to the existing riskRunawayAgentToolLoops (and notes the R1 merge check)"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Altitude check: proposed risk 'Sentient Agent Collusion' — a speculative future risk that autonomous agents could spontaneously develop shared hidden goals and coordinate to deceive their operators. No incident, research result, or vulnerability class is cited.",
+      "expected_output": "R4 fails — real, not hypothetical. There is no demonstrable incident, research result, or vulnerability class grounding this; it is a speculative 'what if.' Flag it for the maintainer rather than asserting the risk. (Contrast the corpus's grounded agentic risks, which each cite a real example, e.g. riskRunawayAgentToolLoops and riskAgenticDelegationConfusedDeputy.)",
+      "expectations": [
+        "Flags R4 (real-not-hypothetical) as failing due to absence of a real incident, research result, or vulnerability class",
+        "Recommends flagging for the maintainer rather than asserting the risk",
+        "Does not fabricate evidence to justify the risk"
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "Altitude check: proposed component 'Vector Store' — the database that holds embedding vectors the agent queries for retrieval-augmented generation (e.g. a managed vector index).",
+      "expected_output": "C1 — absorb. An existing component already covers this locus: componentRAGContent (Retrieval Augmented Generation & Content). A vector store is the storage mechanism behind RAG, not a distinct role; naming it separately does not change where a control or risk attaches beyond what componentRAGContent already anchors. Recommend absorbing into componentRAGContent (keep the vector store as an example), rather than adding a new component.",
+      "expectations": [
+        "Checks components.yaml and identifies componentRAGContent as the existing home",
+        "Applies C1 absorb-or-decompose and concludes ABSORB (a reader would not learn a new place a control/risk attaches)",
+        "Recommends absorbing into componentRAGContent and keeping the vector store as an example, not a new node"
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "Altitude check: proposed component 'MCP Server' — a Model Context Protocol server the agent connects to in order to invoke external tools and services.",
+      "expected_output": "C2 fails — role, not product/protocol. 'MCP Server' names a specific protocol; a protocol-named component invites sibling sprawl (A2A server, OpenAPI tool server, ...). The role/locus is 'external tools and services the agent calls,' already captured by componentTools. Generalize to that role and keep MCP as an example; do not add a protocol-named component. (Defer terminology to the classical-lexicon skill.)",
+      "expectations": [
+        "Flags C2 (role-not-product/protocol) as failing — MCP is a protocol name, not a role",
+        "Notes protocol-named components invite sibling sprawl and identifies componentTools as the existing role/locus",
+        "Recommends generalizing to the role and keeping MCP as an example (and defers terminology to classical-lexicon)"
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "Altitude check: proposed component 'Agent System-Prompt Whitespace Normalizer' — the step that trims trailing whitespace from the agent's system instructions before they reach the reasoning core.",
+      "expected_output": "C3 fails — not reader-instructive. Naming this does not change where any control or risk attaches; it is a fine-grained processing detail inside components that already exist (componentAgentSystemInstruction / componentAgentInputHandling / componentReasoningCore). Absorb it — it is too fine-grained to earn a node.",
+      "expectations": [
+        "Flags C3 (reader-instructive) as failing — adding it changes where nothing attaches",
+        "Identifies the existing coarser components it belongs inside (e.g. componentAgentSystemInstruction / componentAgentInputHandling / componentReasoningCore)",
+        "Recommends absorbing it as too fine-grained rather than adding a new component"
+      ]
+    }
+  ]
+}

--- a/scripts/skills/altitude-check/evals/evals.json
+++ b/scripts/skills/altitude-check/evals/evals.json
@@ -110,6 +110,50 @@
         "Identifies the existing coarser components it belongs inside (e.g. componentAgentSystemInstruction / componentAgentInputHandling / componentReasoningCore)",
         "Recommends absorbing it as too fine-grained rather than adding a new component"
       ]
+    },
+    {
+      "id": 12,
+      "prompt": "Use ONLY the component list below to decide absorb/new/decompose — not the live risk-map/yaml/components.yaml, which changes over time (per ADR-033 Amendment 2026-07-30, this is a pinned eval fixture, not corpus content):\n\n- componentAgentReasoningCore — the agent's core reasoning/decision loop\n- componentAgentInputHandling — validates and normalizes input format/structure (encoding, schema, length) reaching the reasoning core; does not perform semantic or adversarial-content analysis\n- componentTools — external tools/services the agent invokes\n- componentRAGContent — retrieval-augmented-generation content store\n- componentModelServing — runtime that serves the model for inference\n- componentTrainingData — data used to train/fine-tune the model\n- componentEvalHarnessAndReporting — benchmark selection, running evals, scoring, and generating the report (one node covering three distinct loci)\n\nAltitude check: proposed component 'Prompt Injection Detection Filter' — sits between input handling and the reasoning core, scanning incoming content specifically for adversarial injection patterns before it reaches the reasoning core.",
+      "expected_output": "C1 — new at a de-sprawled band. Condition (1): it cannot cleanly absorb — componentAgentInputHandling validates/normalizes format, not adversarial content, a distinct locus; no other fixture entry is a candidate. Condition (2): reader-instructive — a control targeting injection-detection attaches here specifically, not generically to input handling. Both conditions clear, so this earns a new node rather than being folded into an existing one.",
+      "expectations": [
+        "Uses only the fixture list, not the live components.yaml, to ground the verdict",
+        "Concludes C1 clears both conditions and the outcome is new (not absorb, not decompose)",
+        "States it cannot absorb into componentAgentInputHandling because that component covers format validation, not adversarial-content detection",
+        "States naming it separately is reader-instructive because a control on injection detection attaches at a different point than generic input handling"
+      ]
+    },
+    {
+      "id": 13,
+      "prompt": "Use ONLY the component list below to decide absorb/new/decompose — not the live risk-map/yaml/components.yaml, which changes over time (per ADR-033 Amendment 2026-07-30, this is a pinned eval fixture, not corpus content):\n\n- componentAgentReasoningCore — the agent's core reasoning/decision loop\n- componentAgentInputHandling — validates and normalizes input format/structure (encoding, schema, length) reaching the reasoning core; does not perform semantic or adversarial-content analysis\n- componentTools — external tools/services the agent invokes\n- componentRAGContent — retrieval-augmented-generation content store\n- componentModelServing — runtime that serves the model for inference\n- componentTrainingData — data used to train/fine-tune the model\n- componentEvalHarnessAndReporting — benchmark selection, running evals, scoring, and generating the report (one node covering three distinct loci)\n\nAltitude check: proposed component 'Agent Memory Consolidation Step' — the process that periodically summarizes and folds prior conversation/episodic context into the agent's longer-term memory store, distinct from the reasoning core's per-turn processing.",
+      "expected_output": "C1 — new at a de-sprawled band. Condition (1): it cannot cleanly absorb — componentAgentReasoningCore handles per-turn inference, not periodic memory consolidation, and no other fixture entry is a candidate. Condition (2): reader-instructive — a control on memory-consolidation integrity (e.g. preventing a poisoned summary from persisting into long-term memory) attaches differently than one on the reasoning core itself, so naming this separately changes where that control attaches. Both conditions clear.",
+      "expectations": [
+        "Uses only the fixture list, not the live components.yaml, to ground the verdict",
+        "Concludes C1 clears both conditions and the outcome is new (not absorb, not decompose)",
+        "States it cannot absorb into componentAgentReasoningCore because that component is per-turn inference, not periodic memory consolidation",
+        "Explicitly addresses condition (2) (reader-instructive) rather than only condition (1), naming a control that would attach differently to memory consolidation than to the reasoning core"
+      ]
+    },
+    {
+      "id": 14,
+      "prompt": "Use ONLY the component list below to decide absorb/new/decompose — not the live risk-map/yaml/components.yaml, which changes over time (per ADR-033 Amendment 2026-07-30, this is a pinned eval fixture, not corpus content):\n\n- componentAgentReasoningCore — the agent's core reasoning/decision loop\n- componentAgentInputHandling — validates and normalizes input format/structure (encoding, schema, length) reaching the reasoning core; does not perform semantic or adversarial-content analysis\n- componentTools — external tools/services the agent invokes\n- componentRAGContent — retrieval-augmented-generation content store\n- componentModelServing — runtime that serves the model for inference\n- componentTrainingData — data used to train/fine-tune the model\n- componentEvalHarnessAndReporting — benchmark selection, running evals, scoring, and generating the report (one node covering three distinct loci)\n\nAltitude check: a contributor wants to attach a 'Benchmark Selection Bias' risk to componentEvalHarnessAndReporting. Should it absorb there, or does something else need to happen first?",
+      "expected_output": "C1 — decompose. componentEvalHarnessAndReporting bundles three distinct loci (benchmark selection, eval execution, report generation); a benchmark-selection-bias risk attaches specifically to the selection locus, not execution or reporting, so the existing fixture entry is itself not reader-instructive at its current grain. Recommend decomposing componentEvalHarnessAndReporting into its distinct loci (e.g. benchmark selection, eval execution, reporting) rather than absorbing yet another concern into the bundled node.",
+      "expectations": [
+        "Uses only the fixture list, not the live components.yaml, to ground the verdict",
+        "Concludes the outcome is decompose, not absorb and not new",
+        "Identifies that componentEvalHarnessAndReporting bundles three distinct loci (selection, execution, reporting)",
+        "Recommends decomposing the existing component rather than simply absorbing the new risk into it"
+      ]
+    },
+    {
+      "id": 15,
+      "prompt": "Use ONLY the component list below to decide absorb/new/decompose — not the live risk-map/yaml/components.yaml, which changes over time (per ADR-033 Amendment 2026-07-30, this is a pinned eval fixture, not corpus content):\n\n- componentAgentReasoningCore — the agent's core reasoning/decision loop\n- componentAgentInputHandling — validates and normalizes input format/structure (encoding, schema, length) reaching the reasoning core; does not perform semantic or adversarial-content analysis\n- componentTools — external tools/services the agent invokes\n- componentRAGContent — retrieval-augmented-generation content store\n- componentModelServing — runtime that serves the model for inference\n- componentTrainingData — data used to train/fine-tune the model\n- componentEvalHarnessAndReporting — benchmark selection, running evals, scoring, and generating the report (one node covering three distinct loci)\n\nAltitude check: separately, another contributor wants to attach a 'Report Falsification / Tampering' risk to componentEvalHarnessAndReporting. Same question: absorb, new, or decompose?",
+      "expected_output": "C1 — decompose, same underlying defect as the benchmark-selection case reached from a different angle: this confirms the decompose verdict is driven by componentEvalHarnessAndReporting's own grain problem (reachable from more than one direction), not a one-off artifact of how one case happened to be framed. Report falsification attaches to the reporting locus specifically, distinct from selection and execution — again showing the bundled node isn't reader-instructive. Recommend the same decomposition as case 14.",
+      "expectations": [
+        "Uses only the fixture list, not the live components.yaml, to ground the verdict",
+        "Concludes the outcome is decompose, not absorb and not new",
+        "Identifies that the report-falsification concern attaches to the reporting locus specifically, distinct from selection/execution",
+        "Recognizes this as the same grain defect as a benchmark-selection-style case, reachable from a different angle, not a one-off"
+      ]
     }
   ]
 }

--- a/scripts/skills/altitude-check/evals/fixtures/components-fixture.md
+++ b/scripts/skills/altitude-check/evals/fixtures/components-fixture.md
@@ -1,0 +1,23 @@
+# Component placement fixture
+
+**This is test input, not CoSAI Risk Map content.** It is a small, hand-authored, purpose-built
+stand-in for `risk-map/yaml/components.yaml`, used only to grade eval cases whose correct verdict
+depends on "does anything already cover this candidate" — never the live, growing corpus (see
+ADR-033 Amendment 2026-07-30, D7). It must not be cited, validated, or consumed as if it were real
+Risk Map content. It is refreshed only if the component entity shape changes structurally (e.g. a
+required schema field is added), never in response to the real corpus growing.
+
+Fixture entries:
+
+- `componentAgentReasoningCore` — the agent's core reasoning/decision loop.
+- `componentAgentInputHandling` — validates and normalizes input format/structure (encoding,
+  schema, length) reaching the reasoning core; does not perform semantic or adversarial-content
+  analysis.
+- `componentTools` — external tools and services the agent invokes.
+- `componentRAGContent` — the retrieval-augmented-generation content store.
+- `componentModelServing` — the runtime that serves the model for inference.
+- `componentTrainingData` — data used to train or fine-tune the model.
+- `componentEvalHarnessAndReporting` — benchmark selection, running evals, scoring, and
+  generating the human-facing report, all in one node. **Deliberately over-broad** — three
+  distinct loci (selection, execution, reporting) bundled together, a C3 "not
+  reader-instructive at this grain" failure that should decompose, not merely adjust.

--- a/scripts/skills/audit-framework-mappings/SKILL.md
+++ b/scripts/skills/audit-framework-mappings/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: audit-framework-mappings
+description: Audit all framework mappings in risks.yaml, controls.yaml, and personas.yaml against the framework mappings style guide. Use when reviewing or proposing changes to mappings sections.
+---
+
+# Framework Mappings Audit
+
+Audit framework mappings for correctness, style compliance, and term validity.
+
+## Scope
+
+Target: a single entity id (e.g., `riskModelEvasion`, `controlInputValidationAndSanitization`, `personaEndUser`), or the whole corpus — every entity across `risks.yaml`, `controls.yaml`, `personas.yaml` (the default). If a specific entity id is given, audit only that entity's mappings.
+
+## Reference documents
+
+Read these before auditing:
+
+1. **Style guide** (authoritative): `risk-map/docs/contributing/framework-mappings-style-guide.md`
+
+## Audit checklist
+
+For each entity with mappings, verify ALL of the following. Report pass/fail per item.
+
+### Format and version compliance
+
+Mapping values are **version-pinned** (ADR-027): every value carries its framework's version token. Verify each value against the **canonical pinned pattern for its framework in the authoritative style guide** — read the patterns from the guide, do not restate them from memory (restating them here is how this check previously drifted stale). As of the current guide the pinned forms are, for example:
+
+- **MITRE ATLAS:** `AML.T####@5.0.1` / `AML.T####.###@5.0.1` (techniques), `AML.M####@5.0.1` (mitigations)
+- **NIST AI RMF:** subcategory-level, full function name, version-pinned — e.g. `MEASURE-2.3@1.0`, `GOVERN-6.2@1.0` (never the category alone, never an abbreviation like `MS-2.3`)
+- **STRIDE:** PascalCase, unversioned — `Spoofing`, `Tampering`, `Repudiation`, `InformationDisclosure`, `DenialOfService`, `ElevationOfPrivilege`
+- **OWASP Top 10 for LLM:** `LLM##:2025`
+- **ISO 22989:** the controlled role name, version-pinned `@2022`
+- **EU AI Act:** `Article ##@2024` / `Article ##(#)@2024`
+
+Flag any value whose form or version token does not match the guide's current pinned pattern.
+
+*(This skill AUDITS existing mappings across the corpus; to SELECT mappings while authoring a single control or risk, use the `mapping-selection` skill.)*
+
+### Structural compliance
+
+- [ ] **No parent + sub-technique collisions**: If `AML.T0010.002` is used, `AML.T0010` must NOT appear on the same entity
+- [ ] **No technique/mitigation crossover**: Risks use only `AML.T####`; controls use only `AML.M####`
+- [ ] **applicableTo respected**: Each framework is only used on entity types listed in its `applicableTo` (per style guide table)
+
+### Selectivity compliance
+
+- [ ] **Soft limit (4 per framework)**: Flag any entity with more than 4 mappings in a single framework. Not a hard error, but requires justification.
+- [ ] **Direct relevance**: Each mapping should be defensible with a one-sentence rationale. Flag mappings where the connection is "related" rather than "directly relevant."
+
+### Term and identifier verification
+
+- [ ] **Verify identifiers exist in the source framework.** For MITRE ATLAS, confirm technique/mitigation IDs are real. For OWASP, confirm the category title matches. For ISO 22989, confirm role names match the standard's terminology.
+- [ ] **When proposing new mappings**, search the web to confirm the identifier is current and not deprecated or renamed in the latest version of the framework.
+
+## Coverage analysis (for whole-corpus scope only)
+
+- Count entities with vs. without mappings per entity type
+- Identify unmapped entities where obvious framework matches exist
+- Note underutilized frameworks (e.g., NIST AI RMF, OWASP LLM08)
+- Note STRIDE categories never used
+
+## Output format
+
+For targeted audits (single entity), provide:
+
+1. Current mappings listed per framework
+2. Pass/fail on each checklist item
+3. Any recommended additions or removals with rationale

--- a/scripts/skills/audit-framework-mappings/SKILL.md
+++ b/scripts/skills/audit-framework-mappings/SKILL.md
@@ -23,14 +23,7 @@ For each entity with mappings, verify ALL of the following. Report pass/fail per
 
 ### Format and version compliance
 
-Mapping values are **version-pinned** (ADR-027): every value carries its framework's version token. Verify each value against the **canonical pinned pattern for its framework in the authoritative style guide** — read the patterns from the guide, do not restate them from memory (restating them here is how this check previously drifted stale). As of the current guide the pinned forms are, for example:
-
-- **MITRE ATLAS:** `AML.T####@5.0.1` / `AML.T####.###@5.0.1` (techniques), `AML.M####@5.0.1` (mitigations)
-- **NIST AI RMF:** subcategory-level, full function name, version-pinned — e.g. `MEASURE-2.3@1.0`, `GOVERN-6.2@1.0` (never the category alone, never an abbreviation like `MS-2.3`)
-- **STRIDE:** PascalCase, unversioned — `Spoofing`, `Tampering`, `Repudiation`, `InformationDisclosure`, `DenialOfService`, `ElevationOfPrivilege`
-- **OWASP Top 10 for LLM:** `LLM##:2025`
-- **ISO 22989:** the controlled role name, version-pinned `@2022`
-- **EU AI Act:** `Article ##@2024` / `Article ##(#)@2024`
+Mapping values are **version-pinned** (ADR-027): every value carries its framework's version token, except STRIDE, which is intentionally unversioned. Verify each value against the **canonical pinned pattern for its framework in the authoritative style guide** (`risk-map/docs/contributing/framework-mappings-style-guide.md`, "Identifier Enforcement" table) — read the patterns from the guide every time; do not restate them from memory or inline here. The guide is the single source for pattern and version-token conventions across every supported framework, including any framework registered after this skill was written — new frameworks are a recurring, actively-requested change (see open issues against `frameworks.yaml`), so nothing about the pinned-pattern set may live in two places.
 
 Flag any value whose form or version token does not match the guide's current pinned pattern.
 
@@ -49,8 +42,10 @@ Flag any value whose form or version token does not match the guide's current pi
 
 ### Term and identifier verification
 
-- [ ] **Verify identifiers exist in the source framework.** For MITRE ATLAS, confirm technique/mitigation IDs are real. For OWASP, confirm the category title matches. For ISO 22989, confirm role names match the standard's terminology.
-- [ ] **When proposing new mappings**, search the web to confirm the identifier is current and not deprecated or renamed in the latest version of the framework.
+Two distinct checks — do not conflate them. The first is structural and runs at whatever scope the audit is already covering; the second is a live, per-entity lookup that is never an automatic side effect of the first.
+
+- [ ] **Verify identifiers are well-formed against the style guide's patterns.** For MITRE ATLAS, technique/mitigation IDs match the pinned regex. For OWASP, the category title matches the guide. For ISO 22989, role names match the controlled vocabulary. This is a structural check — no live lookup — and applies at whatever scope the audit already covers, whole-corpus included, the same as the structural-compliance and selectivity checks above.
+- [ ] **Live-verify identifier currency (search the web)** when a specific identifier's currency is actually in question: proposing a new mapping value, or auditing a single **targeted** entity (per Scope) whose identifiers you are specifically confirming. This is a heavier, per-entity check. **It is not run automatically across every entry as a side effect of a whole-corpus audit** — a whole-corpus audit's job is the structural/selectivity/overlap sweep above, not a live web-search of every existing mapping in the file. If comprehensive liveness verification of the full corpus is genuinely wanted, invoke it as its own explicit, separately-requested pass — never as an implicit consequence of the routine audit.
 
 ## Coverage analysis (for whole-corpus scope only)
 

--- a/scripts/skills/audit-framework-mappings/evals/evals.json
+++ b/scripts/skills/audit-framework-mappings/evals/evals.json
@@ -1,0 +1,97 @@
+{
+  "skill_name": "audit-framework-mappings",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Audit this control mapping value: mitre-atlas: [AML.M0028]. Is it conformant?",
+      "expected_output": "Flags the missing version pin — ADR-027 requires AML.M0028@5.0.1 — deferring to the style guide's pinned pattern.",
+      "expectations": [
+        "Flags that the value is missing its version pin (@5.0.1) required by ADR-027",
+        "States the correct form is AML.M0028@5.0.1",
+        "Treats the framework-mappings-style-guide as the authoritative source rather than an unversioned form"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Audit these risk STRIDE values: stride: [tampering, information-disclosure]. Are they formatted correctly?",
+      "expected_output": "Flags the lowercase form; STRIDE is PascalCase (Tampering, InformationDisclosure).",
+      "expectations": [
+        "Flags the STRIDE values as incorrectly cased",
+        "States the correct form is PascalCase (Tampering, InformationDisclosure)",
+        "Does not accept lowercase STRIDE"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Audit this control mapping: mitre-atlas: [AML.T0043@5.0.1]. Is a technique valid on a control?",
+      "expected_output": "Flags technique-on-control: controls map to mitigations (AML.M####), risks map to techniques (AML.T####).",
+      "expectations": [
+        "Flags that controls map to MITRE ATLAS mitigations (AML.M####), not techniques (AML.T####)",
+        "Identifies AML.T0043 as a technique that does not belong on a control"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "A control has 6 NIST AI RMF mappings. Audit for selectivity.",
+      "expected_output": "Flags exceeding the soft limit of 4 per framework; recommends keeping only directly-relevant mappings.",
+      "expectations": [
+        "Flags exceeding the soft limit of ~4 mappings per framework",
+        "Recommends keeping only directly-relevant mappings, each defensible in one sentence"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Audit this persona mapping: iso-22989: [AI Partner (data supplier)]. Is it conformant?",
+      "expected_output": "Flags the missing @2022 version pin; ISO 22989 role descriptors are pinned, so the correct value is 'AI Partner (data supplier)@2022', which is a valid member of the closed controlled-vocabulary enum.",
+      "expectations": [
+        "Flags that the ISO 22989 value is missing its @2022 version pin",
+        "States the correct form is 'AI Partner (data supplier)@2022'",
+        "Confirms the role name is a valid member of the ISO 22989 closed controlled-vocabulary enum (personas-only framework)",
+        "Reads the ISO 22989 rule from the style guide rather than restating it from memory"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Audit this persona mapping: mitre-atlas: [AML.T0020@5.0.1] on personaDataProvider. Is MITRE ATLAS valid on a persona?",
+      "expected_output": "Flags an applicableTo violation: MITRE ATLAS applies to risks and controls only, not personas. The mapping must be removed regardless of whether the identifier is well-formed.",
+      "expectations": [
+        "Flags that MITRE ATLAS is not applicable to personas per the applicableTo table",
+        "States that MITRE ATLAS applies to risks and controls only",
+        "Treats this as a structural (applicableTo) violation, independent of whether the identifier form is correct",
+        "Grounds the applicability decision in the style guide's Framework Applicability table"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Audit this control mapping: owasp-top10-llm: [LLM01]. Is it conformant?",
+      "expected_output": "Flags the missing :2025 version token; OWASP Top 10 for LLM values are pinned as LLM##:2025, so the correct form is LLM01:2025.",
+      "expectations": [
+        "Flags that the OWASP value is missing its :2025 version token",
+        "States the correct form is LLM01:2025",
+        "Notes OWASP uses the colon delimiter (:2025), not the @ token used by other frameworks",
+        "Reads the OWASP pinned pattern from the style guide"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Audit this risk mapping: mitre-atlas: [AML.T0010@5.0.1, AML.T0010.002@5.0.1]. Is it conformant?",
+      "expected_output": "Flags a parent + sub-technique collision: AML.T0010.002 is the more specific match, so AML.T0010 must be dropped. Use only the most specific accurate level.",
+      "expectations": [
+        "Flags the parent + sub-technique collision (AML.T0010 alongside AML.T0010.002)",
+        "States that only the more specific sub-technique (AML.T0010.002@5.0.1) should remain",
+        "Grounds the rule in the style guide's granularity / do-not-map-parent-and-sub-technique guidance"
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "Audit this risk mapping: nist-ai-rmf: [MEASURE-2.3@1.0] on a risk. Is NIST AI RMF valid on a risk?",
+      "expected_output": "Flags an applicableTo violation: NIST AI RMF applies to controls only, not risks. The value is well-formed but the framework does not apply to this entity type and must be removed.",
+      "expectations": [
+        "Flags that NIST AI RMF is not applicable to risks per the applicableTo table",
+        "States that NIST AI RMF applies to controls only (it is control-oriented, with no threat taxonomy)",
+        "Treats this as a structural (applicableTo) violation even though the identifier form is correct",
+        "Grounds the applicability decision in the style guide's Framework Applicability table"
+      ]
+    }
+  ]
+}

--- a/scripts/skills/audit-framework-mappings/evals/evals.json
+++ b/scripts/skills/audit-framework-mappings/evals/evals.json
@@ -105,12 +105,13 @@
     },
     {
       "id": 11,
-      "prompt": "This is a targeted audit of a single control's mappings (not a whole-corpus sweep). Audit this mapping for identifier currency: mitre-atlas: [AML.T9999@5.0.1]. The value is well-formed — is it a real, current MITRE ATLAS identifier?",
-      "expected_output": "The value passes the structural/format check (well-formed AML.T####@5.0.1 pattern) but fails live verification: AML.T9999 is not a real or current MITRE ATLAS technique/mitigation id. Because this is a targeted single-entity audit, live web verification applies; recommends removing or correcting the mapping rather than accepting it on form alone.",
+      "prompt": "This is a targeted audit of a single control's mappings (not a whole-corpus sweep). Audit this mapping for identifier currency: mitre-atlas: [AML.M9999@5.0.1]. The value is well-formed and correctly a mitigation (not a technique) for a control — is it a real, current MITRE ATLAS identifier?",
+      "expected_output": "The value passes every structural check (well-formed AML.M####@5.0.1 pattern; correct mitigation-on-control class, no crossover) but fails live verification: MITRE ATLAS currently has only ~32 mitigations (AML.M0000 through roughly AML.M0031); AML.M9999 is far outside that range and does not exist. Because this is a targeted single-entity audit, live web verification applies; recommends removing or correcting the mapping rather than accepting it on form alone.",
       "expectations": [
-        "Confirms the value passes the structural/format check (correct AML.T####@5.0.1 pattern)",
+        "Confirms the value passes the structural/format check (correct AML.M####@5.0.1 pattern)",
+        "Confirms no technique/mitigation crossover (a mitigation is correct for a control) -- the case is designed so only live verification can fail it, not the structural crossover check",
         "Live-verifies the identifier against the source framework and finds it does not exist / is not current",
-        "Does NOT accept the mapping as conformant merely because its form is well-pinned",
+        "Does NOT accept the mapping as conformant merely because its form and class are correct",
         "Recognizes this as a targeted single-entity audit (per Scope) where live verification is expected, not a whole-corpus sweep that would skip it"
       ]
     }

--- a/scripts/skills/audit-framework-mappings/evals/evals.json
+++ b/scripts/skills/audit-framework-mappings/evals/evals.json
@@ -92,6 +92,27 @@
         "Treats this as a structural (applicableTo) violation even though the identifier form is correct",
         "Grounds the applicability decision in the style guide's Framework Applicability table"
       ]
+    },
+    {
+      "id": 10,
+      "prompt": "Audit this control mapping: eu-ai-act: [Article 9]. Is it conformant?",
+      "expected_output": "Flags the missing version pin — ADR-027 requires Article 9@2024 — deferring to the style guide's pinned pattern.",
+      "expectations": [
+        "Flags that the value is missing its version pin (@2024) required by ADR-027",
+        "States the correct form is Article 9@2024",
+        "Reads the EU AI Act pinned pattern from the style guide rather than restating it from memory"
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "This is a targeted audit of a single control's mappings (not a whole-corpus sweep). Audit this mapping for identifier currency: mitre-atlas: [AML.T9999@5.0.1]. The value is well-formed — is it a real, current MITRE ATLAS identifier?",
+      "expected_output": "The value passes the structural/format check (well-formed AML.T####@5.0.1 pattern) but fails live verification: AML.T9999 is not a real or current MITRE ATLAS technique/mitigation id. Because this is a targeted single-entity audit, live web verification applies; recommends removing or correcting the mapping rather than accepting it on form alone.",
+      "expectations": [
+        "Confirms the value passes the structural/format check (correct AML.T####@5.0.1 pattern)",
+        "Live-verifies the identifier against the source framework and finds it does not exist / is not current",
+        "Does NOT accept the mapping as conformant merely because its form is well-pinned",
+        "Recognizes this as a targeted single-entity audit (per Scope) where live verification is expected, not a whole-corpus sweep that would skip it"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Phase 2c · audit-framework-mappings skill

Closes #418
Addresses #404

### Summary

Adds the `audit-framework-mappings` skill — checks that an entry's external-framework mappings are well-formed and correctly scoped across the supported frameworks. It owns the framework-mapping discipline that `mapping-selection` defers to.

### What's included

- `scripts/skills/audit-framework-mappings/` — `SKILL.md`, `evals/evals.json`. No internal `references/` — the skill defers entirely to `risk-map/docs/contributing/framework-mappings-style-guide.md` as the single authoritative source for pattern/version-token conventions (ADR-031 D2's "no per-framework reference-pack skills" principle), rather than shipping a second, independently-driftable copy.
- One README roster bullet.

### Ordering

Follows: **Phase 2b · altitude-check** (`feature/phase2-altitude-check`). Precedes: **Phase 2d · audit-identification-questions** (`feature/phase2-audit-identification-questions`).
