### PR TITLE
Phase 2d · audit-identification-questions skill

### DIFF
--- a/docs/adr/031-authoring-time-agents-and-skills.md
+++ b/docs/adr/031-authoring-time-agents-and-skills.md
@@ -183,4 +183,4 @@ Because the standard is maintained externally and versions on its own cadence, c
 **Follow-up**
 
 - **Maintainer sign-off flips this amendment `Draft → Accepted`.**
-- `scripts/skills/README.md`'s roster entry for `audit-identification-questions` currently cites "(ADR-031 D5, ADR-021 D7)" — D5 is the Persona creator/critic sequencing section and does not admit this skill. Update the citation to point at this amendment's D7 once accepted.
+- `scripts/skills/README.md`'s roster entry for `audit-identification-questions` cited "(ADR-031 D5, ADR-021 D7)" — D5 is the Persona creator/critic sequencing section and does not admit this skill. Already corrected in the same commit as this amendment to cite ADR-021 D7 (responsibility) and this D7 (admission), rather than waiting on Accept.

--- a/docs/adr/031-authoring-time-agents-and-skills.md
+++ b/docs/adr/031-authoring-time-agents-and-skills.md
@@ -144,3 +144,43 @@ Because the standard is maintained externally and versions on its own cadence, c
 - Curation ownership (settled): the NIST-first term set and the escape-hatch adjudication (D3a) are owned by maintainers via CoSAI governance review (issues, offline discussion); the global-legitimacy check (D3b) is materialized by the classical-lexicon skill, which records the cross-standard equivalence set and flags parochialism / naming-conflict gaps for maintainers to carry into that review; STABLE-snapshot re-pinning (D4) is triggered per framework-version bump through the existing ADR-027 mapping cadence. Implementation obligation: the classical-lexicon skill must include the equivalence-recording and gap-flagging behavior so the maintainer can establish global legitimacy correctly.
 - This ADR introduces `scripts/skills/` as a new canonical, tracked directory — none exists today. The skill format is decided in D6 (the Agent Skills open standard); the first skill PR establishes the on-disk layout and pins the spec revision the canonical surface targets (D6), setting the pattern every later skill follows.
 - A lightweight consistency check that the authoring skills/agents and their source rules (the contributing guides) stay in sync is deferred to the backlog. Until it exists, D1's "reference the source, don't re-derive" mandate is enforced by review.
+
+## Amendment 2026-08-02: Admission of `audit-identification-questions` as a fifth authoring skill
+
+**Status:** Draft (2026-08-02). Adds D7; does not alter the Accepted status of D1–D6 above.
+**Authors:** maintainer review, prompted by PR review.
+
+### Context
+
+[D2](#d2-agent-vs-skill-boundary) named four skills at authoring time (2026-07-01): `classical-lexicon`, `mapping-selection`, `altitude-check`, `audit-framework-mappings`. A fifth skill, `audit-identification-questions`, was subsequently built and shipped to `scripts/skills/` (PR #433) without going through the admission this ADR's own governing standard, [ADR-033 D6](033-vendor-neutral-agent-skill-shipping.md), requires: *"A new agent or skill enters the shipped set by an amendment to the relevant ADR ... or a new ADR that conforms to this standard ... not by dropping a file, but by an ADR-level decision that admits it and records that it conforms."* [ADR-021 D7](021-personas-and-self-assessment-schema.md) recognizes the skill's editorial-review responsibility, but ADR-021 D7 answers a different question (what the skill is *for*) than the one this amendment answers (whether it is admitted to *this* ADR's shipped roster and whether it conforms to ADR-033). PR #433's own description described the skill as completing "the last of the four ADR-031 D2 authoring skills" — text that is simply wrong against D2's actual four-item enumeration, and is corrected by this amendment rather than repeated.
+
+### D7. Admission of `audit-identification-questions`
+
+**Why a fifth skill, not a fold-in.** The skill is the same *shape* as `audit-framework-mappings` (D2): an audit skill that defers editorial/format rules to a style guide (`identification-questions-style-guide.md`) rather than restating them, covering ground content-reviewer's mechanical structural checks cannot reach — leading-question framing, scoping-clause completeness, example-parenthetical judgment. It does not fold into any of the original four; its editorial surface (identification questions) is distinct from theirs (terminology, selection judgment, altitude, framework-mapping correctness).
+
+**ADR-033 D1-D5 conformance:**
+
+- **D1 (canonical-only, neutral, cloneable):** ships only as its neutral canonical form at `scripts/skills/audit-identification-questions/SKILL.md`; no first-party harness wrapper is tracked in-repo.
+- **D2 (the neutrality contract):** the shipped file carries no denylisted harness- or vendor-specific tokens; the D5 neutrality check passes against it.
+- **D3 (consumer leverage):** defers editorial rules to `identification-questions-style-guide.md` rather than restating them.
+- **D4 (shipping format):** ships in the Agent Skills open standard fixed by [D6](#d6-skill-format-the-agent-skills-open-standard), the same format as the original four.
+- **D5 (a neutrality check is required):** the ADR-033 D5 check passes.
+- **Portable eval:** ships at `scripts/skills/audit-identification-questions/evals/evals.json`.
+
+`audit-identification-questions` is admitted to the shipped set as of this amendment's acceptance. From this point forward, [D2](#d2-agent-vs-skill-boundary)'s original "four skills" language describes the roster **as decided on 2026-07-01**, not the current shipped count; `scripts/skills/README.md` and any other roster-count text should read **five**.
+
+### Consequences
+
+**Positive**
+
+- `scripts/skills/` no longer has a skill operating without a recorded ADR-033 D6 admission. The gap PR #433's review surfaced is closed the same way the ADR-008 amendment closed the analogous gap for `draft-issue-comment` (D6 above, the standing pattern for exactly this situation — though this ADR is itself the "relevant ADR" here, so the admission lands in-place rather than in a different document).
+- D2's original text is preserved as the historical record of the 2026-07-01 decision; nothing about the "four skills" framing needed to be correct in hindsight, only clearly superseded.
+
+**Negative**
+
+- A reader who stops at D2 without reaching this amendment will undercount the roster by one. Mitigated by this section explicitly flagging D2's language as decision-time, not current.
+
+**Follow-up**
+
+- **Maintainer sign-off flips this amendment `Draft → Accepted`.**
+- `scripts/skills/README.md`'s roster entry for `audit-identification-questions` currently cites "(ADR-031 D5, ADR-021 D7)" — D5 is the Persona creator/critic sequencing section and does not admit this skill. Update the citation to point at this amendment's D7 once accepted.

--- a/scripts/skills/README.md
+++ b/scripts/skills/README.md
@@ -68,3 +68,7 @@ python3 scripts/hooks/precommit/validate_neutrality.py scripts/skills/<name>/SKI
   risks, controls, and personas against the framework-mappings style
   guide (version pinning, applicability, selectivity), deferring format
   to the style guide (ADR-031 D2, ADR-027).
+- `audit-identification-questions/` — audits persona identification
+  questions against the identification-questions style guide (framing,
+  scoping, examples, ordering), deferring the rules to the style guide
+  (ADR-031 D5, ADR-021 D7).

--- a/scripts/skills/README.md
+++ b/scripts/skills/README.md
@@ -70,5 +70,6 @@ python3 scripts/hooks/precommit/validate_neutrality.py scripts/skills/<name>/SKI
   to the style guide (ADR-031 D2, ADR-027).
 - `audit-identification-questions/` — audits persona identification
   questions against the identification-questions style guide (framing,
-  scoping, examples, ordering), deferring the rules to the style guide
-  (ADR-031 D5, ADR-021 D7).
+  scoping, examples, ordering), deferring the rules to the style guide.
+  Editorial responsibility per ADR-021 D7; admitted to this roster per the
+  [2026-08-02 ADR-031 amendment](../../docs/adr/031-authoring-time-agents-and-skills.md#amendment-2026-08-02-admission-of-audit-identification-questions-as-a-fifth-authoring-skill) D7.

--- a/scripts/skills/audit-identification-questions/SKILL.md
+++ b/scripts/skills/audit-identification-questions/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: audit-identification-questions
+description: Audit persona identification questions in personas.yaml against the identification questions style guide. Use when reviewing or proposing changes to identificationQuestions.
+---
+
+# Identification Questions Audit
+
+Audit persona identification questions for style guide compliance, boundary clarity, and term validity.
+
+## Scope
+
+Target: a single persona id, or `all` to audit every non-deprecated persona in `personas.yaml` (default).
+
+If a specific persona ID is provided (e.g., `personaAgenticProvider`), audit only that persona's questions.
+
+## Reference documents
+
+Read these before auditing:
+
+1. **Style guide** (authoritative): `risk-map/docs/contributing/identification-questions-style-guide.md`
+
+## Audit checklist
+
+For each persona with `identificationQuestions`, verify ALL of the following. Report pass/fail per item.
+
+**Passing the mechanical checks (Structure, Examples format) does not make a question conformant.** The editorial checks — Framing (an activity, not a role/title or a third party), Scoping, and especially **"including" for scope expansion** — take judgment against the style guide and are the *most common* remaining issue on a question that already looks clean. Do not return a conformant verdict until you have positively evaluated each editorial check on its merits — e.g. a base term narrow enough that a reader might wrongly exclude themselves, used without an "including" clause, is a scope-expansion flag even when structure and format are perfect.
+
+### Structure
+
+- [ ] **Count 5-7**: Between 5 and 7 questions inclusive
+- [ ] **Yes/no answerable**: Every question can be answered with yes or no
+- [ ] **No embedded conditionals**: No nested conditions requiring evaluation before answering
+
+### Framing
+
+- [ ] **Second-person, activity-focused**: Questions ask what *you* do — "Do you…", "Are you…", "Does your team…" — about the reader's activities. Avoid framings about a system/platform/product ("Is your system…", "Does your platform…") and third-person framings about other roles ("Do developers…").
+- [ ] **Activity-focused**: Questions describe what the reader does, not what their job title is or what their product is
+
+### Scoping and boundaries
+
+- [ ] **Scoping clauses present**: Where an activity is shared with an adjacent persona, a scoping clause disambiguates (e.g., "as a framework author rather than as an application developer")
+- [ ] **No overlapping questions**: No two questions ask effectively the same thing at different abstraction levels. If overlap exists, merge or add a scoping clause.
+
+### Examples and terminology
+
+- [ ] **Parenthetical examples**: Technical terms have parenthetical examples using `(e.g., item1, item2, item3)` format — NOT "such as" inline, NOT parenthetical without "e.g."
+- [ ] **Example list length**: Parenthetical lists have 2-4 items
+- [ ] **"including" for scope expansion**: Used where the base term might be read too narrowly
+
+### Ordering
+
+- [ ] **Question ordering**: Most distinguishing activity first, scope-expanding questions in the middle, boundary-clarifying questions last
+
+## Term verification (critical)
+
+When reviewing or proposing parenthetical examples (the `(e.g., ...)` items):
+
+1. **Search the web** to confirm each term has strong real-world usage in the relevant ecosystem
+2. Check major frameworks, tools, and documentation (e.g., LangChain, Semantic Kernel, Vertex AI, CrewAI, etc.)
+3. If a proposed term is not an established concept, find the industry-standard term for the same idea
+4. Flag any term that is:
+   - Not used in any major framework's documentation
+   - Deprecated or renamed in the latest version
+   - A colloquial shorthand rather than a concrete, recognized component or pattern
+5. Provide sources/evidence for term validation
+
+## Coverage analysis (for `all` scope only)
+
+- List all non-deprecated personas with vs. without identification questions
+- Calculate per-persona compliance scores (checklist pass rate)
+- Calculate aggregate compliance score
+- Prioritize missing personas by disambiguation value (how adjacent they are to other personas)
+
+## Proposing rewrites
+
+When proposing rewritten questions:
+
+1. Show the current question and the proposed replacement side by side
+2. Identify which checklist items the rewrite fixes
+3. For any new parenthetical examples, include term verification results
+4. Ensure the rewrite does not introduce new violations
+
+## Output format
+
+For targeted audits (single persona), provide:
+
+1. All current questions listed
+2. Pass/fail on each checklist item with notes
+3. Specific violations with remediation suggestions
+4. Term verification results for any proposed example terms

--- a/scripts/skills/audit-identification-questions/SKILL.md
+++ b/scripts/skills/audit-identification-questions/SKILL.md
@@ -43,10 +43,15 @@ For each persona with `identificationQuestions`, verify ALL of the following. Re
 
 ### Examples and terminology
 
-- [ ] **Parenthetical examples**: Technical terms have parenthetical examples using `(e.g., item1, item2, item3)` format — NOT "such as" inline
+- [ ] **Parenthetical examples where needed**: When a technical term may be unfamiliar or ambiguous, use parenthetical examples in `(e.g., item1, item2, item3)` format — NOT "such as" inline
 - [ ] **`e.g.` not `i.e.`**: parentheticals signal an illustrative list, never an exhaustive one — read the exact rule from the style guide's Rule enforcement summary
 - [ ] **Example list length**: read the item-count bound from the style guide's Rule enforcement summary rather than restating it here
 - [ ] **"including" for scope expansion**: Used where the base term might be read too narrowly
+
+### Neutrality and assumptions
+
+- [ ] **No embedded assumptions**: Do not constrain an activity with implementation details that are not part of the persona boundary (e.g. "GPU clusters in the cloud" excludes an on-premises or other-hardware actor who should still answer yes).
+- [ ] **Neutral wording**: Questions do not lead or nudge the reader toward answering "yes."
 
 ### Ordering
 

--- a/scripts/skills/audit-identification-questions/SKILL.md
+++ b/scripts/skills/audit-identification-questions/SKILL.md
@@ -27,13 +27,13 @@ For each persona with `identificationQuestions`, verify ALL of the following. Re
 
 ### Structure
 
-- [ ] **Count 5-7**: Between 5 and 7 questions inclusive
+- [ ] **Count in range**: read the count bound from the style guide's Rule enforcement summary (`validate-identification-questions` hook) rather than restating the number here
 - [ ] **Yes/no answerable**: Every question can be answered with yes or no
 - [ ] **No embedded conditionals**: No nested conditions requiring evaluation before answering
 
 ### Framing
 
-- [ ] **Second-person, activity-focused**: Questions ask what *you* do — "Do you…", "Are you…", "Does your team…" — about the reader's activities. Avoid framings about a system/platform/product ("Is your system…", "Does your platform…") and third-person framings about other roles ("Do developers…").
+- [ ] **Second-person, activity-focused**: Questions ask what *you* do about the reader's own activities, using the approved second-person openers listed in the style guide's Rule enforcement summary. Avoid framings about a system/platform/product ("Is your system…", "Does your platform…") and third-person framings about other roles ("Do developers…").
 - [ ] **Activity-focused**: Questions describe what the reader does, not what their job title is or what their product is
 
 ### Scoping and boundaries
@@ -43,8 +43,9 @@ For each persona with `identificationQuestions`, verify ALL of the following. Re
 
 ### Examples and terminology
 
-- [ ] **Parenthetical examples**: Technical terms have parenthetical examples using `(e.g., item1, item2, item3)` format — NOT "such as" inline, NOT parenthetical without "e.g."
-- [ ] **Example list length**: Parenthetical lists have 2-4 items
+- [ ] **Parenthetical examples**: Technical terms have parenthetical examples using `(e.g., item1, item2, item3)` format — NOT "such as" inline
+- [ ] **`e.g.` not `i.e.`**: parentheticals signal an illustrative list, never an exhaustive one — read the exact rule from the style guide's Rule enforcement summary
+- [ ] **Example list length**: read the item-count bound from the style guide's Rule enforcement summary rather than restating it here
 - [ ] **"including" for scope expansion**: Used where the base term might be read too narrowly
 
 ### Ordering

--- a/scripts/skills/audit-identification-questions/evals/evals.json
+++ b/scripts/skills/audit-identification-questions/evals/evals.json
@@ -1,0 +1,78 @@
+{
+  "skill_name": "audit-identification-questions",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Audit this identification question: 'Do developers building on your framework configure model access policies?'",
+      "expected_output": "Flags the third-person framing ('Do developers'); should be second-person about the reader's own activity.",
+      "expectations": [
+        "Flags the third-person framing ('Do developers') as a violation",
+        "States questions should be second-person, about what the reader does",
+        "Suggests a second-person rewrite"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "A persona has 9 identification questions. Audit the structure.",
+      "expected_output": "Flags the count as outside the 5-7 range; recommends reducing.",
+      "expectations": [
+        "Flags that the count (9) exceeds the 5-7 range",
+        "Recommends reducing to 5-7 questions"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Audit the example format in this question: 'Do you use agent frameworks such as LangChain and CrewAI?'",
+      "expected_output": "Flags the 'such as' inline form; the required format is parenthetical '(e.g., LangChain, CrewAI)'.",
+      "expectations": [
+        "Flags 'such as' inline as non-conformant",
+        "States the required format is parenthetical (e.g., item1, item2)",
+        "Notes the 2-4 item length guidance"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Audit this question, which the author believes is already clean: 'Are you responsible for training or fine-tuning foundation models (e.g., pre-training, RLHF, instruction tuning)?'",
+      "note": "Recalibrated after a smoke run: the question is NOT fully clean by the guide — the skill correctly caught guide-grounded issues without manufacturing nits.",
+      "expected_output": "Confirms the strong parts, but catches the narrow-scope issue ('foundation models' should use an 'including' scope-expansion) and/or the 'responsible for' role-vs-activity framing — grounding each flag in the style guide.",
+      "expectations": [
+        "Confirms the conformant parts (second-person 'Are you', correct (e.g., ...) parenthetical with 2-4 items, yes/no answerable)",
+        "Catches the narrow-scope issue ('foundation models' should use an 'including' scope-expansion per the guide) and/or the 'responsible for' role-vs-activity framing",
+        "Grounds each flag in the style guide rather than asserting ungrounded or manufactured violations"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Audit this identification question for the Agentic Platform and Framework Providers persona: 'Do you connect large language models to external APIs, tools, or services?' Note that the Application Developer persona also integrates models with external services.",
+      "note": "Scoping-clause presence. The activity (connecting LLMs to external services) is shared with the adjacent Application Developer persona; the corpus resolves it with a framework-vs-application scoping clause (personaAgenticProvider Q3 says 'as a reusable framework or platform rather than a single application'). The bare question lets both personas answer yes.",
+      "expected_output": "Flags the missing scoping clause: the activity is shared with the Application Developer persona, so a clause distinguishing the framework/platform provider from a single-application integrator is required. Suggests a clause modeled on the guide's shared-activity rule.",
+      "expectations": [
+        "Flags that the activity is shared with an adjacent persona (Application Developer) and lacks a disambiguating scoping clause",
+        "States the style guide's rule that a shared activity needs a scoping clause assigning it to exactly one persona",
+        "Suggests a scoping clause (e.g., 'as a reusable framework or platform rather than a single application') and grounds it in the guide"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Audit these two identification questions from the same persona: 'Do you train AI models?' and 'Do you build or create machine learning models?'",
+      "note": "No-overlapping-questions. This is the style guide's explicit overlapping-questions anti-pattern: two questions describing the same activity at different abstraction levels. Remedy is merge or add a scoping clause.",
+      "expected_output": "Flags the two questions as overlapping — they ask effectively the same thing at different abstraction levels — and recommends merging them or adding a scoping clause to distinguish them.",
+      "expectations": [
+        "Flags the two questions as overlapping / asking effectively the same thing",
+        "Identifies this as the style guide's overlapping-questions anti-pattern",
+        "Recommends merging the two questions or adding a scoping clause to differentiate them"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Audit the ordering of these questions for a persona, in this order: (1) 'Do you provide integration layers as a reusable framework rather than as a single application?' (2) 'Do you build or maintain software that orchestrates which tools an AI model invokes (e.g., tool-calling frameworks, agent orchestrators, or planning engines)?' (3) 'Do you define the agent architecture for AI systems (e.g., reasoning loops, planning workflows, or reflection patterns)?'",
+      "note": "Ordering. Question 1 is a boundary-clarifying question (it carries the framework-vs-application scoping clause) but is placed first; the guide says the most distinguishing activity leads and boundary-clarifying questions come last.",
+      "expected_output": "Flags the ordering: the boundary-clarifying question (Q1, with the 'reusable framework rather than a single application' scoping clause) is placed first but should come last; the most distinguishing activity (tool orchestration) should lead.",
+      "expectations": [
+        "Flags that a boundary-clarifying / scoping-clause question is placed first instead of last",
+        "States the style guide's ordering rule (most distinguishing activity first, boundary-clarifying questions last)",
+        "Suggests reordering so the most distinguishing question leads and the boundary-clarifying question ends the list"
+      ]
+    }
+  ]
+}

--- a/scripts/skills/audit-identification-questions/evals/evals.json
+++ b/scripts/skills/audit-identification-questions/evals/evals.json
@@ -73,6 +73,17 @@
         "States the style guide's ordering rule (most distinguishing activity first, boundary-clarifying questions last)",
         "Suggests reordering so the most distinguishing question leads and the boundary-clarifying question ends the list"
       ]
+    },
+    {
+      "id": 8,
+      "prompt": "Audit the example terms in this question: 'Do you orchestrate multi-agent workflows (e.g., LangGraph, AutoGPT-Prime, CrewAI)?'",
+      "expected_output": "LangGraph and CrewAI are real, established multi-agent orchestration frameworks with strong real-world usage; 'AutoGPT-Prime' does not correspond to any established framework, tool, or documented variant -- it is a fabricated/colloquial-sounding term. Flags AutoGPT-Prime specifically and does not flag LangGraph or CrewAI.",
+      "expectations": [
+        "Confirms LangGraph and CrewAI as established, real frameworks (does not flag them)",
+        "Flags 'AutoGPT-Prime' as not an established or verifiable term",
+        "States it searched for real-world usage rather than accepting the term on its plausible-sounding name alone",
+        "Does not accept the parenthetical as conformant just because two of the three terms are real"
+      ]
     }
   ]
 }

--- a/scripts/skills/audit-identification-questions/evals/evals.json
+++ b/scripts/skills/audit-identification-questions/evals/evals.json
@@ -84,6 +84,30 @@
         "States it searched for real-world usage rather than accepting the term on its plausible-sounding name alone",
         "Does not accept the parenthetical as conformant just because two of the three terms are real"
       ]
+    },
+    {
+      "id": 9,
+      "prompt": "Audit this identification question: 'Do you want to make sure your AI models are properly secured against unauthorized access?'",
+      "note": "Leading-question anti-pattern with a mechanically valid opener. 'Do you' is a hook-approved second-person opener, and the question is yes/no answerable -- structure and Framing checks pass. This isolates the editorial leading-question detection from the opener/structure hooks: the question nudges toward 'yes' (nobody would admit to not wanting security) rather than identifying a concrete activity the reader either does or does not perform.",
+      "expected_output": "Flags the question as leading -- it nudges the reader toward 'yes' via a value judgment ('want to make sure ... properly secured') rather than asking about a concrete activity. Notes that structure/opener checks pass (this is not a third-person or count violation) but the editorial neutrality check fails. Suggests a rewrite that asks about a specific activity instead (e.g., what the reader actually does for model access control).",
+      "expectations": [
+        "Flags the question as a leading question that nudges toward 'yes'",
+        "Identifies this as the style guide's leading-questions anti-pattern, not a structural violation",
+        "Notes the mechanical checks (second-person opener, yes/no answerable) pass on their own, so this is caught by editorial judgment, not the hook",
+        "Suggests a rewrite framed around a concrete, neutral activity rather than a value judgment"
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "Audit this identification question: 'Do you train models using GPU clusters in the cloud?'",
+      "note": "Binary question with an embedded assumption -- the style guide's own worked anti-pattern example, used directly so the case is traceable to its source.",
+      "expected_output": "Flags 'GPU clusters in the cloud' as an implementation-detail assumption that is not part of the persona boundary -- it improperly excludes a valid actor who trains on-premises or with other hardware. Suggests dropping the hardware/location constraint (e.g., 'Do you train models?' or similar, scoped only by the activity that actually matters).",
+      "expectations": [
+        "Flags the 'GPU clusters in the cloud' clause as an embedded assumption/implementation detail",
+        "States this would incorrectly exclude a valid actor (on-premises or other-hardware training)",
+        "Identifies this as the style guide's binary-question-with-embedded-assumptions anti-pattern",
+        "Suggests removing the hardware/location constraint rather than just narrowing it"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Phase 2d · audit-identification-questions skill

Closes #419
Addresses #404

### Summary

Adds the `audit-identification-questions` skill — checks a persona's `identificationQuestions` for distinguishing power. This is the persona-authoring discipline `persona-creator` applies. It is a fifth authoring skill beyond ADR-031 D2's original four; the 2026-08-02 ADR-031 amendment (D7) admits it per ADR-033 D6's requirement that a new skill enter the shipped set through an ADR-level decision.

### What's included

- `scripts/skills/audit-identification-questions/` — `SKILL.md`, `evals/evals.json`.
- One README roster bullet.

### Ordering

Follows: **Phase 2c · audit-framework-mappings** (`feature/phase2-audit-framework-mappings`). Precedes: **Phase 3a · control agents** (`feature/phase3-control`).
