### PR TITLE
fix(agents): content-reviewer.md cites the schema instead of enumerating taxonomy ids

### DIFF
--- a/scripts/agents/content-reviewer.md
+++ b/scripts/agents/content-reviewer.md
@@ -93,7 +93,7 @@ This agent reads schema and corpus files directly via its own tool access when a
 
 ### ADR Citation Resolution
 
-Corpus content, PR descriptions, and prior review findings sometimes cite a specific decision as `ADR-0NN DN` (e.g. `ADR-030 D5`). Cross-cutting rules are uniformly `D`-numbered across the ADR set — there is no separate `P` tier to disambiguate. Resolve every such citation before relying on it or repeating it in a finding: read `docs/adr/0NN-*.md` and find the `### DN.` heading; do not accept a paraphrase, a title, or an inference about what a decision says as a substitute for its actual text. A rule that a decision states applies "throughout" the document can still sit inside a sub-paragraph whose surrounding heading reads as being about something else entirely — the citation is only as good as the text it resolves to.
+Corpus content, PR descriptions, and prior review findings sometimes cite a specific decision as `ADR-0NN DN` (e.g. `ADR-030 D5`). Most ADRs number cross-cutting rules `D1`, `D2`, ...; some earlier ADRs — e.g. ADR-014 — use `P1`-`P6` instead. Resolve every such citation before relying on it or repeating it in a finding: read `docs/adr/0NN-*.md` and find the heading matching the exact identifier cited (`### D5.`, `### P2.`, whichever the citation names); do not accept a paraphrase, a title, or an inference about what a decision says as a substitute for its actual text. A rule that a decision states applies "throughout" the document can still sit inside a sub-paragraph whose surrounding heading reads as being about something else entirely — the citation is only as good as the text it resolves to.
 
 ### Content Types & Key Fields
 

--- a/scripts/agents/content-reviewer.md
+++ b/scripts/agents/content-reviewer.md
@@ -88,6 +88,8 @@ If provided, use them to supplement (not override) the embedded schema awareness
 
 ## Schema Awareness
 
+This agent reads schema and corpus files directly via its own tool access when a check below says "consult the schema" or "consult the corpus" — that instruction does not depend on the caller pasting schema content into the prompt. The Input Contract's "caller may optionally provide schema files" above describes an inline convenience (skipping a tool call when the caller already has the file open), not a hard dependency the checks below assume.
+
 ### Content Types & Key Fields
 
 **Risks** (`risks.yaml`):

--- a/scripts/agents/content-reviewer.md
+++ b/scripts/agents/content-reviewer.md
@@ -68,6 +68,7 @@ The caller specifies output style via a format flag:
    - `components.yaml`
    - `personas.yaml`
    - `risk-map/yaml/archive/self-assessment-legacy.yaml` (reference only — archived per ADR-021 D6; not a review target)
+   - `docs/adr/` — the tooling/infrastructure ADR set, consulted whenever a corpus claim cites or should be checked against a specific decision (see ADR Citation Resolution below)
 
 **For `issue` mode:**
 
@@ -89,6 +90,10 @@ If provided, use them to supplement (not override) the embedded schema awareness
 ## Schema Awareness
 
 This agent reads schema and corpus files directly via its own tool access when a check below says "consult the schema" or "consult the corpus" — that instruction does not depend on the caller pasting schema content into the prompt. The Input Contract's "caller may optionally provide schema files" above describes an inline convenience (skipping a tool call when the caller already has the file open), not a hard dependency the checks below assume.
+
+### ADR Citation Resolution
+
+Corpus content, PR descriptions, and prior review findings sometimes cite a specific decision as `ADR-0NN DN` (e.g. `ADR-030 D5`). Cross-cutting rules are uniformly `D`-numbered across the ADR set — there is no separate `P` tier to disambiguate. Resolve every such citation before relying on it or repeating it in a finding: read `docs/adr/0NN-*.md` and find the `### DN.` heading; do not accept a paraphrase, a title, or an inference about what a decision says as a substitute for its actual text. A rule that a decision states applies "throughout" the document can still sit inside a sub-paragraph whose surrounding heading reads as being about something else entirely — the citation is only as good as the text it resolves to.
 
 ### Content Types & Key Fields
 

--- a/scripts/agents/content-reviewer.md
+++ b/scripts/agents/content-reviewer.md
@@ -95,7 +95,7 @@ If provided, use them to supplement (not override) the embedded schema awareness
 - Required: `id`, `title`, `description`, `category`
 - Relationships: mapped to controls that mitigate them
 - Personas: parties **impacted by** the risk (who bears the consequences). `personaEndUser` appears on most risks. `personaGovernance` is NOT used on risks (it appears exclusively on controls).
-- Categories (enum in `risks.schema.json`): `risksSupplyChainAndDevelopment`, `risksDeploymentAndInfrastructure`, `risksRuntimeInputSecurity`, `risksRuntimeDataSecurity`, `risksRuntimeOutputSecurity`
+- Categories: enum in `risks.schema.json`'s `category` definition; consult the schema rather than inferring
 - May include framework references: MITRE ATLAS, NIST AI RMF, OWASP Top 10 for LLM
 
 **Controls** (`controls.yaml`):
@@ -109,7 +109,7 @@ If provided, use them to supplement (not override) the embedded schema awareness
 
 - Required: `id`, `title`, `description`, `category`
 - Relationships: `to` and `from` edges (bidirectional, validated by external tooling)
-- Categories: `componentsData`, `componentsInfrastructure`, `componentsModel`, `componentsApplication`
+- Categories: category enum + conditional category/subcategory constraint in `components.schema.json`, mirrored in the `categories:` block of `components.yaml`; consult those rather than inferring (a category only accepts specific subcategories, and a subcategory is not itself a category)
 
 **Personas** (`personas.yaml`):
 


### PR DESCRIPTION
## fix(agents): content-reviewer.md cites the schema instead of enumerating taxonomy ids

Closes: #453 

### Summary

`scripts/agents/content-reviewer.md` hardcoded the components category list as `componentsData, componentsInfrastructure, componentsModel, componentsApplication`. 

This is wrong today, independent of any branch: `componentsData` is a **subcategory** of `componentsInfrastructure`, not a peer category (confirmed against the live schema enum, which has exactly three: `componentsInfrastructure`, `componentsModel`, `componentsApplication`). 

The risks category list a few lines above had the same shape of problem — currently correct, but a value copy that goes stale the next time the taxonomy changes rather than a citation that stays correct.

Both replaced with citations to the schema/corpus, matching the file's own stated rule 16 lines below the bug ("Authoritative enums live in the per-type `*.schema.json` files; consult those rather than inferring") and the pattern ADR-031 D1 already mandates ("reference the source rather than re-deriving it").

### What's included

- `scripts/agents/content-reviewer.md` — the risks and components category bullets now point at `risks.schema.json` / `components.schema.json` + `components.yaml`'s `categories:` block instead of listing values.

### Why now

Surfaced while checking what an in-flight component-taxonomy rename  would break against the agent-spec surface. The rename didn't cause this bug — it's wrong against `main` today — but it's the reason it was found: a citation is timeline-invariant, so this fix has no dependency on and no conflict with that work landing.

### Test plan

- `pytest scripts/hooks/tests/test_validate_neutrality.py` — 152 passed.
- Full suite — 3633 passed, 6 skipped (pre-existing, unrelated).
- Pre-commit hooks pass on the change (vendor-neutrality check: Passed).

### Follow-up

A backlog issue tracks building the automated lint ADR-031 already deferred ("a lightweight consistency check... is deferred to the backlog") so this class of drift is caught mechanically instead of by review.