### PR TITLE
[docs] State what a component is before the guide says how to add one

### DIFF
--- a/risk-map/docs/guide-components.md
+++ b/risk-map/docs/guide-components.md
@@ -2,6 +2,18 @@
 
 Once you've determined the need for a new component, the following steps are required to integrate it into the framework. For this example, we'll add a new component called `componentNewComponent` to the "Application" category.
 
+## What a component is
+
+A component is an **architectural shape** — a class of element an AI system can contain — not a named thing in one deployment. `componentIdentityProvider` is the shape "identity authority"; a deployment may hold several instances of it under different authorities, and the identity provider a tool server demands is a different instance from the agent's own. Both are the same component.
+
+Three consequences follow, and each is a common source of review findings:
+
+- **A second instance does not earn a second component.** Two of the same shape under different authorities is a deployment fact, not a modeling one. What earns a second component is a second *locus* — a distinct place where something is decided, enforced, or stored.
+- **A description should not read as a singular.** Prefer "the authoritative source of identity for a deployment" over wording that implies the corpus knows of exactly one. If a sentence would be false in a deployment with two of them, rewrite it.
+- **Edges connect shapes, not instances.** An edge means "this class of element reaches that one," so an edge is right if the path exists in any deployment that has both.
+
+Adding a component is the highest-blast-radius change in the corpus: it cascades into reciprocal edges on every component it touches, the controls and risks that reference it, and the regenerated graphs and tables. Before adding one, test whether an existing component absorbs it — and if the candidate is too broad to instruct a reader, decompose an existing component instead of adding a wider one.
+
 ## 1. Add the new component ID to the schema
 
 First, derive the new component ID from the component title (`component` + camelCase descriptor — e.g., "Feature Store" → `componentFeatureStore`) and declare it in the schema. This makes the system aware of the new component and allows for validation. (The issue-template flow derives this ID automatically; when authoring YAML/schema directly via PR, apply the same convention by hand.)


### PR DESCRIPTION
## [docs] State what a component is before the guide says how to add one

Closes: #474 

The component authoring guide opened at step one — add the id to the schema — on the assumption that a contributor arrives already knowing what they are adding. This adds the missing definition ahead of the numbered steps.

### The rule

A component is an **architectural shape**, not an instance. A deployment may hold several instances of one component under different authorities: the identity provider a tool server demands is a different instance from the agent's own, and both are the same component.

That is load-bearing across the corpus — it is why there is one audit record repository written by many components rather than one per writer, and one runtime hosting substrate with three tenants. Until now it was stated in no tracked file, only inside a decision record's justification for a particular component, which is not where a contributor looks.

Three reviewers independently reconstructed the rule as a defect, each filing a finding of the same shape: *this deployment needs two of these, so a component is missing.* Answering them one at a time left nothing a fourth reviewer would find.

### What lands

One prose section, `risk-map/docs/guide-components.md`, before step 1:

- The shape-not-instance definition, with a worked example.
- Its three consequences, which are what produce the findings when unknown — a second instance does not earn a second component; a description must not read as a singular; edges connect shapes, so an edge is right if the path exists in any deployment that has both endpoints.
- The blast radius of adding a component, and the absorb-or-decompose test. Both previously lived only in the authoring agents, which a contributor writing YAML by hand never invokes.

### Scope

- Prose only. No schema, corpus, tooling, or generated-artifact change; one file, one commit.
- Base `main` as infrastructure rather than `develop` — documentation rather than framework content.
- Independent of the component-layer work under review in #471 and #473. Those PRs are where the rule is *applied*; this is where a contributor can *read* it, and it is worth landing whichever way that review goes.
