### PR TITLE
ADR-034 follow-up: D3a guard + contributor landing-sequence guide

### DIFF
--- a/docs/adr/034-corpus-change-landing-sequence.md
+++ b/docs/adr/034-corpus-change-landing-sequence.md
@@ -1,6 +1,6 @@
 # ADR-034: Dependency-ordered landing sequence for risk-map corpus changes
 
-**Status:** Draft
+**Status:** Accepted
 **Date:** 2026-07-09
 **Authors:** Architect agent, with maintainer review
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,7 +49,7 @@ If a decision is about *how the Risk Map content model is shaped*, it belongs in
 | [031](031-authoring-time-agents-and-skills.md) | Authoring-time agents and skills for Risk Map content — creator + critic agents, classical-lexicon / mapping-selection / altitude-check / audit-framework-mappings skills | Accepted | 2026-07-01 |
 | [032](032-consumer-exploration-skills.md) | Read-only consumer exploration skill surface (explore-* skills) | Accepted | 2026-07-06 |
 | [033](033-vendor-neutral-agent-skill-shipping.md) | Vendor-neutral shipping and lifecycle for CoSAI agents and skills — canonical-only neutral cloneable artifacts, the neutrality contract (machine-checkable denylist + framework-authority allowlist), consumer adaptation, required neutrality check, develop/eval/expand lifecycle | Accepted | 2026-07-08 |
-| [034](034-corpus-change-landing-sequence.md) | Dependency-ordered landing sequence for risk-map corpus changes | Draft | 2026-07-09 |
+| [034](034-corpus-change-landing-sequence.md) | Dependency-ordered landing sequence for risk-map corpus changes | Accepted | 2026-07-09 |
 | [035](035-pinned-sources-manifest.md) | Pinned-sources manifest (`risk-map/yaml/sources.yaml`) for reproducible citation provenance — corpus-wide registry, disjoint-by-role sibling to `frameworks.yaml`, keep-and-flag fallback; implements ADR-031 D4 | Draft | 2026-07-22 |
 
 ## Conventions

--- a/risk-map/docs/contributing/landing-sequence.md
+++ b/risk-map/docs/contributing/landing-sequence.md
@@ -1,0 +1,133 @@
+# Landing Sequence for Corpus Changes
+
+This guide is the step-by-step companion to ADR-034 (Dependency-ordered landing sequence for risk-map corpus changes). ADR-034 records the decision and rationale; this guide records the how-to — which files you edit, in which layer, and in what order, for your specific change.
+
+If you're proposing a new risk, control, component, or persona — or updating an existing one — read this **before** you decide how many PRs your change needs.
+
+---
+
+## Who this guide is for
+
+- Your change touches more than one entity type (e.g. a new component plus the controls and risks that reference it) and you're not sure how to split it into PRs.
+- You want to know whether a new component or persona needs control/risk coverage before it can merge (it doesn't — see Layers 1 and 2 below).
+- You're following [Adding a Component](../guide-components.md), [Adding a Control](../guide-controls.md), [Adding a Risk](../guide-risks.md), or [Adding a Persona](../guide-personas.md) and got pointed here because your change spans more than one of them.
+
+If your change touches exactly one entity type and only references entities that already exist in the corpus, you don't need this guide — follow the relevant content-type guide and the [General Content Contribution Workflow](../workflow.md) as usual; you'll land in one layer, one PR.
+
+---
+
+## The invariant
+
+Corpus changes land in a fixed, dependency-ordered sequence of layers, keyed to the corpus reference graph. **Every layer merges independently validator-green** — at every intermediate commit there is no dangling reference, no broken control-risk reciprocity, and no edgeless component. A change uses only the layers its entity types touch; an empty layer is skipped without disturbing the relative order of the layers used. See ADR-034 for the full rationale — the reference graph, the two failure modes a fixed order prevents, and the alternatives considered.
+
+---
+
+## The 7 layers
+
+Work through the layers that apply to your change, in order. Layer order is the invariant; how many PRs a layer takes is an operational choice — most single-layer changes are one PR.
+
+### Layer 1 — New components
+
+**Triggers when:** you're adding a component that doesn't exist in the corpus yet.
+
+**Files:** `risk-map/schemas/components.schema.json` (id-enum) + `risk-map/yaml/components.yaml` (the entry, **with its bidirectional edges** — both the new component's `edges.to`/`edges.from` and the reciprocal edge on every peer component it connects to).
+
+**Rule:** the new component must carry at least one real component-to-component edge. It does **not** need to be referenced by any control or risk yet — that's not required and not expected. See [New components and personas don't need control/risk coverage](#new-components-and-personas-dont-need-controlrisk-coverage) below.
+
+Follow [Adding a Component](../guide-components.md).
+
+### Layer 2 — New personas
+
+**Triggers when:** you're adding a persona that doesn't exist in the corpus yet. This is rare and held to a high bar — confirm the necessity case before drafting.
+
+**Files:** `risk-map/schemas/personas.schema.json` (id-enum) + `risk-map/yaml/personas.yaml` (the entry). Nothing else — a persona carries no reciprocal back-link field, so there's no back-link half to co-locate.
+
+**Rule:** the new persona does **not** need to be referenced by any risk or control yet — same non-requirement as Layer 1.
+
+Follow [Adding a Persona](../guide-personas.md), Steps 1-2. (Wiring the persona into existing risks/controls is a separate, later PR — see Layer 6.)
+
+### Layer 3 — Existing component and persona updates
+
+**Triggers when:** you're editing a component or persona already in the corpus (description, responsibilities, etc.) — no new ids, no deletions.
+
+**Files:** `risk-map/yaml/components.yaml` or `risk-map/yaml/personas.yaml` (YAML only, no schema edit).
+
+### Layer 4 — New controls
+
+**Triggers when:** you're adding a control that doesn't exist in the corpus yet.
+
+**Files:** `risk-map/schemas/controls.schema.json` (id-enum) + `risk-map/yaml/controls.yaml` (the entry), plus:
+
+- Any **new** risk the control requires lands in this same layer/PR, not in Layer 5 — a new risk co-dependent with a new control always lands in the earlier of the two layers (`risk-map/schemas/risks.schema.json` + `risk-map/yaml/risks.yaml`).
+- The **reciprocal back-link**: every already-existing risk the new control references gets the new control's id added to its `controls` list in `risks.yaml`, in the same PR. This is the control-half of the control-risk cycle break — the pair is never split across a layer boundary.
+
+Any persona or component the new control references already exists (Layers 1-2), so no schema edit is needed for those references.
+
+Follow [Adding a Control](../guide-controls.md).
+
+### Layer 5 — New risks
+
+**Triggers when:** you're adding a risk that doesn't exist in the corpus yet **and** it wasn't already pulled into Layer 4 as a co-dependency of a new control.
+
+**Files:** `risk-map/schemas/risks.schema.json` (id-enum) + `risk-map/yaml/risks.yaml` (the entry), plus the **reciprocal back-link**: every already-existing control the new risk references gets the new risk's id added to its `risks` list in `controls.yaml`, in the same PR.
+
+Follow [Adding a Risk](../guide-risks.md).
+
+### Layer 6 — Modifications to existing risks and controls
+
+**Triggers when:** you're editing a risk or control already in the corpus — tuneups, description improvements, or wiring in a reference to an entity that landed in an earlier layer (for example, adding a newly-landed persona to an existing risk's or control's `personas` list).
+
+**Files:** `risk-map/yaml/risks.yaml` or `risk-map/yaml/controls.yaml` (YAML only, no schema edit, no new ids).
+
+### Layer 7 — Deprecations
+
+**Triggers when:** retiring a component, control, risk, or persona.
+
+**Files:** the relevant `*.yaml` file — flip `deprecated: true` (or the entity's status field). **Never delete the id from the schema enum**; a status flip removes no edges and no references, so it's safe to land any time after every addition and modification that might have kept the entity in use, which is why it's last.
+
+---
+
+## New components and personas don't need control/risk coverage
+
+A new component or persona can land in Layer 1 or 2 with **nothing** referencing it yet, and it can stay that way indefinitely. This is intentional, not a gap: an unreferenced component is a legitimate modeled locus for controls or risks not yet authored, and a persona may precede the risks and controls that will cite it. No validator requires coverage — that non-requirement is guarded by a regression test, `scripts/hooks/tests/test_adr034_orphan_leaves_guard.py`, which pins this behavior. See ADR-034 §D3/§D3a for the full reasoning.
+
+---
+
+## Worked examples
+
+### Example A: single-entity change — one new risk, no new control
+
+You're adding a risk that's addressed entirely by controls already in the corpus.
+
+1. **Layer 5 only, one PR:**
+   - Add the id to `risk-map/schemas/risks.schema.json`.
+   - Add the entry to `risk-map/yaml/risks.yaml`, listing the existing controls that address it.
+   - Add the reciprocal back-link: for each of those existing controls, add your new risk's id to its `risks` list in `risk-map/yaml/controls.yaml`.
+2. Validate (see [Validation Tools](../validation.md)) and open the PR.
+
+No other layer is touched — the component and persona references on your new risk all point at entities that already exist.
+
+### Example B: multi-entity change — a new component with controls and risks that reference it
+
+You're adding a component, plus a control that governs it (which in turn requires a new risk), plus an additional risk against the same component that's addressed by an existing control.
+
+1. **Layer 1, PR 1:** add the new component (schema id-enum + `components.yaml` entry) with real bidirectional edges to at least one peer component. No control or risk references it yet — that's expected. Merge before starting PR 2.
+2. **Layer 4, PR 2:** add the new control (schema id-enum + `controls.yaml` entry) referencing the new component, plus the new risk it requires (schema id-enum + `risks.yaml` entry, bundled into this same PR per the co-dependent-new-node rule), plus the reciprocal back-link on every already-existing risk the new control also references. Merge before starting PR 3.
+3. **Layer 5, PR 3:** add the additional new risk (schema id-enum + `risks.yaml` entry) referencing the new component and an already-existing control, plus the reciprocal back-link on that existing control.
+
+Layers 2, 3, 6, and 7 are skipped — this change doesn't touch personas, existing-entity edits, or deprecations. Skipping a layer doesn't disturb the order of the layers used: 1, then 4, then 5.
+
+---
+
+## Validating each PR
+
+Each layer's PR must pass the same validators as any content change. See [Validation Tools](../validation.md) for the commands — schema validation, component edge consistency, and control-to-risk reference checks all run per-PR, and each layer is designed to pass every one of them on its own.
+
+---
+
+## Related documentation
+
+- ADR-034 (Dependency-ordered landing sequence for risk-map corpus changes) — the decision and rationale behind this guide
+- [General Content Contribution Workflow](../workflow.md) — the overall contribution process this guide slots into
+- [Adding a Component](../guide-components.md), [Adding a Control](../guide-controls.md), [Adding a Risk](../guide-risks.md), [Adding a Persona](../guide-personas.md) — the per-entity how-tos this guide sequences
+- [Validation Tools](../validation.md) — validator commands referenced above

--- a/risk-map/docs/guide-components.md
+++ b/risk-map/docs/guide-components.md
@@ -138,6 +138,8 @@ All files are automatically staged for your commit.
 
 After successful validation, follow the [General Content Contribution Workflow](workflow.md) to create your pull request.
 
+**Note:** A new component does not need any control or risk referencing it yet to merge — that's the normal case, not a gap to fill in this PR. If your change also adds controls or risks that reference this component, see [Landing Sequence for Corpus Changes](contributing/landing-sequence.md) — they land in a later, separate PR.
+
 ---
 
 **Related:**

--- a/risk-map/docs/guide-controls.md
+++ b/risk-map/docs/guide-controls.md
@@ -188,6 +188,8 @@ risks:
 
 Once validated, follow the [General Content Contribution Workflow](workflow.md) to create your pull request.
 
+**Note:** Step 3 above assumes the risks your new control references already exist. If your control also requires a **new** risk, see [Landing Sequence for Corpus Changes](contributing/landing-sequence.md) — the two land together in one PR, not as separate steps.
+
 ---
 
 **Related:**

--- a/risk-map/docs/guide-personas.md
+++ b/risk-map/docs/guide-personas.md
@@ -265,6 +265,11 @@ The framework ID must be defined in `frameworks.yaml` with `applicableTo` includ
 
 ## Adding a Persona
 
+This spans two PRs, in order — see [Landing Sequence for Corpus Changes](contributing/landing-sequence.md):
+
+- **PR 1:** Steps 1-2 below, then validate and submit (Step 4).
+- **PR 2 (later, after PR 1 merges):** Step 3, then validate and submit (Step 4) again.
+
 ### Step 1: Add the persona ID to the schema
 
 Declare the new persona's unique ID in `schemas/personas.schema.json`. The ID should follow the `persona[Name]` convention.
@@ -308,11 +313,11 @@ Add the definition to `yaml/personas.yaml`:
 - `identificationQuestions` - Questions to help identify if this persona applies
 - `deprecated` - Set to `true` for legacy personas
 
-### Step 3 (separate, later PR): Wire the persona into existing risks and controls
+### Step 3 (PR 2): Wire the persona into existing risks and controls
 
-Steps 1-2 above are their own PR: a new persona is a referenced-only leaf and lands on its own, with nothing referencing it yet — that's expected, not a gap to fill before merging. See [Landing Sequence for Corpus Changes](contributing/landing-sequence.md).
+A new persona is a referenced-only leaf and lands on its own in PR 1, with nothing referencing it yet — that's expected, not a gap to fill before merging.
 
-Once that PR has merged, add the new persona ID to relevant entries in `risks.yaml` and `controls.yaml` in a separate PR:
+Once PR 1 has merged, add the new persona ID to relevant entries in `risks.yaml` and `controls.yaml`:
 
 ```yaml
 # In yaml/controls.yaml
@@ -326,7 +331,7 @@ Once that PR has merged, add the new persona ID to relevant entries in `risks.ya
 
 ### Step 4: Validate and submit
 
-Run validation to ensure your changes are correct (once per PR — Steps 1-2, and again for Step 3 if you do it):
+Run validation to ensure your changes are correct — once for PR 1 (Steps 1-2) and again for PR 2 (Step 3):
 
 ```bash
 # Schema validation

--- a/risk-map/docs/guide-personas.md
+++ b/risk-map/docs/guide-personas.md
@@ -308,9 +308,11 @@ Add the definition to `yaml/personas.yaml`:
 - `identificationQuestions` - Questions to help identify if this persona applies
 - `deprecated` - Set to `true` for legacy personas
 
-### Step 3: Update existing risks and controls
+### Step 3 (separate, later PR): Wire the persona into existing risks and controls
 
-Add the new persona ID to relevant entries in `risks.yaml` and `controls.yaml`:
+Steps 1-2 above are their own PR: a new persona is a referenced-only leaf and lands on its own, with nothing referencing it yet — that's expected, not a gap to fill before merging. See [Landing Sequence for Corpus Changes](contributing/landing-sequence.md).
+
+Once that PR has merged, add the new persona ID to relevant entries in `risks.yaml` and `controls.yaml` in a separate PR:
 
 ```yaml
 # In yaml/controls.yaml
@@ -324,7 +326,7 @@ Add the new persona ID to relevant entries in `risks.yaml` and `controls.yaml`:
 
 ### Step 4: Validate and submit
 
-Run validation to ensure your changes are correct:
+Run validation to ensure your changes are correct (once per PR — Steps 1-2, and again for Step 3 if you do it):
 
 ```bash
 # Schema validation

--- a/risk-map/docs/guide-risks.md
+++ b/risk-map/docs/guide-risks.md
@@ -186,6 +186,8 @@ All files are automatically staged for your commit.
 
 Once validated, follow the [General Content Contribution Workflow](workflow.md) to create your pull request.
 
+**Note:** Step 3 above assumes the controls your new risk references already exist. If your risk also requires a **new** control, see [Landing Sequence for Corpus Changes](contributing/landing-sequence.md) — the two land together in one PR, ordered with the control, not with this risk.
+
 ---
 
 **Related:**

--- a/risk-map/docs/workflow.md
+++ b/risk-map/docs/workflow.md
@@ -17,6 +17,7 @@ This page outlines the overall process for contributing content to the CoSAI Ris
 6. Open a PR against the `develop` branch describing the Risk Map updates and validation performed
    - GitHub Actions will automatically run the same validations on your PR
    - Address any CI failures before requesting review
+   - **Change spans more than one entity type?** (e.g. a new component plus the controls and risks that reference it) — it lands as multiple PRs in a fixed order, not one. See [Landing Sequence for Corpus Changes](contributing/landing-sequence.md) before you open a PR.
 
 ## Content Type Guides
 

--- a/scripts/hooks/riskmap_validator/validator.py
+++ b/scripts/hooks/riskmap_validator/validator.py
@@ -90,6 +90,12 @@ class ComponentEdgeValidator:
         """
         Find components with no edges.
 
+        "Isolated" means no component-to-component edges only — this never checks
+        whether a component is referenced by any control or risk. That coverage
+        axis is intentionally left unchecked per ADR-034 §D3a: a new component may
+        land with edges but zero control/risk coverage. Do not add per-PR coverage
+        enforcement here without revisiting that ADR.
+
         Returns:
             Set of isolated component IDs
         """

--- a/scripts/hooks/tests/test_adr034_orphan_leaves_guard.py
+++ b/scripts/hooks/tests/test_adr034_orphan_leaves_guard.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Regression guard for ADR-034 §D3a — orphan leaves are deliberately allowed.
+
+A newly-added component (with its bidirectional edges) or a newly-added
+persona may be referenced by zero controls and zero risks and must still
+pass validation. This is what lets a new component/persona land in its own
+PR (ADR-034 Layers 1-2) before the controls/risks that will reference it.
+
+No validator today enforces coverage, and none should without revisiting
+ADR-034 §D3a. This file pins that absence: if a future contributor adds a
+per-PR coverage check to any of the three seams below, the corresponding
+test here starts failing.
+
+Case A targets the component side: `ComponentEdgeValidator` (edge-only
+isolation, not coverage) and `validate_control_risk_references`
+(control<->risk reciprocity only, no notion of components at all). Case B
+targets the persona side: `build_persona_site_data.build_site_data`, which
+seeds every active persona with empty risk/control id lists regardless of
+whether anything references it.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from riskmap_validator.validator import ComponentEdgeValidator  # noqa: E402
+from validate_control_risk_references import validate_control_to_risk  # noqa: E402
+
+from scripts.build_persona_site_data import build_site_data  # noqa: E402
+
+
+class TestOrphanComponentPassesValidation:
+    """ADR-034 §D3a: an edged-but-uncovered component must pass validation."""
+
+    def test_edged_but_uncovered_component_passes_component_edge_validator(self, tmp_path):
+        """
+        A component with real bidirectional edges but zero control/risk
+        coverage must not be flagged as isolated.
+
+        ADR-034 §D3a: "isolated" means no component-to-component edges;
+        coverage by a control or risk is a different, intentionally
+        unchecked, axis. If a future coverage check is added to
+        ComponentEdgeValidator, this assertion flips to False.
+        """
+        data = {
+            "components": [
+                {
+                    "id": "comp-orphan-guard",
+                    "title": "Orphan Guard Component",
+                    "category": "test1",
+                    "edges": {"to": ["comp-orphan-guard-peer"], "from": []},
+                },
+                {
+                    "id": "comp-orphan-guard-peer",
+                    "title": "Orphan Guard Peer",
+                    "category": "test1",
+                    "edges": {"to": [], "from": ["comp-orphan-guard"]},
+                },
+            ]
+        }
+        yaml_file = tmp_path / "components.yaml"
+        yaml_file.write_text(yaml.dump(data))
+
+        validator = ComponentEdgeValidator(allow_isolated=False, verbose=False)
+        assert validator.validate_file(yaml_file) is True
+
+    def test_control_risk_validator_has_no_notion_of_component_coverage(self):
+        """
+        `validate_control_risk_references` must pass a fully self-consistent
+        controls.yaml/risks.yaml pair that never mentions a given component id.
+
+        ADR-034 §D3a: this validator checks only control<->risk reciprocity;
+        it never touches components.yaml, so an uncovered component cannot
+        fail it. "comp-orphan-guard" (from the sibling test above) never
+        appears below — if a future contributor teaches this validator to
+        consult components.yaml for coverage, this assertion starts failing.
+        """
+        controls_yaml = {
+            "controls": [
+                {"id": "CTL-ORPHAN-GUARD", "risks": ["RSK-ORPHAN-GUARD"]},
+            ]
+        }
+        risks_yaml = {
+            "risks": [
+                {"id": "RSK-ORPHAN-GUARD", "controls": ["CTL-ORPHAN-GUARD"]},
+            ]
+        }
+
+        with patch("validate_control_risk_references.load_yaml_file") as mock_load:
+            mock_load.side_effect = [controls_yaml, risks_yaml]
+            result = validate_control_to_risk([Path("controls.yaml"), Path("risks.yaml")])
+
+        assert result is True
+
+
+class TestOrphanPersonaPassesValidation:
+    """ADR-034 §D3a: a persona referenced by zero risks/controls must pass the site build."""
+
+    def test_uncovered_persona_builds_with_empty_risk_and_control_ids(self):
+        """
+        A persona with no risk or control referencing it must still build
+        successfully, with empty riskIds/controlIds rather than an error.
+
+        ADR-034 §D3a: `build_site_data` seeds every active persona with an
+        empty risk/control id list up front (build_persona_site_data.py
+        risk_ids_by_persona / control_ids_by_persona), so an unreferenced
+        persona is never rejected. If a future contributor adds a coverage
+        requirement here, this assertion starts failing.
+        """
+        personas_data = {
+            "personas": [
+                {"id": "personaOrphanGuard", "title": "Orphan Guard Persona"},
+            ]
+        }
+        risks_data = {"risks": []}
+        controls_data = {"categories": [], "controls": []}
+
+        site_data = build_site_data(personas_data, risks_data, controls_data, components_data={})
+
+        persona_ids = [p["id"] for p in site_data["personas"]]
+        assert "personaOrphanGuard" in persona_ids
+
+        persona_record = next(p for p in site_data["personas"] if p["id"] == "personaOrphanGuard")
+        assert persona_record["riskIds"] == []
+        assert persona_record["controlIds"] == []
+        assert persona_record["riskCount"] == 0
+        assert persona_record["controlCount"] == 0

--- a/scripts/hooks/validate_control_risk_references.py
+++ b/scripts/hooks/validate_control_risk_references.py
@@ -8,6 +8,13 @@ This script validates that:
 - Controls or risks that list "all" or "none" are exempt from validation.
 - Identifies any controls or risks that have no cross-references.
 
+This validator checks only control<->risk reciprocity; it never loads
+components.yaml or personas.yaml and so has no notion of component or persona
+coverage. That is intentional per ADR-034 §D3a: a newly-added component or
+persona may be referenced by zero controls/risks and must still pass. Do not
+add per-PR component/persona coverage enforcement here without revisiting
+that ADR.
+
 Only runs when YAML files are modified in the commit.
 Provides -f/--force option to run validation regardless of git status.
 """


### PR DESCRIPTION
## ADR-034 follow-up: D3a guard + contributor landing-sequence guide

Implements the follow-up work ADR-034 commissions: the D3a orphan-leaves regression guard, plus the companion contributing guide and its cross-references, so the landing sequence is both enforced and documented for contributors.

Closes #411 
_note: this is the second and final checklist item; the ADR itself landed in #410._

### What this adds

1. **D3a orphan-leaves guard** (`5e81dde`) — a regression test (`scripts/hooks/tests/test_adr034_orphan_leaves_guard.py`) pinning that a component with bidirectional edges but zero control/risk references, and a persona referenced by zero risks/controls, both pass validation today. Pointer-comments in `validator.py` and `validate_control_risk_references.py` flag that coverage is intentionally unchecked, so a future per-PR coverage check can't be added silently without revisiting ADR-034.
2. **Contributor how-to guide** (`2eb1f49`) — new `risk-map/docs/contributing/landing-sequence.md`: the operational companion to ADR-034, covering all 7 layers, the reciprocal-back-link rules (D2a/D2b), the D3/D3a orphan-leaf allowance, and two worked examples (single-layer and multi-layer changes).
3. **Guide alignment** (`2eb1f49`, `8289b3a`) — `workflow.md` gets a pointer for multi-entity-type changes; `guide-components.md`, `guide-controls.md`, `guide-risks.md` each get a one-line cross-reference; `guide-personas.md` is restructured (its old "Adding a Persona" flow bundled persona-wiring into existing risks/controls with the same-PR schema+YAML steps, which contradicted ADR-034's Layer 2 invariant that a new persona lands alone) into an explicit two-PR sequence.

### Scope

- Tooling/process + docs → base `main` (per ADR-002). No `risk-map/yaml/**` or `risk-map/schemas/**` changes — guard test + validator comments + markdown only.
- Depends conceptually on ADR-034, which merged to `main` via #410 on 2026-07-16. The guide and the guard cite it by name rather than by relative link — a holdover from when the ADR was not yet on `main`. Worth adding the link in review or a follow-up; not a blocker.

---

## ADR-034 flipped to Accepted in this PR

ADR-034 landed `Status: Draft` in #410, per the convention that the architect authors as Draft and the maintainer flips on sign-off. #411's first checklist item carried that flip, and this PR closes #411 — so the flip lands here (`8b8ead1`) rather than being retired with the issue. 

Both the ADR header and the `docs/adr/README.md` index row are updated.
