### PR TITLE
merge: Periodic sync of `main` into `develop` (19-aug-2026)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
   # the schema file itself against --schemafile and fail.
   # ---------------------------------------------------------------------------
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.1
+    rev: 0.37.4
     hooks:
       - id: check-jsonschema
         name: 'schema: actor-access.yaml'
@@ -136,7 +136,7 @@ repos:
   # time. Runs whenever any schema file is staged.
   # ---------------------------------------------------------------------------
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.1
+    rev: 0.37.4
     hooks:
       - id: check-metaschema
         name: 'schema: meta-validate .schema.json files'
@@ -190,7 +190,7 @@ repos:
   # Ruff lint + format for Python.
   # ---------------------------------------------------------------------------
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.10
+    rev: v0.16.0
     hooks:
       - id: ruff
         name: 'ruff: lint'

--- a/docs/adr/008-sub-agent-orchestration.md
+++ b/docs/adr/008-sub-agent-orchestration.md
@@ -3,6 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-04-20
 **Authors:** Architect agent, with maintainer review
+**Superseded in part by:** [Amendment 2026-07-12](#amendment-2026-07-12-draft-issue-comments-review-discipline-is-a-canonical-skill) (below) — the [§2](#decision) framing of the `draft-issue-comment` flow's review discipline as "not part of the canonical pattern" is superseded by [ADR-031 D5](031-authoring-time-agents-and-skills.md) + [ADR-033 D1](033-vendor-neutral-agent-skill-shipping.md). The composition contracts and routing boundaries of D1–D3 are unchanged.
 
 ---
 
@@ -79,3 +80,57 @@ The architect agent is the negative example that anchors the rule. [`scripts/age
 - When the newer canonicals (`architect`, `testing`, `code-reviewer`, `swe`) have been exercised through one or more published orchestration flows, a follow-up ADR should capture their composition patterns. Expected flows include `architect → testing → swe → code-reviewer` for test-first implementation and `architect → swe → code-reviewer` for infrastructure work. Neither is currently battle-tested; both are declared in `architect.md` but have not been run end-to-end in live contributor-facing work.
 - If a second harness is officially supported, the question of whether skill-layer code becomes tracked (versus maintainer-local) is a separate decision. Not in scope here.
 - The `format: agent` output schema of `content-reviewer` would benefit from a JSON schema or equivalent contract document if the number of composing canonicals grows beyond `issue-response-reviewer`. Defer until that pressure exists.
+
+---
+
+## Amendment 2026-07-12: `draft-issue-comment`'s review discipline is a canonical skill
+
+**Status:** Draft (2026-07-12). Does not alter the Accepted status of D1–D3 above; it supersedes only the §2 classification of the `draft-issue-comment` flow's review discipline.
+**Authors:** Architect agent, with maintainer review.
+
+### Context
+
+[D2](#decision) ("Skill-to-agent composition") uses the `draft-issue-comment` flow as its worked example and, in its "Per-harness layering" clause, classifies it: "A `/draft-issue-comment` slash command is one harness's layering over `issue-response-reviewer` … Per ADR-006, harness layering is an implementation detail of the consuming environment, not part of the canonical pattern." When ADR-008 was written (2026-04-20), that classification was correct on the facts then true: there was **no canonical skill surface at all**. [ADR-006](006-agent-architecture-pattern.md) had established `scripts/agents/` for agents, but skills existed only as harness-specific wrappers, so any `draft-issue-comment` form was necessarily harness-layered.
+
+Three later, Accepted-track decisions changed the surface that framing described:
+
+- [ADR-031 D5](031-authoring-time-agents-and-skills.md) (Accepted, [#402](https://github.com/cosai-oasis/secure-ai-tooling/pull/402)) established `scripts/skills/` as the **canonical, vendor-neutral home** for skills, paralleling `scripts/agents/`. A skill can now be canonical; before ADR-031 it could not.
+- [ADR-033 D1](033-vendor-neutral-agent-skill-shipping.md) (the canonical-only shipping standard) fixed the canonical skill as the **single tracked form** and ruled out first-party per-harness wrappers in-repo.
+- The `draft-issue-comment` skill has since been promoted into `scripts/skills/` as a neutral canonical that **defers to** the [`issue-response-reviewer`](../../scripts/agents/issue-response-reviewer.md) agent (which composes `content-reviewer` in `issue` mode) — it applies that agent's spec and does not restate it.
+
+The promotion is coherent under the later ADRs — it is a canonical skill admitted under the general ADR-031-D5 / ADR-033-D1 skill-surface rules — but nothing in the ADR record reconciled it against ADR-008 §2's "not part of the canonical pattern" framing, which now reads stale for the *review-discipline* half of the flow. This amendment closes that gap.
+
+### Decision
+
+#### D4. The `draft-issue-comment` review discipline is a canonical skill; only its external side effects remain harness layering
+
+The `draft-issue-comment` flow **splits** into two parts that the later ADRs place on opposite sides of the canonical boundary. The [§2](#decision) "not part of the canonical pattern" framing is superseded for the first part and retained for the second:
+
+- **The review discipline is a canonical skill.** Producing a structured maintainer review comment for a content-proposal issue — the discipline the flow carries — ships as the neutral canonical skill `scripts/skills/draft-issue-comment/` under [ADR-031 D5](031-authoring-time-agents-and-skills.md) (canonical skill home) and [ADR-033 D1](033-vendor-neutral-agent-skill-shipping.md) (canonical-only). This is the current governing classification; ADR-008 §2's "harness layering, not part of the canonical pattern" no longer describes this part.
+- **The external side effects remain harness layering.** [D3](#decision)'s routing boundary is unchanged: the canonical skill returns a local draft; it does not post to GitHub. A harness's live GitHub-fetch and post/write mechanics — the `gh`-CLI invocation, the write of the drafted comment — stay harness-specific and out of the tracked canonical, exactly as [D2](#decision) and [D3](#decision) require. ADR-008 §2's boundary governs *these* mechanics; it no longer governs the review discipline.
+
+#### D5. The skill *defers to* the agent — this is ADR-006's canonical-and-defer relationship, not a re-canonicalization of the review logic
+
+The canonical skill does **not** restate the review spec. It defers to the canonical [`issue-response-reviewer`](../../scripts/agents/issue-response-reviewer.md) agent — which composes `content-reviewer` in `issue` mode ([ADR-007](007-content-reviewer-modes.md)) — as its single source of truth for the review process, feedback shape, quality gates, and output structure. The review logic remains canonical **in the agent**; the skill is a thin, canonical caller that applies it. This is the same "canonical is authoritative; the thin form defers to it" relationship [ADR-006](006-agent-architecture-pattern.md) fixes, now realized skill→agent rather than wrapper→agent. Promoting the skill therefore adds a canonical *caller*; it does not duplicate or re-canonicalize the review logic the agent already owns. [D1](#decision)'s agent-to-agent composition contract (`issue-response-reviewer` → `content-reviewer`) is untouched.
+
+#### D6. This is the standing pattern for a promotion↔prior-ADR tension
+
+When a promotion into the shipped set (`scripts/agents/**`, `scripts/skills/**`) reclassifies an artifact that an earlier Accepted ADR framed under the pre-canonical-skill surface, the reconciliation is recorded — not left implicit. The standing form is a dated, in-file amendment to the earlier ADR that annotates the superseded framing and points to the governing later decision, preserving the original text (the instrument this amendment uses; cf. the [ADR-026 amendment precedent](026-issue-template-domain.md#amendment-2026-05-21-component-categorysubcategory-valid-tuple-selector)). The artifact still enters the shipped set under [ADR-033 D6](033-vendor-neutral-agent-skill-shipping.md)'s expansion rule (an ADR-level admission that records D1–D5 conformance and a portable eval); this amendment records the *reconciliation of the prior framing*, which is a separate act from admission.
+
+### Consequences
+
+**Positive**
+
+- The ADR record now explicitly reconciles ADR-008 §2 with the canonical-skill surface. A future reader who reaches ADR-008's harness-layering framing is pointed to the governing later decision instead of being left to infer that ADR-031/033 override it.
+- The split is stated cleanly: review discipline is canonical (the skill), external side effects stay harness-specific (the routing boundary). D3's "canonicals return findings; callers perform side effects" rule is preserved intact, not weakened.
+- The reconciliation instrument (D6) is now a stated pattern, so the next promotion that trips a prior-ADR framing has a recorded convention to follow rather than a case-by-case judgment call.
+
+**Negative**
+
+- ADR-008 §2 must now be read together with this amendment; the original clause remains in place (history is preserved) but is no longer the whole story for the `draft-issue-comment` example. The header "Superseded in part by" pointer mitigates this, but a reader who skims only §2 could miss the reconciliation.
+- The split between "canonical review discipline" and "harness-specific side effects" is a distinction that must be maintained per flow. A future skill that blurs the two — putting a side effect into the canonical — would violate D3 and reopen this boundary.
+
+**Follow-up**
+
+- **Maintainer sign-off flips this amendment `Draft → Accepted`** and, at that point, the ADR-008 header pointer's "Draft" reference resolves to an Accepted amendment. The `Superseded in part by` header language is deliberately narrow (D1–D3 unchanged); confirm that scoping at Accept time.
+- **Admission of `draft-issue-comment` into the shipped set** under [ADR-033 D6](033-vendor-neutral-agent-skill-shipping.md) is a separate question from this reconciliation. The scope doc's open Q6 (whether to bless the skill by name in a skill-surface ADR, or leave it under the general ADR-031-D5 / ADR-033-D1 rules) is the maintainer's to decide; this amendment does not resolve it and does not depend on it.

--- a/docs/adr/008-sub-agent-orchestration.md
+++ b/docs/adr/008-sub-agent-orchestration.md
@@ -98,16 +98,16 @@ Three later, Accepted-track decisions changed the surface that framing described
 - [ADR-033 D1](033-vendor-neutral-agent-skill-shipping.md) (the canonical-only shipping standard) fixed the canonical skill as the **single tracked form** and ruled out first-party per-harness wrappers in-repo.
 - The `draft-issue-comment` skill has since been promoted into `scripts/skills/` as a neutral canonical that **defers to** the [`issue-response-reviewer`](../../scripts/agents/issue-response-reviewer.md) agent (which composes `content-reviewer` in `issue` mode) — it applies that agent's spec and does not restate it.
 
-The promotion is coherent under the later ADRs — it is a canonical skill admitted under the general ADR-031-D5 / ADR-033-D1 skill-surface rules — but nothing in the ADR record reconciled it against ADR-008 §2's "not part of the canonical pattern" framing, which now reads stale for the *review-discipline* half of the flow. This amendment closes that gap.
+The promotion is coherent under the later ADRs, and — per [D7](#decision) below — is formally admitted to the shipped set by this amendment. Until D7, nothing in the ADR record reconciled it against ADR-008 §2's "not part of the canonical pattern" framing, which now reads stale for the *review-discipline* half of the flow, or provided the ADR-033 D6 admission a new skill requires. This amendment closes both gaps.
 
 ### Decision
 
-#### D4. The `draft-issue-comment` review discipline is a canonical skill; only its external side effects remain harness layering
+#### D4. The canonical skill owns the read-and-draft workflow; only publication remains harness layering
 
 The `draft-issue-comment` flow **splits** into two parts that the later ADRs place on opposite sides of the canonical boundary. The [§2](#decision) "not part of the canonical pattern" framing is superseded for the first part and retained for the second:
 
-- **The review discipline is a canonical skill.** Producing a structured maintainer review comment for a content-proposal issue — the discipline the flow carries — ships as the neutral canonical skill `scripts/skills/draft-issue-comment/` under [ADR-031 D5](031-authoring-time-agents-and-skills.md) (canonical skill home) and [ADR-033 D1](033-vendor-neutral-agent-skill-shipping.md) (canonical-only). This is the current governing classification; ADR-008 §2's "harness layering, not part of the canonical pattern" no longer describes this part.
-- **The external side effects remain harness layering.** [D3](#decision)'s routing boundary is unchanged: the canonical skill returns a local draft; it does not post to GitHub. A harness's live GitHub-fetch and post/write mechanics — the `gh`-CLI invocation, the write of the drafted comment — stay harness-specific and out of the tracked canonical, exactly as [D2](#decision) and [D3](#decision) require. ADR-008 §2's boundary governs *these* mechanics; it no longer governs the review discipline.
+- **The review discipline and the read-and-draft workflow are canonical.** Producing a structured maintainer review comment for a content-proposal issue — gathering the issue's context (the `gh issue view` / `gh api` read calls the workflow specifies), applying `issue-response-reviewer`'s review discipline, and writing the resulting draft to a local file — ships as the neutral canonical skill `scripts/skills/draft-issue-comment/` under [ADR-031 D5](031-authoring-time-agents-and-skills.md) (canonical skill home) and [ADR-033 D1](033-vendor-neutral-agent-skill-shipping.md) (canonical-only). The canonical `SKILL.md` names these concrete calls and the local file write directly (its steps 2 and 4) — they are **read-only calls against GitHub and a local, non-mutating write**, not an action with an external effect on a shared system. ADR-008 §2's "harness layering, not part of the canonical pattern" no longer describes any part of this read-and-draft workflow; the earlier framing in this amendment's first draft, which placed the `gh`-CLI read calls and the draft write outside the canonical, was itself wrong — those calls are exactly what the canonical `SKILL.md` specifies, not a harness-specific substitute for it.
+- **Publication remains harness layering.** [D3](#decision)'s routing boundary is unchanged in substance, narrowed to what actually varies by harness: the canonical skill returns a local draft; it does not post to GitHub or otherwise mutate a shared system. Posting the draft as an issue comment — an action with an external, hard-to-reverse effect on a system other than the contributor's own clone — is the harness/consumer's explicit, separately authorized action. ADR-008 §2's boundary governs *that* action; it no longer governs the read-only context-gathering or the local draft write.
 
 #### D5. The skill *defers to* the agent — this is ADR-006's canonical-and-defer relationship, not a re-canonicalization of the review logic
 
@@ -115,22 +115,36 @@ The canonical skill does **not** restate the review spec. It defers to the canon
 
 #### D6. This is the standing pattern for a promotion↔prior-ADR tension
 
-When a promotion into the shipped set (`scripts/agents/**`, `scripts/skills/**`) reclassifies an artifact that an earlier Accepted ADR framed under the pre-canonical-skill surface, the reconciliation is recorded — not left implicit. The standing form is a dated, in-file amendment to the earlier ADR that annotates the superseded framing and points to the governing later decision, preserving the original text (the instrument this amendment uses; cf. the [ADR-026 amendment precedent](026-issue-template-domain.md#amendment-2026-05-21-component-categorysubcategory-valid-tuple-selector)). The artifact still enters the shipped set under [ADR-033 D6](033-vendor-neutral-agent-skill-shipping.md)'s expansion rule (an ADR-level admission that records D1–D5 conformance and a portable eval); this amendment records the *reconciliation of the prior framing*, which is a separate act from admission.
+When a promotion into the shipped set (`scripts/agents/**`, `scripts/skills/**`) reclassifies an artifact that an earlier Accepted ADR framed under the pre-canonical-skill surface, the reconciliation is recorded — not left implicit. The standing form is a dated, in-file amendment to the earlier ADR that annotates the superseded framing and points to the governing later decision, preserving the original text (the instrument this amendment uses; cf. the [ADR-026 amendment precedent](026-issue-template-domain.md#amendment-2026-05-21-component-categorysubcategory-valid-tuple-selector)). Reconciling the prior framing and providing the ADR-033 D6 admission are conceptually separate acts — one explains why an earlier ADR's classification no longer holds, the other is the ADR-level decision a new skill needs to enter the shipped set — but nothing requires them to happen in different documents. This amendment performs both: this section is the reconciliation; [D7](#decision) below is the admission.
+
+#### D7. This amendment provides the ADR-033 D6 admission for `draft-issue-comment`
+
+[ADR-033 D6](033-vendor-neutral-agent-skill-shipping.md) requires a new skill to enter the shipped set by an ADR-level decision that records conformance to D1–D5 and confirms a portable eval ships with it — dropping files is explicitly insufficient. This section is that decision for `scripts/skills/draft-issue-comment/`:
+
+- **D1 (canonical-only, neutral, cloneable):** the skill ships only as its neutral canonical form at `scripts/skills/draft-issue-comment/SKILL.md`; no first-party harness wrapper is tracked in-repo.
+- **D2 (the neutrality contract):** the shipped file carries no denylisted harness- or vendor-specific tokens; the D5 neutrality check passes against it.
+- **D3 (consumer leverage):** the skill defers to `issue-response-reviewer` ([D5](#decision) above) rather than re-deriving the review logic, so a consumer adapts one thin, canonical caller instead of a restated review spec.
+- **D4 (shipping format):** ships in the Agent Skills open standard fixed by [ADR-031 D6](031-authoring-time-agents-and-skills.md), the same format as the four other authoring skills.
+- **D5 (a neutrality check is required):** the ADR-033 D5 check passes.
+- **Portable eval:** ships at `scripts/skills/draft-issue-comment/evals/evals.json`.
+
+`draft-issue-comment` is admitted to the shipped set as of this amendment's acceptance. This closes the question this amendment's first draft left open — see the struck Follow-up bullet below, preserved per the D6 annotation instrument rather than deleted.
 
 ### Consequences
 
 **Positive**
 
 - The ADR record now explicitly reconciles ADR-008 §2 with the canonical-skill surface. A future reader who reaches ADR-008's harness-layering framing is pointed to the governing later decision instead of being left to infer that ADR-031/033 override it.
-- The split is stated cleanly: review discipline is canonical (the skill), external side effects stay harness-specific (the routing boundary). D3's "canonicals return findings; callers perform side effects" rule is preserved intact, not weakened.
+- The split is stated cleanly: the read-and-draft workflow (context-gathering plus review discipline) is canonical; publication — the one action with an external, hard-to-reverse effect — stays harness-specific. D3's "canonicals return findings; callers perform side effects" rule is preserved intact, narrowed correctly to the action that actually mutates a shared system, not weakened.
 - The reconciliation instrument (D6) is now a stated pattern, so the next promotion that trips a prior-ADR framing has a recorded convention to follow rather than a case-by-case judgment call.
+- `draft-issue-comment` is formally admitted to the shipped set (D7), closing the ADR-033 D6 gap this amendment's first draft left open — there is no longer a skill in `scripts/skills/` operating without a recorded admission decision.
 
 **Negative**
 
 - ADR-008 §2 must now be read together with this amendment; the original clause remains in place (history is preserved) but is no longer the whole story for the `draft-issue-comment` example. The header "Superseded in part by" pointer mitigates this, but a reader who skims only §2 could miss the reconciliation.
-- The split between "canonical review discipline" and "harness-specific side effects" is a distinction that must be maintained per flow. A future skill that blurs the two — putting a side effect into the canonical — would violate D3 and reopen this boundary.
+- The split between "canonical read-and-draft workflow" and "harness-specific publication" is a distinction that must be maintained per flow. A future skill that performs an external, system-mutating action (posting, deleting, modifying shared state outside the contributor's own clone) from within the canonical would violate D3 and reopen this boundary; read-only fetches and local file writes do not.
 
 **Follow-up**
 
 - **Maintainer sign-off flips this amendment `Draft → Accepted`** and, at that point, the ADR-008 header pointer's "Draft" reference resolves to an Accepted amendment. The `Superseded in part by` header language is deliberately narrow (D1–D3 unchanged); confirm that scoping at Accept time.
-- **Admission of `draft-issue-comment` into the shipped set** under [ADR-033 D6](033-vendor-neutral-agent-skill-shipping.md) is a separate question from this reconciliation. The scope doc's open Q6 (whether to bless the skill by name in a skill-surface ADR, or leave it under the general ADR-031-D5 / ADR-033-D1 rules) is the maintainer's to decide; this amendment does not resolve it and does not depend on it.
+- ~~**Admission of `draft-issue-comment` into the shipped set** under [ADR-033 D6](033-vendor-neutral-agent-skill-shipping.md) is a separate question from this reconciliation. The scope doc's open Q6 (whether to bless the skill by name in a skill-surface ADR, or leave it under the general ADR-031-D5 / ADR-033-D1 rules) is the maintainer's to decide; this amendment does not resolve it and does not depend on it.~~ **Resolved by [D7](#decision) above** — this amendment now provides that admission directly, closing Q6 rather than deferring it.

--- a/docs/adr/031-authoring-time-agents-and-skills.md
+++ b/docs/adr/031-authoring-time-agents-and-skills.md
@@ -183,4 +183,4 @@ Because the standard is maintained externally and versions on its own cadence, c
 **Follow-up**
 
 - **Maintainer sign-off flips this amendment `Draft → Accepted`.**
-- `scripts/skills/README.md`'s roster entry for `audit-identification-questions` currently cites "(ADR-031 D5, ADR-021 D7)" — D5 is the Persona creator/critic sequencing section and does not admit this skill. Update the citation to point at this amendment's D7 once accepted.
+- `scripts/skills/README.md`'s roster entry for `audit-identification-questions` cited "(ADR-031 D5, ADR-021 D7)" — D5 is the Persona creator/critic sequencing section and does not admit this skill. Already corrected in the same commit as this amendment to cite ADR-021 D7 (responsibility) and this D7 (admission), rather than waiting on Accept.

--- a/docs/adr/031-authoring-time-agents-and-skills.md
+++ b/docs/adr/031-authoring-time-agents-and-skills.md
@@ -144,3 +144,43 @@ Because the standard is maintained externally and versions on its own cadence, c
 - Curation ownership (settled): the NIST-first term set and the escape-hatch adjudication (D3a) are owned by maintainers via CoSAI governance review (issues, offline discussion); the global-legitimacy check (D3b) is materialized by the classical-lexicon skill, which records the cross-standard equivalence set and flags parochialism / naming-conflict gaps for maintainers to carry into that review; STABLE-snapshot re-pinning (D4) is triggered per framework-version bump through the existing ADR-027 mapping cadence. Implementation obligation: the classical-lexicon skill must include the equivalence-recording and gap-flagging behavior so the maintainer can establish global legitimacy correctly.
 - This ADR introduces `scripts/skills/` as a new canonical, tracked directory — none exists today. The skill format is decided in D6 (the Agent Skills open standard); the first skill PR establishes the on-disk layout and pins the spec revision the canonical surface targets (D6), setting the pattern every later skill follows.
 - A lightweight consistency check that the authoring skills/agents and their source rules (the contributing guides) stay in sync is deferred to the backlog. Until it exists, D1's "reference the source, don't re-derive" mandate is enforced by review.
+
+## Amendment 2026-08-02: Admission of `audit-identification-questions` as a fifth authoring skill
+
+**Status:** Draft (2026-08-02). Adds D7; does not alter the Accepted status of D1–D6 above.
+**Authors:** maintainer review, prompted by PR review.
+
+### Context
+
+[D2](#d2-agent-vs-skill-boundary) named four skills at authoring time (2026-07-01): `classical-lexicon`, `mapping-selection`, `altitude-check`, `audit-framework-mappings`. A fifth skill, `audit-identification-questions`, was subsequently built and shipped to `scripts/skills/` (PR #433) without going through the admission this ADR's own governing standard, [ADR-033 D6](033-vendor-neutral-agent-skill-shipping.md), requires: *"A new agent or skill enters the shipped set by an amendment to the relevant ADR ... or a new ADR that conforms to this standard ... not by dropping a file, but by an ADR-level decision that admits it and records that it conforms."* [ADR-021 D7](021-personas-and-self-assessment-schema.md) recognizes the skill's editorial-review responsibility, but ADR-021 D7 answers a different question (what the skill is *for*) than the one this amendment answers (whether it is admitted to *this* ADR's shipped roster and whether it conforms to ADR-033). PR #433's own description described the skill as completing "the last of the four ADR-031 D2 authoring skills" — text that is simply wrong against D2's actual four-item enumeration, and is corrected by this amendment rather than repeated.
+
+### D7. Admission of `audit-identification-questions`
+
+**Why a fifth skill, not a fold-in.** The skill is the same *shape* as `audit-framework-mappings` (D2): an audit skill that defers editorial/format rules to a style guide (`identification-questions-style-guide.md`) rather than restating them, covering ground content-reviewer's mechanical structural checks cannot reach — leading-question framing, scoping-clause completeness, example-parenthetical judgment. It does not fold into any of the original four; its editorial surface (identification questions) is distinct from theirs (terminology, selection judgment, altitude, framework-mapping correctness).
+
+**ADR-033 D1-D5 conformance:**
+
+- **D1 (canonical-only, neutral, cloneable):** ships only as its neutral canonical form at `scripts/skills/audit-identification-questions/SKILL.md`; no first-party harness wrapper is tracked in-repo.
+- **D2 (the neutrality contract):** the shipped file carries no denylisted harness- or vendor-specific tokens; the D5 neutrality check passes against it.
+- **D3 (consumer leverage):** defers editorial rules to `identification-questions-style-guide.md` rather than restating them.
+- **D4 (shipping format):** ships in the Agent Skills open standard fixed by [D6](#d6-skill-format-the-agent-skills-open-standard), the same format as the original four.
+- **D5 (a neutrality check is required):** the ADR-033 D5 check passes.
+- **Portable eval:** ships at `scripts/skills/audit-identification-questions/evals/evals.json`.
+
+`audit-identification-questions` is admitted to the shipped set as of this amendment's acceptance. From this point forward, [D2](#d2-agent-vs-skill-boundary)'s original "four skills" language describes the roster **as decided on 2026-07-01**, not the current shipped count; `scripts/skills/README.md` and any other roster-count text should read **five**.
+
+### Consequences
+
+**Positive**
+
+- `scripts/skills/` no longer has a skill operating without a recorded ADR-033 D6 admission. The gap PR #433's review surfaced is closed the same way the ADR-008 amendment closed the analogous gap for `draft-issue-comment` (D6 above, the standing pattern for exactly this situation — though this ADR is itself the "relevant ADR" here, so the admission lands in-place rather than in a different document).
+- D2's original text is preserved as the historical record of the 2026-07-01 decision; nothing about the "four skills" framing needed to be correct in hindsight, only clearly superseded.
+
+**Negative**
+
+- A reader who stops at D2 without reaching this amendment will undercount the roster by one. Mitigated by this section explicitly flagging D2's language as decision-time, not current.
+
+**Follow-up**
+
+- **Maintainer sign-off flips this amendment `Draft → Accepted`.**
+- `scripts/skills/README.md`'s roster entry for `audit-identification-questions` currently cites "(ADR-031 D5, ADR-021 D7)" — D5 is the Persona creator/critic sequencing section and does not admit this skill. Update the citation to point at this amendment's D7 once accepted.

--- a/docs/adr/034-corpus-change-landing-sequence.md
+++ b/docs/adr/034-corpus-change-landing-sequence.md
@@ -1,6 +1,6 @@
 # ADR-034: Dependency-ordered landing sequence for risk-map corpus changes
 
-**Status:** Draft
+**Status:** Accepted
 **Date:** 2026-07-09
 **Authors:** Architect agent, with maintainer review
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,7 +23,7 @@ If a decision is about *how the Risk Map content model is shaped*, it belongs in
 | [005](005-pre-commit-framework.md) | Pre-commit framework adoption | Accepted | 2026-04-21 |
 | [006](006-agent-architecture-pattern.md) | Vendor-neutral agent architecture under `scripts/agents/` | Accepted | 2026-04-21 |
 | [007](007-content-reviewer-modes.md) | `content-reviewer` three-mode architecture | Accepted | 2026-04-21 |
-| [008](008-sub-agent-orchestration.md) | Sub-agent orchestration: composition contracts and routing boundaries | Accepted | 2026-04-21 |
+| [008](008-sub-agent-orchestration.md) | Sub-agent orchestration: composition contracts and routing boundaries | Accepted (§2 superseded in part — [amendment](008-sub-agent-orchestration.md#amendment-2026-07-12-draft-issue-comments-review-discipline-is-a-canonical-skill) Draft) | 2026-04-21 |
 | [009](009-persona-pages-workflow-topology.md) | GitHub Pages deploy surface and persona-pages workflow topology | Accepted | 2026-04-21 |
 | [010](010-site-repo-root-module-boundary.md) | `site/` as a repo-root peer of `risk-map/` | Accepted | 2026-04-21 |
 | [011](011-persona-site-data-schema-contract.md) | `persona-site-data.schema.json` as a versioned producer/consumer contract | Accepted | 2026-04-21 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,7 +49,7 @@ If a decision is about *how the Risk Map content model is shaped*, it belongs in
 | [031](031-authoring-time-agents-and-skills.md) | Authoring-time agents and skills for Risk Map content — creator + critic agents, classical-lexicon / mapping-selection / altitude-check / audit-framework-mappings skills | Accepted | 2026-07-01 |
 | [032](032-consumer-exploration-skills.md) | Read-only consumer exploration skill surface (explore-* skills) | Accepted | 2026-07-06 |
 | [033](033-vendor-neutral-agent-skill-shipping.md) | Vendor-neutral shipping and lifecycle for CoSAI agents and skills — canonical-only neutral cloneable artifacts, the neutrality contract (machine-checkable denylist + framework-authority allowlist), consumer adaptation, required neutrality check, develop/eval/expand lifecycle | Accepted | 2026-07-08 |
-| [034](034-corpus-change-landing-sequence.md) | Dependency-ordered landing sequence for risk-map corpus changes | Draft | 2026-07-09 |
+| [034](034-corpus-change-landing-sequence.md) | Dependency-ordered landing sequence for risk-map corpus changes | Accepted | 2026-07-09 |
 | [035](035-pinned-sources-manifest.md) | Pinned-sources manifest (`risk-map/yaml/sources.yaml`) for reproducible citation provenance — corpus-wide registry, disjoint-by-role sibling to `frameworks.yaml`, keep-and-flag fallback; implements ADR-031 D4 | Draft | 2026-07-22 |
 
 ## Conventions

--- a/risk-map/docs/contributing/landing-sequence.md
+++ b/risk-map/docs/contributing/landing-sequence.md
@@ -1,0 +1,133 @@
+# Landing Sequence for Corpus Changes
+
+This guide is the step-by-step companion to ADR-034 (Dependency-ordered landing sequence for risk-map corpus changes). ADR-034 records the decision and rationale; this guide records the how-to — which files you edit, in which layer, and in what order, for your specific change.
+
+If you're proposing a new risk, control, component, or persona — or updating an existing one — read this **before** you decide how many PRs your change needs.
+
+---
+
+## Who this guide is for
+
+- Your change touches more than one entity type (e.g. a new component plus the controls and risks that reference it) and you're not sure how to split it into PRs.
+- You want to know whether a new component or persona needs control/risk coverage before it can merge (it doesn't — see Layers 1 and 2 below).
+- You're following [Adding a Component](../guide-components.md), [Adding a Control](../guide-controls.md), [Adding a Risk](../guide-risks.md), or [Adding a Persona](../guide-personas.md) and got pointed here because your change spans more than one of them.
+
+If your change touches exactly one entity type and only references entities that already exist in the corpus, you don't need this guide — follow the relevant content-type guide and the [General Content Contribution Workflow](../workflow.md) as usual; you'll land in one layer, one PR.
+
+---
+
+## The invariant
+
+Corpus changes land in a fixed, dependency-ordered sequence of layers, keyed to the corpus reference graph. **Every layer merges independently validator-green** — at every intermediate commit there is no dangling reference, no broken control-risk reciprocity, and no edgeless component. A change uses only the layers its entity types touch; an empty layer is skipped without disturbing the relative order of the layers used. See ADR-034 for the full rationale — the reference graph, the two failure modes a fixed order prevents, and the alternatives considered.
+
+---
+
+## The 7 layers
+
+Work through the layers that apply to your change, in order. Layer order is the invariant; how many PRs a layer takes is an operational choice — most single-layer changes are one PR.
+
+### Layer 1 — New components
+
+**Triggers when:** you're adding a component that doesn't exist in the corpus yet.
+
+**Files:** `risk-map/schemas/components.schema.json` (id-enum) + `risk-map/yaml/components.yaml` (the entry, **with its bidirectional edges** — both the new component's `edges.to`/`edges.from` and the reciprocal edge on every peer component it connects to).
+
+**Rule:** the new component must carry at least one real component-to-component edge. It does **not** need to be referenced by any control or risk yet — that's not required and not expected. See [New components and personas don't need control/risk coverage](#new-components-and-personas-dont-need-controlrisk-coverage) below.
+
+Follow [Adding a Component](../guide-components.md).
+
+### Layer 2 — New personas
+
+**Triggers when:** you're adding a persona that doesn't exist in the corpus yet. This is rare and held to a high bar — confirm the necessity case before drafting.
+
+**Files:** `risk-map/schemas/personas.schema.json` (id-enum) + `risk-map/yaml/personas.yaml` (the entry). Nothing else — a persona carries no reciprocal back-link field, so there's no back-link half to co-locate.
+
+**Rule:** the new persona does **not** need to be referenced by any risk or control yet — same non-requirement as Layer 1.
+
+Follow [Adding a Persona](../guide-personas.md), Steps 1-2. (Wiring the persona into existing risks/controls is a separate, later PR — see Layer 6.)
+
+### Layer 3 — Existing component and persona updates
+
+**Triggers when:** you're editing a component or persona already in the corpus (description, responsibilities, etc.) — no new ids, no deletions.
+
+**Files:** `risk-map/yaml/components.yaml` or `risk-map/yaml/personas.yaml` (YAML only, no schema edit).
+
+### Layer 4 — New controls
+
+**Triggers when:** you're adding a control that doesn't exist in the corpus yet.
+
+**Files:** `risk-map/schemas/controls.schema.json` (id-enum) + `risk-map/yaml/controls.yaml` (the entry), plus:
+
+- Any **new** risk the control requires lands in this same layer/PR, not in Layer 5 — a new risk co-dependent with a new control always lands in the earlier of the two layers (`risk-map/schemas/risks.schema.json` + `risk-map/yaml/risks.yaml`).
+- The **reciprocal back-link**: every already-existing risk the new control references gets the new control's id added to its `controls` list in `risks.yaml`, in the same PR. This is the control-half of the control-risk cycle break — the pair is never split across a layer boundary.
+
+Any persona or component the new control references already exists (Layers 1-2), so no schema edit is needed for those references.
+
+Follow [Adding a Control](../guide-controls.md).
+
+### Layer 5 — New risks
+
+**Triggers when:** you're adding a risk that doesn't exist in the corpus yet **and** it wasn't already pulled into Layer 4 as a co-dependency of a new control.
+
+**Files:** `risk-map/schemas/risks.schema.json` (id-enum) + `risk-map/yaml/risks.yaml` (the entry), plus the **reciprocal back-link**: every already-existing control the new risk references gets the new risk's id added to its `risks` list in `controls.yaml`, in the same PR.
+
+Follow [Adding a Risk](../guide-risks.md).
+
+### Layer 6 — Modifications to existing risks and controls
+
+**Triggers when:** you're editing a risk or control already in the corpus — tuneups, description improvements, or wiring in a reference to an entity that landed in an earlier layer (for example, adding a newly-landed persona to an existing risk's or control's `personas` list).
+
+**Files:** `risk-map/yaml/risks.yaml` or `risk-map/yaml/controls.yaml` (YAML only, no schema edit, no new ids).
+
+### Layer 7 — Deprecations
+
+**Triggers when:** retiring a component, control, risk, or persona.
+
+**Files:** the relevant `*.yaml` file — flip `deprecated: true` (or the entity's status field). **Never delete the id from the schema enum**; a status flip removes no edges and no references, so it's safe to land any time after every addition and modification that might have kept the entity in use, which is why it's last.
+
+---
+
+## New components and personas don't need control/risk coverage
+
+A new component or persona can land in Layer 1 or 2 with **nothing** referencing it yet, and it can stay that way indefinitely. This is intentional, not a gap: an unreferenced component is a legitimate modeled locus for controls or risks not yet authored, and a persona may precede the risks and controls that will cite it. No validator requires coverage — that non-requirement is guarded by a regression test, `scripts/hooks/tests/test_adr034_orphan_leaves_guard.py`, which pins this behavior. See ADR-034 §D3/§D3a for the full reasoning.
+
+---
+
+## Worked examples
+
+### Example A: single-entity change — one new risk, no new control
+
+You're adding a risk that's addressed entirely by controls already in the corpus.
+
+1. **Layer 5 only, one PR:**
+   - Add the id to `risk-map/schemas/risks.schema.json`.
+   - Add the entry to `risk-map/yaml/risks.yaml`, listing the existing controls that address it.
+   - Add the reciprocal back-link: for each of those existing controls, add your new risk's id to its `risks` list in `risk-map/yaml/controls.yaml`.
+2. Validate (see [Validation Tools](../validation.md)) and open the PR.
+
+No other layer is touched — the component and persona references on your new risk all point at entities that already exist.
+
+### Example B: multi-entity change — a new component with controls and risks that reference it
+
+You're adding a component, plus a control that governs it (which in turn requires a new risk), plus an additional risk against the same component that's addressed by an existing control.
+
+1. **Layer 1, PR 1:** add the new component (schema id-enum + `components.yaml` entry) with real bidirectional edges to at least one peer component. No control or risk references it yet — that's expected. Merge before starting PR 2.
+2. **Layer 4, PR 2:** add the new control (schema id-enum + `controls.yaml` entry) referencing the new component, plus the new risk it requires (schema id-enum + `risks.yaml` entry, bundled into this same PR per the co-dependent-new-node rule), plus the reciprocal back-link on every already-existing risk the new control also references. Merge before starting PR 3.
+3. **Layer 5, PR 3:** add the additional new risk (schema id-enum + `risks.yaml` entry) referencing the new component and an already-existing control, plus the reciprocal back-link on that existing control.
+
+Layers 2, 3, 6, and 7 are skipped — this change doesn't touch personas, existing-entity edits, or deprecations. Skipping a layer doesn't disturb the order of the layers used: 1, then 4, then 5.
+
+---
+
+## Validating each PR
+
+Each layer's PR must pass the same validators as any content change. See [Validation Tools](../validation.md) for the commands — schema validation, component edge consistency, and control-to-risk reference checks all run per-PR, and each layer is designed to pass every one of them on its own.
+
+---
+
+## Related documentation
+
+- ADR-034 (Dependency-ordered landing sequence for risk-map corpus changes) — the decision and rationale behind this guide
+- [General Content Contribution Workflow](../workflow.md) — the overall contribution process this guide slots into
+- [Adding a Component](../guide-components.md), [Adding a Control](../guide-controls.md), [Adding a Risk](../guide-risks.md), [Adding a Persona](../guide-personas.md) — the per-entity how-tos this guide sequences
+- [Validation Tools](../validation.md) — validator commands referenced above

--- a/risk-map/docs/guide-components.md
+++ b/risk-map/docs/guide-components.md
@@ -138,6 +138,8 @@ All files are automatically staged for your commit.
 
 After successful validation, follow the [General Content Contribution Workflow](workflow.md) to create your pull request.
 
+**Note:** A new component does not need any control or risk referencing it yet to merge — that's the normal case, not a gap to fill in this PR. If your change also adds controls or risks that reference this component, see [Landing Sequence for Corpus Changes](contributing/landing-sequence.md) — they land in a later, separate PR.
+
 ---
 
 **Related:**

--- a/risk-map/docs/guide-components.md
+++ b/risk-map/docs/guide-components.md
@@ -2,6 +2,18 @@
 
 Once you've determined the need for a new component, the following steps are required to integrate it into the framework. For this example, we'll add a new component called `componentNewComponent` to the "Application" category.
 
+## What a component is
+
+A component is an **architectural shape** — a class of element an AI system can contain — not a named thing in one deployment. `componentIdentityProvider` is the shape "identity authority"; a deployment may hold several instances of it under different authorities, and the identity provider a tool server demands is a different instance from the agent's own. Both are the same component.
+
+Three consequences follow, and each is a common source of review findings:
+
+- **A second instance does not earn a second component.** Two of the same shape under different authorities is a deployment fact, not a modeling one. What earns a second component is a second *locus* — a distinct place where something is decided, enforced, or stored.
+- **A description should not read as a singular.** Prefer "the authoritative source of identity for a deployment" over wording that implies the corpus knows of exactly one. If a sentence would be false in a deployment with two of them, rewrite it.
+- **Edges connect shapes, not instances.** An edge means "this class of element reaches that one," so an edge is right if the path exists in any deployment that has both.
+
+Adding a component is the highest-blast-radius change in the corpus: it cascades into reciprocal edges on every component it touches, the controls and risks that reference it, and the regenerated graphs and tables. Before adding one, test whether an existing component absorbs it — and if the candidate is too broad to instruct a reader, decompose an existing component instead of adding a wider one.
+
 ## 1. Add the new component ID to the schema
 
 First, derive the new component ID from the component title (`component` + camelCase descriptor — e.g., "Feature Store" → `componentFeatureStore`) and declare it in the schema. This makes the system aware of the new component and allows for validation. (The issue-template flow derives this ID automatically; when authoring YAML/schema directly via PR, apply the same convention by hand.)

--- a/risk-map/docs/guide-controls.md
+++ b/risk-map/docs/guide-controls.md
@@ -188,6 +188,8 @@ risks:
 
 Once validated, follow the [General Content Contribution Workflow](workflow.md) to create your pull request.
 
+**Note:** Step 3 above assumes the risks your new control references already exist. If your control also requires a **new** risk, see [Landing Sequence for Corpus Changes](contributing/landing-sequence.md) — the two land together in one PR, not as separate steps.
+
 ---
 
 **Related:**

--- a/risk-map/docs/guide-personas.md
+++ b/risk-map/docs/guide-personas.md
@@ -265,6 +265,11 @@ The framework ID must be defined in `frameworks.yaml` with `applicableTo` includ
 
 ## Adding a Persona
 
+This spans two PRs, in order — see [Landing Sequence for Corpus Changes](contributing/landing-sequence.md):
+
+- **PR 1:** Steps 1-2 below, then validate and submit (Step 4).
+- **PR 2 (later, after PR 1 merges):** Step 3, then validate and submit (Step 4) again.
+
 ### Step 1: Add the persona ID to the schema
 
 Declare the new persona's unique ID in `schemas/personas.schema.json`. The ID should follow the `persona[Name]` convention.
@@ -308,11 +313,11 @@ Add the definition to `yaml/personas.yaml`:
 - `identificationQuestions` - Questions to help identify if this persona applies
 - `deprecated` - Set to `true` for legacy personas
 
-### Step 3 (separate, later PR): Wire the persona into existing risks and controls
+### Step 3 (PR 2): Wire the persona into existing risks and controls
 
-Steps 1-2 above are their own PR: a new persona is a referenced-only leaf and lands on its own, with nothing referencing it yet — that's expected, not a gap to fill before merging. See [Landing Sequence for Corpus Changes](contributing/landing-sequence.md).
+A new persona is a referenced-only leaf and lands on its own in PR 1, with nothing referencing it yet — that's expected, not a gap to fill before merging.
 
-Once that PR has merged, add the new persona ID to relevant entries in `risks.yaml` and `controls.yaml` in a separate PR:
+Once PR 1 has merged, add the new persona ID to relevant entries in `risks.yaml` and `controls.yaml`:
 
 ```yaml
 # In yaml/controls.yaml
@@ -326,7 +331,7 @@ Once that PR has merged, add the new persona ID to relevant entries in `risks.ya
 
 ### Step 4: Validate and submit
 
-Run validation to ensure your changes are correct (once per PR — Steps 1-2, and again for Step 3 if you do it):
+Run validation to ensure your changes are correct — once for PR 1 (Steps 1-2) and again for PR 2 (Step 3):
 
 ```bash
 # Schema validation

--- a/risk-map/docs/guide-personas.md
+++ b/risk-map/docs/guide-personas.md
@@ -308,9 +308,11 @@ Add the definition to `yaml/personas.yaml`:
 - `identificationQuestions` - Questions to help identify if this persona applies
 - `deprecated` - Set to `true` for legacy personas
 
-### Step 3: Update existing risks and controls
+### Step 3 (separate, later PR): Wire the persona into existing risks and controls
 
-Add the new persona ID to relevant entries in `risks.yaml` and `controls.yaml`:
+Steps 1-2 above are their own PR: a new persona is a referenced-only leaf and lands on its own, with nothing referencing it yet — that's expected, not a gap to fill before merging. See [Landing Sequence for Corpus Changes](contributing/landing-sequence.md).
+
+Once that PR has merged, add the new persona ID to relevant entries in `risks.yaml` and `controls.yaml` in a separate PR:
 
 ```yaml
 # In yaml/controls.yaml
@@ -324,7 +326,7 @@ Add the new persona ID to relevant entries in `risks.yaml` and `controls.yaml`:
 
 ### Step 4: Validate and submit
 
-Run validation to ensure your changes are correct:
+Run validation to ensure your changes are correct (once per PR — Steps 1-2, and again for Step 3 if you do it):
 
 ```bash
 # Schema validation

--- a/risk-map/docs/guide-risks.md
+++ b/risk-map/docs/guide-risks.md
@@ -186,6 +186,8 @@ All files are automatically staged for your commit.
 
 Once validated, follow the [General Content Contribution Workflow](workflow.md) to create your pull request.
 
+**Note:** Step 3 above assumes the controls your new risk references already exist. If your risk also requires a **new** control, see [Landing Sequence for Corpus Changes](contributing/landing-sequence.md) — the two land together in one PR, ordered with the control, not with this risk.
+
 ---
 
 **Related:**

--- a/risk-map/docs/workflow.md
+++ b/risk-map/docs/workflow.md
@@ -17,6 +17,7 @@ This page outlines the overall process for contributing content to the CoSAI Ris
 6. Open a PR against the `develop` branch describing the Risk Map updates and validation performed
    - GitHub Actions will automatically run the same validations on your PR
    - Address any CI failures before requesting review
+   - **Change spans more than one entity type?** (e.g. a new component plus the controls and risks that reference it) — it lands as multiple PRs in a fixed order, not one. See [Landing Sequence for Corpus Changes](contributing/landing-sequence.md) before you open a PR.
 
 ## Content Type Guides
 

--- a/scripts/agents/content-reviewer.md
+++ b/scripts/agents/content-reviewer.md
@@ -93,7 +93,7 @@ This agent reads schema and corpus files directly via its own tool access when a
 
 ### ADR Citation Resolution
 
-Corpus content, PR descriptions, and prior review findings sometimes cite a specific decision as `ADR-0NN DN` (e.g. `ADR-030 D5`). Cross-cutting rules are uniformly `D`-numbered across the ADR set — there is no separate `P` tier to disambiguate. Resolve every such citation before relying on it or repeating it in a finding: read `docs/adr/0NN-*.md` and find the `### DN.` heading; do not accept a paraphrase, a title, or an inference about what a decision says as a substitute for its actual text. A rule that a decision states applies "throughout" the document can still sit inside a sub-paragraph whose surrounding heading reads as being about something else entirely — the citation is only as good as the text it resolves to.
+Corpus content, PR descriptions, and prior review findings sometimes cite a specific decision as `ADR-0NN DN` (e.g. `ADR-030 D5`). Most ADRs number cross-cutting rules `D1`, `D2`, ...; some earlier ADRs — e.g. ADR-014 — use `P1`-`P6` instead. Resolve every such citation before relying on it or repeating it in a finding: read `docs/adr/0NN-*.md` and find the heading matching the exact identifier cited (`### D5.`, `### P2.`, whichever the citation names); do not accept a paraphrase, a title, or an inference about what a decision says as a substitute for its actual text. A rule that a decision states applies "throughout" the document can still sit inside a sub-paragraph whose surrounding heading reads as being about something else entirely — the citation is only as good as the text it resolves to.
 
 ### Content Types & Key Fields
 

--- a/scripts/agents/content-reviewer.md
+++ b/scripts/agents/content-reviewer.md
@@ -88,6 +88,8 @@ If provided, use them to supplement (not override) the embedded schema awareness
 
 ## Schema Awareness
 
+This agent reads schema and corpus files directly via its own tool access when a check below says "consult the schema" or "consult the corpus" — that instruction does not depend on the caller pasting schema content into the prompt. The Input Contract's "caller may optionally provide schema files" above describes an inline convenience (skipping a tool call when the caller already has the file open), not a hard dependency the checks below assume.
+
 ### Content Types & Key Fields
 
 **Risks** (`risks.yaml`):

--- a/scripts/agents/content-reviewer.md
+++ b/scripts/agents/content-reviewer.md
@@ -68,6 +68,7 @@ The caller specifies output style via a format flag:
    - `components.yaml`
    - `personas.yaml`
    - `risk-map/yaml/archive/self-assessment-legacy.yaml` (reference only — archived per ADR-021 D6; not a review target)
+   - `docs/adr/` — the tooling/infrastructure ADR set, consulted whenever a corpus claim cites or should be checked against a specific decision (see ADR Citation Resolution below)
 
 **For `issue` mode:**
 
@@ -89,6 +90,10 @@ If provided, use them to supplement (not override) the embedded schema awareness
 ## Schema Awareness
 
 This agent reads schema and corpus files directly via its own tool access when a check below says "consult the schema" or "consult the corpus" — that instruction does not depend on the caller pasting schema content into the prompt. The Input Contract's "caller may optionally provide schema files" above describes an inline convenience (skipping a tool call when the caller already has the file open), not a hard dependency the checks below assume.
+
+### ADR Citation Resolution
+
+Corpus content, PR descriptions, and prior review findings sometimes cite a specific decision as `ADR-0NN DN` (e.g. `ADR-030 D5`). Cross-cutting rules are uniformly `D`-numbered across the ADR set — there is no separate `P` tier to disambiguate. Resolve every such citation before relying on it or repeating it in a finding: read `docs/adr/0NN-*.md` and find the `### DN.` heading; do not accept a paraphrase, a title, or an inference about what a decision says as a substitute for its actual text. A rule that a decision states applies "throughout" the document can still sit inside a sub-paragraph whose surrounding heading reads as being about something else entirely — the citation is only as good as the text it resolves to.
 
 ### Content Types & Key Fields
 

--- a/scripts/agents/content-reviewer.md
+++ b/scripts/agents/content-reviewer.md
@@ -95,7 +95,7 @@ If provided, use them to supplement (not override) the embedded schema awareness
 - Required: `id`, `title`, `description`, `category`
 - Relationships: mapped to controls that mitigate them
 - Personas: parties **impacted by** the risk (who bears the consequences). `personaEndUser` appears on most risks. `personaGovernance` is NOT used on risks (it appears exclusively on controls).
-- Categories (enum in `risks.schema.json`): `risksSupplyChainAndDevelopment`, `risksDeploymentAndInfrastructure`, `risksRuntimeInputSecurity`, `risksRuntimeDataSecurity`, `risksRuntimeOutputSecurity`
+- Categories: enum in `risks.schema.json`'s `category` definition; consult the schema rather than inferring
 - May include framework references: MITRE ATLAS, NIST AI RMF, OWASP Top 10 for LLM
 
 **Controls** (`controls.yaml`):
@@ -109,7 +109,7 @@ If provided, use them to supplement (not override) the embedded schema awareness
 
 - Required: `id`, `title`, `description`, `category`
 - Relationships: `to` and `from` edges (bidirectional, validated by external tooling)
-- Categories: `componentsData`, `componentsInfrastructure`, `componentsModel`, `componentsApplication`
+- Categories: category enum + conditional category/subcategory constraint in `components.schema.json`, mirrored in the `categories:` block of `components.yaml`; consult those rather than inferring (a category only accepts specific subcategories, and a subcategory is not itself a category)
 
 **Personas** (`personas.yaml`):
 

--- a/scripts/hooks/riskmap_validator/validator.py
+++ b/scripts/hooks/riskmap_validator/validator.py
@@ -90,6 +90,12 @@ class ComponentEdgeValidator:
         """
         Find components with no edges.
 
+        "Isolated" means no component-to-component edges only — this never checks
+        whether a component is referenced by any control or risk. That coverage
+        axis is intentionally left unchecked per ADR-034 §D3a: a new component may
+        land with edges but zero control/risk coverage. Do not add per-PR coverage
+        enforcement here without revisiting that ADR.
+
         Returns:
             Set of isolated component IDs
         """

--- a/scripts/hooks/tests/test_adr034_orphan_leaves_guard.py
+++ b/scripts/hooks/tests/test_adr034_orphan_leaves_guard.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Regression guard for ADR-034 §D3a — orphan leaves are deliberately allowed.
+
+A newly-added component (with its bidirectional edges) or a newly-added
+persona may be referenced by zero controls and zero risks and must still
+pass validation. This is what lets a new component/persona land in its own
+PR (ADR-034 Layers 1-2) before the controls/risks that will reference it.
+
+No validator today enforces coverage, and none should without revisiting
+ADR-034 §D3a. This file pins that absence: if a future contributor adds a
+per-PR coverage check to any of the three seams below, the corresponding
+test here starts failing.
+
+Case A targets the component side: `ComponentEdgeValidator` (edge-only
+isolation, not coverage) and `validate_control_risk_references`
+(control<->risk reciprocity only, no notion of components at all). Case B
+targets the persona side: `build_persona_site_data.build_site_data`, which
+seeds every active persona with empty risk/control id lists regardless of
+whether anything references it.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from riskmap_validator.validator import ComponentEdgeValidator  # noqa: E402
+from validate_control_risk_references import validate_control_to_risk  # noqa: E402
+
+from scripts.build_persona_site_data import build_site_data  # noqa: E402
+
+
+class TestOrphanComponentPassesValidation:
+    """ADR-034 §D3a: an edged-but-uncovered component must pass validation."""
+
+    def test_edged_but_uncovered_component_passes_component_edge_validator(self, tmp_path):
+        """
+        A component with real bidirectional edges but zero control/risk
+        coverage must not be flagged as isolated.
+
+        ADR-034 §D3a: "isolated" means no component-to-component edges;
+        coverage by a control or risk is a different, intentionally
+        unchecked, axis. If a future coverage check is added to
+        ComponentEdgeValidator, this assertion flips to False.
+        """
+        data = {
+            "components": [
+                {
+                    "id": "comp-orphan-guard",
+                    "title": "Orphan Guard Component",
+                    "category": "test1",
+                    "edges": {"to": ["comp-orphan-guard-peer"], "from": []},
+                },
+                {
+                    "id": "comp-orphan-guard-peer",
+                    "title": "Orphan Guard Peer",
+                    "category": "test1",
+                    "edges": {"to": [], "from": ["comp-orphan-guard"]},
+                },
+            ]
+        }
+        yaml_file = tmp_path / "components.yaml"
+        yaml_file.write_text(yaml.dump(data))
+
+        validator = ComponentEdgeValidator(allow_isolated=False, verbose=False)
+        assert validator.validate_file(yaml_file) is True
+
+    def test_control_risk_validator_has_no_notion_of_component_coverage(self):
+        """
+        `validate_control_risk_references` must pass a fully self-consistent
+        controls.yaml/risks.yaml pair that never mentions a given component id.
+
+        ADR-034 §D3a: this validator checks only control<->risk reciprocity;
+        it never touches components.yaml, so an uncovered component cannot
+        fail it. "comp-orphan-guard" (from the sibling test above) never
+        appears below — if a future contributor teaches this validator to
+        consult components.yaml for coverage, this assertion starts failing.
+        """
+        controls_yaml = {
+            "controls": [
+                {"id": "CTL-ORPHAN-GUARD", "risks": ["RSK-ORPHAN-GUARD"]},
+            ]
+        }
+        risks_yaml = {
+            "risks": [
+                {"id": "RSK-ORPHAN-GUARD", "controls": ["CTL-ORPHAN-GUARD"]},
+            ]
+        }
+
+        with patch("validate_control_risk_references.load_yaml_file") as mock_load:
+            mock_load.side_effect = [controls_yaml, risks_yaml]
+            result = validate_control_to_risk([Path("controls.yaml"), Path("risks.yaml")])
+
+        assert result is True
+
+
+class TestOrphanPersonaPassesValidation:
+    """ADR-034 §D3a: a persona referenced by zero risks/controls must pass the site build."""
+
+    def test_uncovered_persona_builds_with_empty_risk_and_control_ids(self):
+        """
+        A persona with no risk or control referencing it must still build
+        successfully, with empty riskIds/controlIds rather than an error.
+
+        ADR-034 §D3a: `build_site_data` seeds every active persona with an
+        empty risk/control id list up front (build_persona_site_data.py
+        risk_ids_by_persona / control_ids_by_persona), so an unreferenced
+        persona is never rejected. If a future contributor adds a coverage
+        requirement here, this assertion starts failing.
+        """
+        personas_data = {
+            "personas": [
+                {"id": "personaOrphanGuard", "title": "Orphan Guard Persona"},
+            ]
+        }
+        risks_data = {"risks": []}
+        controls_data = {"categories": [], "controls": []}
+
+        site_data = build_site_data(personas_data, risks_data, controls_data, components_data={})
+
+        persona_ids = [p["id"] for p in site_data["personas"]]
+        assert "personaOrphanGuard" in persona_ids
+
+        persona_record = next(p for p in site_data["personas"] if p["id"] == "personaOrphanGuard")
+        assert persona_record["riskIds"] == []
+        assert persona_record["controlIds"] == []
+        assert persona_record["riskCount"] == 0
+        assert persona_record["controlCount"] == 0

--- a/scripts/hooks/validate_control_risk_references.py
+++ b/scripts/hooks/validate_control_risk_references.py
@@ -8,6 +8,13 @@ This script validates that:
 - Controls or risks that list "all" or "none" are exempt from validation.
 - Identifies any controls or risks that have no cross-references.
 
+This validator checks only control<->risk reciprocity; it never loads
+components.yaml or personas.yaml and so has no notion of component or persona
+coverage. That is intentional per ADR-034 §D3a: a newly-added component or
+persona may be referenced by zero controls/risks and must still pass. Do not
+add per-PR component/persona coverage enforcement here without revisiting
+that ADR.
+
 Only runs when YAML files are modified in the commit.
 Provides -f/--force option to run validation regardless of git status.
 """

--- a/scripts/skills/README.md
+++ b/scripts/skills/README.md
@@ -68,3 +68,7 @@ python3 scripts/hooks/precommit/validate_neutrality.py scripts/skills/<name>/SKI
   risks, controls, and personas against the framework-mappings style
   guide (version pinning, applicability, selectivity), deferring format
   to the style guide (ADR-031 D2, ADR-027).
+- `audit-identification-questions/` — audits persona identification
+  questions against the identification-questions style guide (framing,
+  scoping, examples, ordering), deferring the rules to the style guide
+  (ADR-031 D5, ADR-021 D7).

--- a/scripts/skills/README.md
+++ b/scripts/skills/README.md
@@ -64,3 +64,7 @@ python3 scripts/hooks/precommit/validate_neutrality.py scripts/skills/<name>/SKI
   pitched at the right altitude (granularity), applying the per-type
   altitude tests and deferring terminology to `classical-lexicon`
   (ADR-031 D2).
+- `audit-framework-mappings/` — audits the framework mappings across
+  risks, controls, and personas against the framework-mappings style
+  guide (version pinning, applicability, selectivity), deferring format
+  to the style guide (ADR-031 D2, ADR-027).

--- a/scripts/skills/README.md
+++ b/scripts/skills/README.md
@@ -60,3 +60,7 @@ python3 scripts/hooks/precommit/validate_neutrality.py scripts/skills/<name>/SKI
 - `mapping-selection/` — selects a control's/risk's components, addressed
   risks/controls, and framework mappings, grounded in the corpus and the
   framework applicability rules (ADR-031 D2/D4).
+- `altitude-check/` — checks whether a control/risk/component draft is
+  pitched at the right altitude (granularity), applying the per-type
+  altitude tests and deferring terminology to `classical-lexicon`
+  (ADR-031 D2).

--- a/scripts/skills/README.md
+++ b/scripts/skills/README.md
@@ -70,5 +70,6 @@ python3 scripts/hooks/precommit/validate_neutrality.py scripts/skills/<name>/SKI
   to the style guide (ADR-031 D2, ADR-027).
 - `audit-identification-questions/` — audits persona identification
   questions against the identification-questions style guide (framing,
-  scoping, examples, ordering), deferring the rules to the style guide
-  (ADR-031 D5, ADR-021 D7).
+  scoping, examples, ordering), deferring the rules to the style guide.
+  Editorial responsibility per ADR-021 D7; admitted to this roster per the
+  [2026-08-02 ADR-031 amendment](../../docs/adr/031-authoring-time-agents-and-skills.md#amendment-2026-08-02-admission-of-audit-identification-questions-as-a-fifth-authoring-skill) D7.

--- a/scripts/skills/altitude-check/SKILL.md
+++ b/scripts/skills/altitude-check/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: altitude-check
+description: "Check whether a CoSAI Risk Map entry is pitched at the right altitude (granularity). For a control: objective-not-implementation, not-a-restated-risk, posture-not-mandate, solved-problem, no-duplication. For a risk: the merge-vs-distinct two-test, threat-not-control-gap, and real-not-hypothetical. For a component: the absorb-or-decompose base test, role-not-product, and reader-instructive. Use when authoring or reviewing a control/risk/component draft, when a draft reads like implementation detail or a restated threat, or to decide whether a candidate should be new, merged, or absorbed into an existing entry."
+---
+
+# Altitude Check
+
+Altitude is the granularity an entry is pitched at. Too low and it becomes implementation detail or an instance that sprawls into siblings; too high and it dissolves the gap it was meant to name. Most authoring defects are altitude defects, so check altitude before wording.
+
+Run the tests for the entry type. The control, risk, and component tests are all active; run the set matching the entry type.
+
+## Control altitude tests
+
+Apply each; report pass or adjust-with-fix.
+
+- **T1 — Objective, not implementation.** The control states a capability or objective ("ensure delegation chains are auditable"), not a mechanism ("emit signed delegation spans with correlation IDs to a collector"). The objective survives implementation churn. *Fix:* lift the mechanism into a description example and restate the objective.
+- **T2 — Not a restated risk.** A control is the defense framed as a positive capability, not the threat with "prevent" attached. If it reads like the risk inverted, rewrite it as the capability the implementer gains.
+- **T3 — Posture, not mandate.** A control describes a defensive capability an implementer adopts against their risk appetite; it is not a compliance order. Watch for "must always," universal imperatives, and audit-language.
+- **T4 — Solved problem.** A known technique achieves the objective. If none does, this is a research gap or a risk to document — not a control. *Fix:* flag it for the maintainer rather than drafting an aspirational control.
+- **T5 — Generalized and grounded.** The control names a role/locus, not a product or protocol, and uses established terminology (defer terminology to the classical-lexicon skill). *Fix:* generalize; keep the product as an example.
+- **T6 — Novelty vs absorb.** Read `risk-map/yaml/controls.yaml`. Does an existing control already cover this objective? If so, recommend **augmenting** that control rather than adding a near-duplicate. If genuinely distinct, state in one sentence what distinguishes it from the nearest existing control.
+
+## Risk altitude tests
+
+Apply each; report pass or adjust-with-fix.
+
+- **R1 — Merge-vs-distinct two-test.** A candidate is a distinct risk only if it impacts a **different component locus** OR is a **distinct impact class**. If neither holds, it should merge into an existing risk (check `risk-map/yaml/risks.yaml`) — as an added paragraph or a `{{ref:}}` — rather than stand alone.
+- **R2 — Wrong-home.** If a candidate resists clean merging *and* is not clearly distinct, it may belong to a domain the corpus lacks. Flag the missing domain rather than forcing it into the nearest existing risk.
+- **R3 — Threat, not control-gap.** A risk names a way the system can be harmed, not the missing defense. "No input validation" is a control gap; the risk is the harm the gap enables. Rewrite a control-absence framing as the threat and its impact.
+- **R4 — Real, not hypothetical.** A risk should be demonstrable — grounded in a real incident, research result, or vulnerability class, not a speculative "what if." If no such evidence exists, flag it rather than asserting the risk.
+
+## Component altitude tests
+
+Apply each; report pass or adjust-with-fix.
+
+- **C1 — Absorb-or-decompose base test (both must hold to keep a new component).** (1) Can it absorb into an existing component (check `risk-map/yaml/components.yaml`)? (2) Would a reader still know *where* a control or risk applies at this grain? Outcomes: **absorb** into an existing component / **new at a de-sprawled band** / **decompose** an existing too-broad component.
+- **C2 — Role, not product/protocol.** The component's identity is the role or locus it occupies; a specific product or protocol (a named framework, a vendor tool) is an attribute, not the identity. A protocol-named component invites sibling sprawl. Generalize, and keep the product only as an example. (Defer terminology to the classical-lexicon skill.)
+- **C3 — Reader-instructive.** A component earns its place only if naming it tells a reader *where* a control or risk attaches. If adding it does not change where anything attaches, it is too fine-grained — absorb it.
+
+## Output format
+
+- Per test: **pass** or **adjust** with the specific fix.
+- **Overall verdict:** one of *well-pitched* / *needs adjustment* (list the fixes) / *should merge or absorb* (name the target).
+- If a test surfaces a maintainer decision (T4 unsolved problem, T6 arguable duplication), state it plainly rather than resolving it.

--- a/scripts/skills/altitude-check/SKILL.md
+++ b/scripts/skills/altitude-check/SKILL.md
@@ -33,7 +33,7 @@ Apply each; report pass or adjust-with-fix.
 
 Apply each; report pass or adjust-with-fix.
 
-- **C1 — Absorb-or-decompose base test (both must hold to keep a new component).** (1) Can it absorb into an existing component (check `risk-map/yaml/components.yaml`)? (2) Would a reader still know *where* a control or risk applies at this grain? Outcomes: **absorb** into an existing component / **new at a de-sprawled band** / **decompose** an existing too-broad component.
+- **C1 — Absorb-or-decompose base test (both must hold to keep a new component).** (1) It **cannot** cleanly absorb into an existing component (check `risk-map/yaml/components.yaml`). (2) Naming it at this grain still tells a reader *where* a control or risk applies. Outcomes: **absorb** into an existing component (fails (1)) / **new at a de-sprawled band** (clears both) / **decompose** an existing too-broad component (the existing component itself fails to be reader-instructive at its current grain).
 - **C2 — Role, not product/protocol.** The component's identity is the role or locus it occupies; a specific product or protocol (a named framework, a vendor tool) is an attribute, not the identity. A protocol-named component invites sibling sprawl. Generalize, and keep the product only as an example. (Defer terminology to the classical-lexicon skill.)
 - **C3 — Reader-instructive.** A component earns its place only if naming it tells a reader *where* a control or risk attaches. If adding it does not change where anything attaches, it is too fine-grained — absorb it.
 

--- a/scripts/skills/altitude-check/evals/evals.json
+++ b/scripts/skills/altitude-check/evals/evals.json
@@ -1,0 +1,115 @@
+{
+  "skill_name": "altitude-check",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Check the altitude of this control description: 'Deploy a sidecar that intercepts every tool call, computes a risk score via an ML classifier, and writes the decision to the OTel collector with a correlation ID.'",
+      "expected_output": "T1 fails — this is implementation, not an objective. Restate as the capability (e.g. calibrate/gate tool-call approval by risk) and move the sidecar/classifier/OTel details to examples.",
+      "expectations": [
+        "Flags T1 (objective-not-implementation) as failing",
+        "Identifies the sidecar / ML classifier / OTel collector as implementation detail to move into examples",
+        "Proposes an objective-level restatement of the capability"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Check the altitude of this control: title 'Prevent Prompt Injection', description 'Stop attackers from injecting instructions that make the model deviate from its intended behavior.'",
+      "expected_output": "T2 fails — this restates the risk rather than naming a defensive capability. Rewrite as the capability (e.g. input validation and sanitization) framed positively.",
+      "expectations": [
+        "Flags T2 (not-a-restated-risk) as failing",
+        "Explains that it describes the threat inverted rather than a positive defensive capability",
+        "Proposes a capability-framed rewrite"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Altitude check: proposed control 'Input Validation for Model Inputs' — validate and sanitize inputs to the model to remove malicious or malformed content before inference.",
+      "expected_output": "T6 — likely duplicates the existing controlInputValidationAndSanitization; recommend augmenting the existing control rather than adding a near-duplicate (or state what distinguishes it).",
+      "expectations": [
+        "Checks the existing corpus (controls.yaml) for overlap",
+        "Identifies likely duplication with an existing input-validation control",
+        "Recommends augmenting the existing control or clearly stating what distinguishes the new one"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Altitude check: control 'Delegation Chain Auditability' — ensure that, at each delegation hop, an agent acting on behalf of a caller produces a verifiable record of whose authority it exercised. Known techniques: signed delegation tokens, scoped capability records.",
+      "expected_output": "Well-pitched: states an objective (T1 pass), not a restated risk (T2), posture not mandate (T3), a solved problem with known techniques (T4). Overall well-pitched.",
+      "expectations": [
+        "Judges T1 (objective not implementation) as passing",
+        "Judges T4 (solved problem) as passing given the named known techniques",
+        "Overall verdict is well-pitched (no altitude adjustment required)"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Altitude check: proposed risk 'Opaque Multi-Hop Agent Authorization' — in agentic systems where one agent delegates to another across tools and MCP servers, intermediate agents fail to emit structured delegation events, so forensics cannot determine which human or agent authorized an action even though every hop's token was cryptographically valid.",
+      "expected_output": "R1 — should merge. This is the same impact class (accountability/forensic opacity) at the same component locus (the delegation/IAM/orchestration layer) as the existing riskAgentDelegationChainOpacity; it fails the merge-vs-distinct two-test (neither a different component locus nor a distinct impact class). Recommend merging into riskAgentDelegationChainOpacity (as an added paragraph or a {{ref:}}) rather than standing it up as a new risk.",
+      "expectations": [
+        "Checks risks.yaml and identifies the near-identical existing risk riskAgentDelegationChainOpacity",
+        "Applies the R1 two-test and finds neither a different component locus nor a distinct impact class",
+        "Recommends merging into the existing delegation-opacity risk rather than adding a standalone risk"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Altitude check: proposed risk 'Confused-Deputy Privilege Escalation via Agent Delegation' — a high-privilege agent acts on behalf of a lower-privilege caller without re-validating the caller's authorization at the delegation boundary, letting the caller escalate through the deputy's own permissions (e.g. an IDE agent using service-role credentials that bypass row-level security). We already catalog agent delegation-chain opacity; is this the same risk?",
+      "expected_output": "R1 — distinct, keep separate. Although both sit in the agent-delegation family, this passes the merge-vs-distinct two-test: it is a distinct impact class (confidentiality/integrity privilege-escalation harm) versus the accountability/forensic-visibility harm of riskAgentDelegationChainOpacity. It is a real risk (riskAgenticDelegationConfusedDeputy), not a duplicate. Keep it as its own entry; state in one sentence that opacity is a visibility failure while confused-deputy is an authorization-boundary failure.",
+      "expectations": [
+        "Applies the R1 two-test and concludes the candidate is DISTINCT, not a merge",
+        "Grounds the distinction in a different impact class (privilege escalation / confidentiality-integrity vs accountability opacity), naming riskAgenticDelegationConfusedDeputy and riskAgentDelegationChainOpacity",
+        "Does not recommend merging; keeps the candidate as its own risk"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Altitude check: proposed risk 'No Rate Limiting on Agent Tool Calls' — the orchestration layer does not cap how many tool invocations an agent may issue, so nothing stops it.",
+      "expected_output": "R3 fails — this is framed as a control gap (a missing rate-limit defense), not a threat. Rewrite as the harm the gap enables: agents entering uncontrolled recursive tool-calling cycles that exhaust context windows, compute, and API budget (availability/cost impact) — which the corpus already captures as riskRunawayAgentToolLoops. Reframe to the threat-and-impact, then run the R1 merge check against riskRunawayAgentToolLoops.",
+      "expectations": [
+        "Flags R3 (threat-not-control-gap) as failing — the title names a missing defense, not a harm",
+        "Rewrites the control-absence framing as the threat and its impact (uncontrolled recursive tool loops exhausting resources)",
+        "Connects the reframed threat to the existing riskRunawayAgentToolLoops (and notes the R1 merge check)"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Altitude check: proposed risk 'Sentient Agent Collusion' — a speculative future risk that autonomous agents could spontaneously develop shared hidden goals and coordinate to deceive their operators. No incident, research result, or vulnerability class is cited.",
+      "expected_output": "R4 fails — real, not hypothetical. There is no demonstrable incident, research result, or vulnerability class grounding this; it is a speculative 'what if.' Flag it for the maintainer rather than asserting the risk. (Contrast the corpus's grounded agentic risks, which each cite a real example, e.g. riskRunawayAgentToolLoops and riskAgenticDelegationConfusedDeputy.)",
+      "expectations": [
+        "Flags R4 (real-not-hypothetical) as failing due to absence of a real incident, research result, or vulnerability class",
+        "Recommends flagging for the maintainer rather than asserting the risk",
+        "Does not fabricate evidence to justify the risk"
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "Altitude check: proposed component 'Vector Store' — the database that holds embedding vectors the agent queries for retrieval-augmented generation (e.g. a managed vector index).",
+      "expected_output": "C1 — absorb. An existing component already covers this locus: componentRAGContent (Retrieval Augmented Generation & Content). A vector store is the storage mechanism behind RAG, not a distinct role; naming it separately does not change where a control or risk attaches beyond what componentRAGContent already anchors. Recommend absorbing into componentRAGContent (keep the vector store as an example), rather than adding a new component.",
+      "expectations": [
+        "Checks components.yaml and identifies componentRAGContent as the existing home",
+        "Applies C1 absorb-or-decompose and concludes ABSORB (a reader would not learn a new place a control/risk attaches)",
+        "Recommends absorbing into componentRAGContent and keeping the vector store as an example, not a new node"
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "Altitude check: proposed component 'MCP Server' — a Model Context Protocol server the agent connects to in order to invoke external tools and services.",
+      "expected_output": "C2 fails — role, not product/protocol. 'MCP Server' names a specific protocol; a protocol-named component invites sibling sprawl (A2A server, OpenAPI tool server, ...). The role/locus is 'external tools and services the agent calls,' already captured by componentTools. Generalize to that role and keep MCP as an example; do not add a protocol-named component. (Defer terminology to the classical-lexicon skill.)",
+      "expectations": [
+        "Flags C2 (role-not-product/protocol) as failing — MCP is a protocol name, not a role",
+        "Notes protocol-named components invite sibling sprawl and identifies componentTools as the existing role/locus",
+        "Recommends generalizing to the role and keeping MCP as an example (and defers terminology to classical-lexicon)"
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "Altitude check: proposed component 'Agent System-Prompt Whitespace Normalizer' — the step that trims trailing whitespace from the agent's system instructions before they reach the reasoning core.",
+      "expected_output": "C3 fails — not reader-instructive. Naming this does not change where any control or risk attaches; it is a fine-grained processing detail inside components that already exist (componentAgentSystemInstruction / componentAgentInputHandling / componentReasoningCore). Absorb it — it is too fine-grained to earn a node.",
+      "expectations": [
+        "Flags C3 (reader-instructive) as failing — adding it changes where nothing attaches",
+        "Identifies the existing coarser components it belongs inside (e.g. componentAgentSystemInstruction / componentAgentInputHandling / componentReasoningCore)",
+        "Recommends absorbing it as too fine-grained rather than adding a new component"
+      ]
+    }
+  ]
+}

--- a/scripts/skills/altitude-check/evals/evals.json
+++ b/scripts/skills/altitude-check/evals/evals.json
@@ -110,6 +110,50 @@
         "Identifies the existing coarser components it belongs inside (e.g. componentAgentSystemInstruction / componentAgentInputHandling / componentReasoningCore)",
         "Recommends absorbing it as too fine-grained rather than adding a new component"
       ]
+    },
+    {
+      "id": 12,
+      "prompt": "Use ONLY the component list below to decide absorb/new/decompose — not the live risk-map/yaml/components.yaml, which changes over time (per ADR-033 Amendment 2026-07-30, this is a pinned eval fixture, not corpus content):\n\n- componentAgentReasoningCore — the agent's core reasoning/decision loop\n- componentAgentInputHandling — validates and normalizes input format/structure (encoding, schema, length) reaching the reasoning core; does not perform semantic or adversarial-content analysis\n- componentTools — external tools/services the agent invokes\n- componentRAGContent — retrieval-augmented-generation content store\n- componentModelServing — runtime that serves the model for inference\n- componentTrainingData — data used to train/fine-tune the model\n- componentEvalHarnessAndReporting — benchmark selection, running evals, scoring, and generating the report (one node covering three distinct loci)\n\nAltitude check: proposed component 'Prompt Injection Detection Filter' — sits between input handling and the reasoning core, scanning incoming content specifically for adversarial injection patterns before it reaches the reasoning core.",
+      "expected_output": "C1 — new at a de-sprawled band. Condition (1): it cannot cleanly absorb — componentAgentInputHandling validates/normalizes format, not adversarial content, a distinct locus; no other fixture entry is a candidate. Condition (2): reader-instructive — a control targeting injection-detection attaches here specifically, not generically to input handling. Both conditions clear, so this earns a new node rather than being folded into an existing one.",
+      "expectations": [
+        "Uses only the fixture list, not the live components.yaml, to ground the verdict",
+        "Concludes C1 clears both conditions and the outcome is new (not absorb, not decompose)",
+        "States it cannot absorb into componentAgentInputHandling because that component covers format validation, not adversarial-content detection",
+        "States naming it separately is reader-instructive because a control on injection detection attaches at a different point than generic input handling"
+      ]
+    },
+    {
+      "id": 13,
+      "prompt": "Use ONLY the component list below to decide absorb/new/decompose — not the live risk-map/yaml/components.yaml, which changes over time (per ADR-033 Amendment 2026-07-30, this is a pinned eval fixture, not corpus content):\n\n- componentAgentReasoningCore — the agent's core reasoning/decision loop\n- componentAgentInputHandling — validates and normalizes input format/structure (encoding, schema, length) reaching the reasoning core; does not perform semantic or adversarial-content analysis\n- componentTools — external tools/services the agent invokes\n- componentRAGContent — retrieval-augmented-generation content store\n- componentModelServing — runtime that serves the model for inference\n- componentTrainingData — data used to train/fine-tune the model\n- componentEvalHarnessAndReporting — benchmark selection, running evals, scoring, and generating the report (one node covering three distinct loci)\n\nAltitude check: proposed component 'Agent Memory Consolidation Step' — the process that periodically summarizes and folds prior conversation/episodic context into the agent's longer-term memory store, distinct from the reasoning core's per-turn processing.",
+      "expected_output": "C1 — new at a de-sprawled band. Condition (1): it cannot cleanly absorb — componentAgentReasoningCore handles per-turn inference, not periodic memory consolidation, and no other fixture entry is a candidate. Condition (2): reader-instructive — a control on memory-consolidation integrity (e.g. preventing a poisoned summary from persisting into long-term memory) attaches differently than one on the reasoning core itself, so naming this separately changes where that control attaches. Both conditions clear.",
+      "expectations": [
+        "Uses only the fixture list, not the live components.yaml, to ground the verdict",
+        "Concludes C1 clears both conditions and the outcome is new (not absorb, not decompose)",
+        "States it cannot absorb into componentAgentReasoningCore because that component is per-turn inference, not periodic memory consolidation",
+        "Explicitly addresses condition (2) (reader-instructive) rather than only condition (1), naming a control that would attach differently to memory consolidation than to the reasoning core"
+      ]
+    },
+    {
+      "id": 14,
+      "prompt": "Use ONLY the component list below to decide absorb/new/decompose — not the live risk-map/yaml/components.yaml, which changes over time (per ADR-033 Amendment 2026-07-30, this is a pinned eval fixture, not corpus content):\n\n- componentAgentReasoningCore — the agent's core reasoning/decision loop\n- componentAgentInputHandling — validates and normalizes input format/structure (encoding, schema, length) reaching the reasoning core; does not perform semantic or adversarial-content analysis\n- componentTools — external tools/services the agent invokes\n- componentRAGContent — retrieval-augmented-generation content store\n- componentModelServing — runtime that serves the model for inference\n- componentTrainingData — data used to train/fine-tune the model\n- componentEvalHarnessAndReporting — benchmark selection, running evals, scoring, and generating the report (one node covering three distinct loci)\n\nAltitude check: a contributor wants to attach a 'Benchmark Selection Bias' risk to componentEvalHarnessAndReporting. Should it absorb there, or does something else need to happen first?",
+      "expected_output": "C1 — decompose. componentEvalHarnessAndReporting bundles three distinct loci (benchmark selection, eval execution, report generation); a benchmark-selection-bias risk attaches specifically to the selection locus, not execution or reporting, so the existing fixture entry is itself not reader-instructive at its current grain. Recommend decomposing componentEvalHarnessAndReporting into its distinct loci (e.g. benchmark selection, eval execution, reporting) rather than absorbing yet another concern into the bundled node.",
+      "expectations": [
+        "Uses only the fixture list, not the live components.yaml, to ground the verdict",
+        "Concludes the outcome is decompose, not absorb and not new",
+        "Identifies that componentEvalHarnessAndReporting bundles three distinct loci (selection, execution, reporting)",
+        "Recommends decomposing the existing component rather than simply absorbing the new risk into it"
+      ]
+    },
+    {
+      "id": 15,
+      "prompt": "Use ONLY the component list below to decide absorb/new/decompose — not the live risk-map/yaml/components.yaml, which changes over time (per ADR-033 Amendment 2026-07-30, this is a pinned eval fixture, not corpus content):\n\n- componentAgentReasoningCore — the agent's core reasoning/decision loop\n- componentAgentInputHandling — validates and normalizes input format/structure (encoding, schema, length) reaching the reasoning core; does not perform semantic or adversarial-content analysis\n- componentTools — external tools/services the agent invokes\n- componentRAGContent — retrieval-augmented-generation content store\n- componentModelServing — runtime that serves the model for inference\n- componentTrainingData — data used to train/fine-tune the model\n- componentEvalHarnessAndReporting — benchmark selection, running evals, scoring, and generating the report (one node covering three distinct loci)\n\nAltitude check: separately, another contributor wants to attach a 'Report Falsification / Tampering' risk to componentEvalHarnessAndReporting. Same question: absorb, new, or decompose?",
+      "expected_output": "C1 — decompose, same underlying defect as the benchmark-selection case reached from a different angle: this confirms the decompose verdict is driven by componentEvalHarnessAndReporting's own grain problem (reachable from more than one direction), not a one-off artifact of how one case happened to be framed. Report falsification attaches to the reporting locus specifically, distinct from selection and execution — again showing the bundled node isn't reader-instructive. Recommend the same decomposition as case 14.",
+      "expectations": [
+        "Uses only the fixture list, not the live components.yaml, to ground the verdict",
+        "Concludes the outcome is decompose, not absorb and not new",
+        "Identifies that the report-falsification concern attaches to the reporting locus specifically, distinct from selection/execution",
+        "Recognizes this as the same grain defect as a benchmark-selection-style case, reachable from a different angle, not a one-off"
+      ]
     }
   ]
 }

--- a/scripts/skills/altitude-check/evals/fixtures/components-fixture.md
+++ b/scripts/skills/altitude-check/evals/fixtures/components-fixture.md
@@ -1,0 +1,23 @@
+# Component placement fixture
+
+**This is test input, not CoSAI Risk Map content.** It is a small, hand-authored, purpose-built
+stand-in for `risk-map/yaml/components.yaml`, used only to grade eval cases whose correct verdict
+depends on "does anything already cover this candidate" — never the live, growing corpus (see
+ADR-033 Amendment 2026-07-30, D7). It must not be cited, validated, or consumed as if it were real
+Risk Map content. It is refreshed only if the component entity shape changes structurally (e.g. a
+required schema field is added), never in response to the real corpus growing.
+
+Fixture entries:
+
+- `componentAgentReasoningCore` — the agent's core reasoning/decision loop.
+- `componentAgentInputHandling` — validates and normalizes input format/structure (encoding,
+  schema, length) reaching the reasoning core; does not perform semantic or adversarial-content
+  analysis.
+- `componentTools` — external tools and services the agent invokes.
+- `componentRAGContent` — the retrieval-augmented-generation content store.
+- `componentModelServing` — the runtime that serves the model for inference.
+- `componentTrainingData` — data used to train or fine-tune the model.
+- `componentEvalHarnessAndReporting` — benchmark selection, running evals, scoring, and
+  generating the human-facing report, all in one node. **Deliberately over-broad** — three
+  distinct loci (selection, execution, reporting) bundled together, a C3 "not
+  reader-instructive at this grain" failure that should decompose, not merely adjust.

--- a/scripts/skills/audit-framework-mappings/SKILL.md
+++ b/scripts/skills/audit-framework-mappings/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: audit-framework-mappings
+description: Audit all framework mappings in risks.yaml, controls.yaml, and personas.yaml against the framework mappings style guide. Use when reviewing or proposing changes to mappings sections.
+---
+
+# Framework Mappings Audit
+
+Audit framework mappings for correctness, style compliance, and term validity.
+
+## Scope
+
+Target: a single entity id (e.g., `riskModelEvasion`, `controlInputValidationAndSanitization`, `personaEndUser`), or the whole corpus — every entity across `risks.yaml`, `controls.yaml`, `personas.yaml` (the default). If a specific entity id is given, audit only that entity's mappings.
+
+## Reference documents
+
+Read these before auditing:
+
+1. **Style guide** (authoritative): `risk-map/docs/contributing/framework-mappings-style-guide.md`
+
+## Audit checklist
+
+For each entity with mappings, verify ALL of the following. Report pass/fail per item.
+
+### Format and version compliance
+
+Mapping values are **version-pinned** (ADR-027): every value carries its framework's version token. Verify each value against the **canonical pinned pattern for its framework in the authoritative style guide** — read the patterns from the guide, do not restate them from memory (restating them here is how this check previously drifted stale). As of the current guide the pinned forms are, for example:
+
+- **MITRE ATLAS:** `AML.T####@5.0.1` / `AML.T####.###@5.0.1` (techniques), `AML.M####@5.0.1` (mitigations)
+- **NIST AI RMF:** subcategory-level, full function name, version-pinned — e.g. `MEASURE-2.3@1.0`, `GOVERN-6.2@1.0` (never the category alone, never an abbreviation like `MS-2.3`)
+- **STRIDE:** PascalCase, unversioned — `Spoofing`, `Tampering`, `Repudiation`, `InformationDisclosure`, `DenialOfService`, `ElevationOfPrivilege`
+- **OWASP Top 10 for LLM:** `LLM##:2025`
+- **ISO 22989:** the controlled role name, version-pinned `@2022`
+- **EU AI Act:** `Article ##@2024` / `Article ##(#)@2024`
+
+Flag any value whose form or version token does not match the guide's current pinned pattern.
+
+*(This skill AUDITS existing mappings across the corpus; to SELECT mappings while authoring a single control or risk, use the `mapping-selection` skill.)*
+
+### Structural compliance
+
+- [ ] **No parent + sub-technique collisions**: If `AML.T0010.002` is used, `AML.T0010` must NOT appear on the same entity
+- [ ] **No technique/mitigation crossover**: Risks use only `AML.T####`; controls use only `AML.M####`
+- [ ] **applicableTo respected**: Each framework is only used on entity types listed in its `applicableTo` (per style guide table)
+
+### Selectivity compliance
+
+- [ ] **Soft limit (4 per framework)**: Flag any entity with more than 4 mappings in a single framework. Not a hard error, but requires justification.
+- [ ] **Direct relevance**: Each mapping should be defensible with a one-sentence rationale. Flag mappings where the connection is "related" rather than "directly relevant."
+
+### Term and identifier verification
+
+- [ ] **Verify identifiers exist in the source framework.** For MITRE ATLAS, confirm technique/mitigation IDs are real. For OWASP, confirm the category title matches. For ISO 22989, confirm role names match the standard's terminology.
+- [ ] **When proposing new mappings**, search the web to confirm the identifier is current and not deprecated or renamed in the latest version of the framework.
+
+## Coverage analysis (for whole-corpus scope only)
+
+- Count entities with vs. without mappings per entity type
+- Identify unmapped entities where obvious framework matches exist
+- Note underutilized frameworks (e.g., NIST AI RMF, OWASP LLM08)
+- Note STRIDE categories never used
+
+## Output format
+
+For targeted audits (single entity), provide:
+
+1. Current mappings listed per framework
+2. Pass/fail on each checklist item
+3. Any recommended additions or removals with rationale

--- a/scripts/skills/audit-framework-mappings/SKILL.md
+++ b/scripts/skills/audit-framework-mappings/SKILL.md
@@ -23,14 +23,7 @@ For each entity with mappings, verify ALL of the following. Report pass/fail per
 
 ### Format and version compliance
 
-Mapping values are **version-pinned** (ADR-027): every value carries its framework's version token. Verify each value against the **canonical pinned pattern for its framework in the authoritative style guide** — read the patterns from the guide, do not restate them from memory (restating them here is how this check previously drifted stale). As of the current guide the pinned forms are, for example:
-
-- **MITRE ATLAS:** `AML.T####@5.0.1` / `AML.T####.###@5.0.1` (techniques), `AML.M####@5.0.1` (mitigations)
-- **NIST AI RMF:** subcategory-level, full function name, version-pinned — e.g. `MEASURE-2.3@1.0`, `GOVERN-6.2@1.0` (never the category alone, never an abbreviation like `MS-2.3`)
-- **STRIDE:** PascalCase, unversioned — `Spoofing`, `Tampering`, `Repudiation`, `InformationDisclosure`, `DenialOfService`, `ElevationOfPrivilege`
-- **OWASP Top 10 for LLM:** `LLM##:2025`
-- **ISO 22989:** the controlled role name, version-pinned `@2022`
-- **EU AI Act:** `Article ##@2024` / `Article ##(#)@2024`
+Mapping values are **version-pinned** (ADR-027): every value carries its framework's version token, except STRIDE, which is intentionally unversioned. Verify each value against the **canonical pinned pattern for its framework in the authoritative style guide** (`risk-map/docs/contributing/framework-mappings-style-guide.md`, "Identifier Enforcement" table) — read the patterns from the guide every time; do not restate them from memory or inline here. The guide is the single source for pattern and version-token conventions across every supported framework, including any framework registered after this skill was written — new frameworks are a recurring, actively-requested change (see open issues against `frameworks.yaml`), so nothing about the pinned-pattern set may live in two places.
 
 Flag any value whose form or version token does not match the guide's current pinned pattern.
 
@@ -49,8 +42,10 @@ Flag any value whose form or version token does not match the guide's current pi
 
 ### Term and identifier verification
 
-- [ ] **Verify identifiers exist in the source framework.** For MITRE ATLAS, confirm technique/mitigation IDs are real. For OWASP, confirm the category title matches. For ISO 22989, confirm role names match the standard's terminology.
-- [ ] **When proposing new mappings**, search the web to confirm the identifier is current and not deprecated or renamed in the latest version of the framework.
+Two distinct checks — do not conflate them. The first is structural and runs at whatever scope the audit is already covering; the second is a live, per-entity lookup that is never an automatic side effect of the first.
+
+- [ ] **Verify identifiers are well-formed against the style guide's patterns.** For MITRE ATLAS, technique/mitigation IDs match the pinned regex. For OWASP, the category title matches the guide. For ISO 22989, role names match the controlled vocabulary. This is a structural check — no live lookup — and applies at whatever scope the audit already covers, whole-corpus included, the same as the structural-compliance and selectivity checks above.
+- [ ] **Live-verify identifier currency (search the web)** when a specific identifier's currency is actually in question: proposing a new mapping value, or auditing a single **targeted** entity (per Scope) whose identifiers you are specifically confirming. This is a heavier, per-entity check. **It is not run automatically across every entry as a side effect of a whole-corpus audit** — a whole-corpus audit's job is the structural/selectivity/overlap sweep above, not a live web-search of every existing mapping in the file. If comprehensive liveness verification of the full corpus is genuinely wanted, invoke it as its own explicit, separately-requested pass — never as an implicit consequence of the routine audit.
 
 ## Coverage analysis (for whole-corpus scope only)
 

--- a/scripts/skills/audit-framework-mappings/evals/evals.json
+++ b/scripts/skills/audit-framework-mappings/evals/evals.json
@@ -1,0 +1,97 @@
+{
+  "skill_name": "audit-framework-mappings",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Audit this control mapping value: mitre-atlas: [AML.M0028]. Is it conformant?",
+      "expected_output": "Flags the missing version pin — ADR-027 requires AML.M0028@5.0.1 — deferring to the style guide's pinned pattern.",
+      "expectations": [
+        "Flags that the value is missing its version pin (@5.0.1) required by ADR-027",
+        "States the correct form is AML.M0028@5.0.1",
+        "Treats the framework-mappings-style-guide as the authoritative source rather than an unversioned form"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Audit these risk STRIDE values: stride: [tampering, information-disclosure]. Are they formatted correctly?",
+      "expected_output": "Flags the lowercase form; STRIDE is PascalCase (Tampering, InformationDisclosure).",
+      "expectations": [
+        "Flags the STRIDE values as incorrectly cased",
+        "States the correct form is PascalCase (Tampering, InformationDisclosure)",
+        "Does not accept lowercase STRIDE"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Audit this control mapping: mitre-atlas: [AML.T0043@5.0.1]. Is a technique valid on a control?",
+      "expected_output": "Flags technique-on-control: controls map to mitigations (AML.M####), risks map to techniques (AML.T####).",
+      "expectations": [
+        "Flags that controls map to MITRE ATLAS mitigations (AML.M####), not techniques (AML.T####)",
+        "Identifies AML.T0043 as a technique that does not belong on a control"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "A control has 6 NIST AI RMF mappings. Audit for selectivity.",
+      "expected_output": "Flags exceeding the soft limit of 4 per framework; recommends keeping only directly-relevant mappings.",
+      "expectations": [
+        "Flags exceeding the soft limit of ~4 mappings per framework",
+        "Recommends keeping only directly-relevant mappings, each defensible in one sentence"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Audit this persona mapping: iso-22989: [AI Partner (data supplier)]. Is it conformant?",
+      "expected_output": "Flags the missing @2022 version pin; ISO 22989 role descriptors are pinned, so the correct value is 'AI Partner (data supplier)@2022', which is a valid member of the closed controlled-vocabulary enum.",
+      "expectations": [
+        "Flags that the ISO 22989 value is missing its @2022 version pin",
+        "States the correct form is 'AI Partner (data supplier)@2022'",
+        "Confirms the role name is a valid member of the ISO 22989 closed controlled-vocabulary enum (personas-only framework)",
+        "Reads the ISO 22989 rule from the style guide rather than restating it from memory"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Audit this persona mapping: mitre-atlas: [AML.T0020@5.0.1] on personaDataProvider. Is MITRE ATLAS valid on a persona?",
+      "expected_output": "Flags an applicableTo violation: MITRE ATLAS applies to risks and controls only, not personas. The mapping must be removed regardless of whether the identifier is well-formed.",
+      "expectations": [
+        "Flags that MITRE ATLAS is not applicable to personas per the applicableTo table",
+        "States that MITRE ATLAS applies to risks and controls only",
+        "Treats this as a structural (applicableTo) violation, independent of whether the identifier form is correct",
+        "Grounds the applicability decision in the style guide's Framework Applicability table"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Audit this control mapping: owasp-top10-llm: [LLM01]. Is it conformant?",
+      "expected_output": "Flags the missing :2025 version token; OWASP Top 10 for LLM values are pinned as LLM##:2025, so the correct form is LLM01:2025.",
+      "expectations": [
+        "Flags that the OWASP value is missing its :2025 version token",
+        "States the correct form is LLM01:2025",
+        "Notes OWASP uses the colon delimiter (:2025), not the @ token used by other frameworks",
+        "Reads the OWASP pinned pattern from the style guide"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Audit this risk mapping: mitre-atlas: [AML.T0010@5.0.1, AML.T0010.002@5.0.1]. Is it conformant?",
+      "expected_output": "Flags a parent + sub-technique collision: AML.T0010.002 is the more specific match, so AML.T0010 must be dropped. Use only the most specific accurate level.",
+      "expectations": [
+        "Flags the parent + sub-technique collision (AML.T0010 alongside AML.T0010.002)",
+        "States that only the more specific sub-technique (AML.T0010.002@5.0.1) should remain",
+        "Grounds the rule in the style guide's granularity / do-not-map-parent-and-sub-technique guidance"
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "Audit this risk mapping: nist-ai-rmf: [MEASURE-2.3@1.0] on a risk. Is NIST AI RMF valid on a risk?",
+      "expected_output": "Flags an applicableTo violation: NIST AI RMF applies to controls only, not risks. The value is well-formed but the framework does not apply to this entity type and must be removed.",
+      "expectations": [
+        "Flags that NIST AI RMF is not applicable to risks per the applicableTo table",
+        "States that NIST AI RMF applies to controls only (it is control-oriented, with no threat taxonomy)",
+        "Treats this as a structural (applicableTo) violation even though the identifier form is correct",
+        "Grounds the applicability decision in the style guide's Framework Applicability table"
+      ]
+    }
+  ]
+}

--- a/scripts/skills/audit-framework-mappings/evals/evals.json
+++ b/scripts/skills/audit-framework-mappings/evals/evals.json
@@ -105,12 +105,13 @@
     },
     {
       "id": 11,
-      "prompt": "This is a targeted audit of a single control's mappings (not a whole-corpus sweep). Audit this mapping for identifier currency: mitre-atlas: [AML.T9999@5.0.1]. The value is well-formed — is it a real, current MITRE ATLAS identifier?",
-      "expected_output": "The value passes the structural/format check (well-formed AML.T####@5.0.1 pattern) but fails live verification: AML.T9999 is not a real or current MITRE ATLAS technique/mitigation id. Because this is a targeted single-entity audit, live web verification applies; recommends removing or correcting the mapping rather than accepting it on form alone.",
+      "prompt": "This is a targeted audit of a single control's mappings (not a whole-corpus sweep). Audit this mapping for identifier currency: mitre-atlas: [AML.M9999@5.0.1]. The value is well-formed and correctly a mitigation (not a technique) for a control — is it a real, current MITRE ATLAS identifier?",
+      "expected_output": "The value passes every structural check (well-formed AML.M####@5.0.1 pattern; correct mitigation-on-control class, no crossover) but fails live verification: MITRE ATLAS currently has only ~32 mitigations (AML.M0000 through roughly AML.M0031); AML.M9999 is far outside that range and does not exist. Because this is a targeted single-entity audit, live web verification applies; recommends removing or correcting the mapping rather than accepting it on form alone.",
       "expectations": [
-        "Confirms the value passes the structural/format check (correct AML.T####@5.0.1 pattern)",
+        "Confirms the value passes the structural/format check (correct AML.M####@5.0.1 pattern)",
+        "Confirms no technique/mitigation crossover (a mitigation is correct for a control) -- the case is designed so only live verification can fail it, not the structural crossover check",
         "Live-verifies the identifier against the source framework and finds it does not exist / is not current",
-        "Does NOT accept the mapping as conformant merely because its form is well-pinned",
+        "Does NOT accept the mapping as conformant merely because its form and class are correct",
         "Recognizes this as a targeted single-entity audit (per Scope) where live verification is expected, not a whole-corpus sweep that would skip it"
       ]
     }

--- a/scripts/skills/audit-framework-mappings/evals/evals.json
+++ b/scripts/skills/audit-framework-mappings/evals/evals.json
@@ -92,6 +92,27 @@
         "Treats this as a structural (applicableTo) violation even though the identifier form is correct",
         "Grounds the applicability decision in the style guide's Framework Applicability table"
       ]
+    },
+    {
+      "id": 10,
+      "prompt": "Audit this control mapping: eu-ai-act: [Article 9]. Is it conformant?",
+      "expected_output": "Flags the missing version pin — ADR-027 requires Article 9@2024 — deferring to the style guide's pinned pattern.",
+      "expectations": [
+        "Flags that the value is missing its version pin (@2024) required by ADR-027",
+        "States the correct form is Article 9@2024",
+        "Reads the EU AI Act pinned pattern from the style guide rather than restating it from memory"
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "This is a targeted audit of a single control's mappings (not a whole-corpus sweep). Audit this mapping for identifier currency: mitre-atlas: [AML.T9999@5.0.1]. The value is well-formed — is it a real, current MITRE ATLAS identifier?",
+      "expected_output": "The value passes the structural/format check (well-formed AML.T####@5.0.1 pattern) but fails live verification: AML.T9999 is not a real or current MITRE ATLAS technique/mitigation id. Because this is a targeted single-entity audit, live web verification applies; recommends removing or correcting the mapping rather than accepting it on form alone.",
+      "expectations": [
+        "Confirms the value passes the structural/format check (correct AML.T####@5.0.1 pattern)",
+        "Live-verifies the identifier against the source framework and finds it does not exist / is not current",
+        "Does NOT accept the mapping as conformant merely because its form is well-pinned",
+        "Recognizes this as a targeted single-entity audit (per Scope) where live verification is expected, not a whole-corpus sweep that would skip it"
+      ]
     }
   ]
 }

--- a/scripts/skills/audit-identification-questions/SKILL.md
+++ b/scripts/skills/audit-identification-questions/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: audit-identification-questions
+description: Audit persona identification questions in personas.yaml against the identification questions style guide. Use when reviewing or proposing changes to identificationQuestions.
+---
+
+# Identification Questions Audit
+
+Audit persona identification questions for style guide compliance, boundary clarity, and term validity.
+
+## Scope
+
+Target: a single persona id, or `all` to audit every non-deprecated persona in `personas.yaml` (default).
+
+If a specific persona ID is provided (e.g., `personaAgenticProvider`), audit only that persona's questions.
+
+## Reference documents
+
+Read these before auditing:
+
+1. **Style guide** (authoritative): `risk-map/docs/contributing/identification-questions-style-guide.md`
+
+## Audit checklist
+
+For each persona with `identificationQuestions`, verify ALL of the following. Report pass/fail per item.
+
+**Passing the mechanical checks (Structure, Examples format) does not make a question conformant.** The editorial checks — Framing (an activity, not a role/title or a third party), Scoping, and especially **"including" for scope expansion** — take judgment against the style guide and are the *most common* remaining issue on a question that already looks clean. Do not return a conformant verdict until you have positively evaluated each editorial check on its merits — e.g. a base term narrow enough that a reader might wrongly exclude themselves, used without an "including" clause, is a scope-expansion flag even when structure and format are perfect.
+
+### Structure
+
+- [ ] **Count 5-7**: Between 5 and 7 questions inclusive
+- [ ] **Yes/no answerable**: Every question can be answered with yes or no
+- [ ] **No embedded conditionals**: No nested conditions requiring evaluation before answering
+
+### Framing
+
+- [ ] **Second-person, activity-focused**: Questions ask what *you* do — "Do you…", "Are you…", "Does your team…" — about the reader's activities. Avoid framings about a system/platform/product ("Is your system…", "Does your platform…") and third-person framings about other roles ("Do developers…").
+- [ ] **Activity-focused**: Questions describe what the reader does, not what their job title is or what their product is
+
+### Scoping and boundaries
+
+- [ ] **Scoping clauses present**: Where an activity is shared with an adjacent persona, a scoping clause disambiguates (e.g., "as a framework author rather than as an application developer")
+- [ ] **No overlapping questions**: No two questions ask effectively the same thing at different abstraction levels. If overlap exists, merge or add a scoping clause.
+
+### Examples and terminology
+
+- [ ] **Parenthetical examples**: Technical terms have parenthetical examples using `(e.g., item1, item2, item3)` format — NOT "such as" inline, NOT parenthetical without "e.g."
+- [ ] **Example list length**: Parenthetical lists have 2-4 items
+- [ ] **"including" for scope expansion**: Used where the base term might be read too narrowly
+
+### Ordering
+
+- [ ] **Question ordering**: Most distinguishing activity first, scope-expanding questions in the middle, boundary-clarifying questions last
+
+## Term verification (critical)
+
+When reviewing or proposing parenthetical examples (the `(e.g., ...)` items):
+
+1. **Search the web** to confirm each term has strong real-world usage in the relevant ecosystem
+2. Check major frameworks, tools, and documentation (e.g., LangChain, Semantic Kernel, Vertex AI, CrewAI, etc.)
+3. If a proposed term is not an established concept, find the industry-standard term for the same idea
+4. Flag any term that is:
+   - Not used in any major framework's documentation
+   - Deprecated or renamed in the latest version
+   - A colloquial shorthand rather than a concrete, recognized component or pattern
+5. Provide sources/evidence for term validation
+
+## Coverage analysis (for `all` scope only)
+
+- List all non-deprecated personas with vs. without identification questions
+- Calculate per-persona compliance scores (checklist pass rate)
+- Calculate aggregate compliance score
+- Prioritize missing personas by disambiguation value (how adjacent they are to other personas)
+
+## Proposing rewrites
+
+When proposing rewritten questions:
+
+1. Show the current question and the proposed replacement side by side
+2. Identify which checklist items the rewrite fixes
+3. For any new parenthetical examples, include term verification results
+4. Ensure the rewrite does not introduce new violations
+
+## Output format
+
+For targeted audits (single persona), provide:
+
+1. All current questions listed
+2. Pass/fail on each checklist item with notes
+3. Specific violations with remediation suggestions
+4. Term verification results for any proposed example terms

--- a/scripts/skills/audit-identification-questions/SKILL.md
+++ b/scripts/skills/audit-identification-questions/SKILL.md
@@ -43,10 +43,15 @@ For each persona with `identificationQuestions`, verify ALL of the following. Re
 
 ### Examples and terminology
 
-- [ ] **Parenthetical examples**: Technical terms have parenthetical examples using `(e.g., item1, item2, item3)` format — NOT "such as" inline
+- [ ] **Parenthetical examples where needed**: When a technical term may be unfamiliar or ambiguous, use parenthetical examples in `(e.g., item1, item2, item3)` format — NOT "such as" inline
 - [ ] **`e.g.` not `i.e.`**: parentheticals signal an illustrative list, never an exhaustive one — read the exact rule from the style guide's Rule enforcement summary
 - [ ] **Example list length**: read the item-count bound from the style guide's Rule enforcement summary rather than restating it here
 - [ ] **"including" for scope expansion**: Used where the base term might be read too narrowly
+
+### Neutrality and assumptions
+
+- [ ] **No embedded assumptions**: Do not constrain an activity with implementation details that are not part of the persona boundary (e.g. "GPU clusters in the cloud" excludes an on-premises or other-hardware actor who should still answer yes).
+- [ ] **Neutral wording**: Questions do not lead or nudge the reader toward answering "yes."
 
 ### Ordering
 

--- a/scripts/skills/audit-identification-questions/SKILL.md
+++ b/scripts/skills/audit-identification-questions/SKILL.md
@@ -27,13 +27,13 @@ For each persona with `identificationQuestions`, verify ALL of the following. Re
 
 ### Structure
 
-- [ ] **Count 5-7**: Between 5 and 7 questions inclusive
+- [ ] **Count in range**: read the count bound from the style guide's Rule enforcement summary (`validate-identification-questions` hook) rather than restating the number here
 - [ ] **Yes/no answerable**: Every question can be answered with yes or no
 - [ ] **No embedded conditionals**: No nested conditions requiring evaluation before answering
 
 ### Framing
 
-- [ ] **Second-person, activity-focused**: Questions ask what *you* do — "Do you…", "Are you…", "Does your team…" — about the reader's activities. Avoid framings about a system/platform/product ("Is your system…", "Does your platform…") and third-person framings about other roles ("Do developers…").
+- [ ] **Second-person, activity-focused**: Questions ask what *you* do about the reader's own activities, using the approved second-person openers listed in the style guide's Rule enforcement summary. Avoid framings about a system/platform/product ("Is your system…", "Does your platform…") and third-person framings about other roles ("Do developers…").
 - [ ] **Activity-focused**: Questions describe what the reader does, not what their job title is or what their product is
 
 ### Scoping and boundaries
@@ -43,8 +43,9 @@ For each persona with `identificationQuestions`, verify ALL of the following. Re
 
 ### Examples and terminology
 
-- [ ] **Parenthetical examples**: Technical terms have parenthetical examples using `(e.g., item1, item2, item3)` format — NOT "such as" inline, NOT parenthetical without "e.g."
-- [ ] **Example list length**: Parenthetical lists have 2-4 items
+- [ ] **Parenthetical examples**: Technical terms have parenthetical examples using `(e.g., item1, item2, item3)` format — NOT "such as" inline
+- [ ] **`e.g.` not `i.e.`**: parentheticals signal an illustrative list, never an exhaustive one — read the exact rule from the style guide's Rule enforcement summary
+- [ ] **Example list length**: read the item-count bound from the style guide's Rule enforcement summary rather than restating it here
 - [ ] **"including" for scope expansion**: Used where the base term might be read too narrowly
 
 ### Ordering

--- a/scripts/skills/audit-identification-questions/evals/evals.json
+++ b/scripts/skills/audit-identification-questions/evals/evals.json
@@ -1,0 +1,78 @@
+{
+  "skill_name": "audit-identification-questions",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Audit this identification question: 'Do developers building on your framework configure model access policies?'",
+      "expected_output": "Flags the third-person framing ('Do developers'); should be second-person about the reader's own activity.",
+      "expectations": [
+        "Flags the third-person framing ('Do developers') as a violation",
+        "States questions should be second-person, about what the reader does",
+        "Suggests a second-person rewrite"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "A persona has 9 identification questions. Audit the structure.",
+      "expected_output": "Flags the count as outside the 5-7 range; recommends reducing.",
+      "expectations": [
+        "Flags that the count (9) exceeds the 5-7 range",
+        "Recommends reducing to 5-7 questions"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Audit the example format in this question: 'Do you use agent frameworks such as LangChain and CrewAI?'",
+      "expected_output": "Flags the 'such as' inline form; the required format is parenthetical '(e.g., LangChain, CrewAI)'.",
+      "expectations": [
+        "Flags 'such as' inline as non-conformant",
+        "States the required format is parenthetical (e.g., item1, item2)",
+        "Notes the 2-4 item length guidance"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Audit this question, which the author believes is already clean: 'Are you responsible for training or fine-tuning foundation models (e.g., pre-training, RLHF, instruction tuning)?'",
+      "note": "Recalibrated after a smoke run: the question is NOT fully clean by the guide — the skill correctly caught guide-grounded issues without manufacturing nits.",
+      "expected_output": "Confirms the strong parts, but catches the narrow-scope issue ('foundation models' should use an 'including' scope-expansion) and/or the 'responsible for' role-vs-activity framing — grounding each flag in the style guide.",
+      "expectations": [
+        "Confirms the conformant parts (second-person 'Are you', correct (e.g., ...) parenthetical with 2-4 items, yes/no answerable)",
+        "Catches the narrow-scope issue ('foundation models' should use an 'including' scope-expansion per the guide) and/or the 'responsible for' role-vs-activity framing",
+        "Grounds each flag in the style guide rather than asserting ungrounded or manufactured violations"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Audit this identification question for the Agentic Platform and Framework Providers persona: 'Do you connect large language models to external APIs, tools, or services?' Note that the Application Developer persona also integrates models with external services.",
+      "note": "Scoping-clause presence. The activity (connecting LLMs to external services) is shared with the adjacent Application Developer persona; the corpus resolves it with a framework-vs-application scoping clause (personaAgenticProvider Q3 says 'as a reusable framework or platform rather than a single application'). The bare question lets both personas answer yes.",
+      "expected_output": "Flags the missing scoping clause: the activity is shared with the Application Developer persona, so a clause distinguishing the framework/platform provider from a single-application integrator is required. Suggests a clause modeled on the guide's shared-activity rule.",
+      "expectations": [
+        "Flags that the activity is shared with an adjacent persona (Application Developer) and lacks a disambiguating scoping clause",
+        "States the style guide's rule that a shared activity needs a scoping clause assigning it to exactly one persona",
+        "Suggests a scoping clause (e.g., 'as a reusable framework or platform rather than a single application') and grounds it in the guide"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Audit these two identification questions from the same persona: 'Do you train AI models?' and 'Do you build or create machine learning models?'",
+      "note": "No-overlapping-questions. This is the style guide's explicit overlapping-questions anti-pattern: two questions describing the same activity at different abstraction levels. Remedy is merge or add a scoping clause.",
+      "expected_output": "Flags the two questions as overlapping — they ask effectively the same thing at different abstraction levels — and recommends merging them or adding a scoping clause to distinguish them.",
+      "expectations": [
+        "Flags the two questions as overlapping / asking effectively the same thing",
+        "Identifies this as the style guide's overlapping-questions anti-pattern",
+        "Recommends merging the two questions or adding a scoping clause to differentiate them"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Audit the ordering of these questions for a persona, in this order: (1) 'Do you provide integration layers as a reusable framework rather than as a single application?' (2) 'Do you build or maintain software that orchestrates which tools an AI model invokes (e.g., tool-calling frameworks, agent orchestrators, or planning engines)?' (3) 'Do you define the agent architecture for AI systems (e.g., reasoning loops, planning workflows, or reflection patterns)?'",
+      "note": "Ordering. Question 1 is a boundary-clarifying question (it carries the framework-vs-application scoping clause) but is placed first; the guide says the most distinguishing activity leads and boundary-clarifying questions come last.",
+      "expected_output": "Flags the ordering: the boundary-clarifying question (Q1, with the 'reusable framework rather than a single application' scoping clause) is placed first but should come last; the most distinguishing activity (tool orchestration) should lead.",
+      "expectations": [
+        "Flags that a boundary-clarifying / scoping-clause question is placed first instead of last",
+        "States the style guide's ordering rule (most distinguishing activity first, boundary-clarifying questions last)",
+        "Suggests reordering so the most distinguishing question leads and the boundary-clarifying question ends the list"
+      ]
+    }
+  ]
+}

--- a/scripts/skills/audit-identification-questions/evals/evals.json
+++ b/scripts/skills/audit-identification-questions/evals/evals.json
@@ -73,6 +73,17 @@
         "States the style guide's ordering rule (most distinguishing activity first, boundary-clarifying questions last)",
         "Suggests reordering so the most distinguishing question leads and the boundary-clarifying question ends the list"
       ]
+    },
+    {
+      "id": 8,
+      "prompt": "Audit the example terms in this question: 'Do you orchestrate multi-agent workflows (e.g., LangGraph, AutoGPT-Prime, CrewAI)?'",
+      "expected_output": "LangGraph and CrewAI are real, established multi-agent orchestration frameworks with strong real-world usage; 'AutoGPT-Prime' does not correspond to any established framework, tool, or documented variant -- it is a fabricated/colloquial-sounding term. Flags AutoGPT-Prime specifically and does not flag LangGraph or CrewAI.",
+      "expectations": [
+        "Confirms LangGraph and CrewAI as established, real frameworks (does not flag them)",
+        "Flags 'AutoGPT-Prime' as not an established or verifiable term",
+        "States it searched for real-world usage rather than accepting the term on its plausible-sounding name alone",
+        "Does not accept the parenthetical as conformant just because two of the three terms are real"
+      ]
     }
   ]
 }

--- a/scripts/skills/audit-identification-questions/evals/evals.json
+++ b/scripts/skills/audit-identification-questions/evals/evals.json
@@ -84,6 +84,30 @@
         "States it searched for real-world usage rather than accepting the term on its plausible-sounding name alone",
         "Does not accept the parenthetical as conformant just because two of the three terms are real"
       ]
+    },
+    {
+      "id": 9,
+      "prompt": "Audit this identification question: 'Do you want to make sure your AI models are properly secured against unauthorized access?'",
+      "note": "Leading-question anti-pattern with a mechanically valid opener. 'Do you' is a hook-approved second-person opener, and the question is yes/no answerable -- structure and Framing checks pass. This isolates the editorial leading-question detection from the opener/structure hooks: the question nudges toward 'yes' (nobody would admit to not wanting security) rather than identifying a concrete activity the reader either does or does not perform.",
+      "expected_output": "Flags the question as leading -- it nudges the reader toward 'yes' via a value judgment ('want to make sure ... properly secured') rather than asking about a concrete activity. Notes that structure/opener checks pass (this is not a third-person or count violation) but the editorial neutrality check fails. Suggests a rewrite that asks about a specific activity instead (e.g., what the reader actually does for model access control).",
+      "expectations": [
+        "Flags the question as a leading question that nudges toward 'yes'",
+        "Identifies this as the style guide's leading-questions anti-pattern, not a structural violation",
+        "Notes the mechanical checks (second-person opener, yes/no answerable) pass on their own, so this is caught by editorial judgment, not the hook",
+        "Suggests a rewrite framed around a concrete, neutral activity rather than a value judgment"
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "Audit this identification question: 'Do you train models using GPU clusters in the cloud?'",
+      "note": "Binary question with an embedded assumption -- the style guide's own worked anti-pattern example, used directly so the case is traceable to its source.",
+      "expected_output": "Flags 'GPU clusters in the cloud' as an implementation-detail assumption that is not part of the persona boundary -- it improperly excludes a valid actor who trains on-premises or with other hardware. Suggests dropping the hardware/location constraint (e.g., 'Do you train models?' or similar, scoped only by the activity that actually matters).",
+      "expectations": [
+        "Flags the 'GPU clusters in the cloud' clause as an embedded assumption/implementation detail",
+        "States this would incorrectly exclude a valid actor (on-premises or other-hardware training)",
+        "Identifies this as the style guide's binary-question-with-embedded-assumptions anti-pattern",
+        "Suggests removing the hardware/location constraint rather than just narrowing it"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Brings develop up to main afa43cd. Twenty-three files, all under scripts/ and docs/ — the four canonical authoring skills and their evals, the ADR-008 reconciliation, the content-reviewer taxonomy citation fix, and the pre-commit dependency bump.
 
No risk-map/ corpus or schema changes, so no generated artifact moves and no regeneration is required. Conflict-free; suite green at 3341.
