### PR TITLE
fix(graphing): stop cluster-derived subgraphs colliding, vanishing, and renaming

### DIFF
--- a/scripts/hooks/riskmap_validator/graphing/base.py
+++ b/scripts/hooks/riskmap_validator/graphing/base.py
@@ -69,6 +69,16 @@ class BaseGraph:
         self.controls: dict[str, ControlNode] = {}
         self.risks: dict[str, RiskNode] = {}
 
+        # Subgraph ids actually written by _create_subgraph_section, across
+        # every call made against this instance. Cluster naming (_find_node_
+        # clusters) derives a candidate id independently per call/category, so
+        # two different categories can legitimately derive the identical
+        # candidate (same common prefix, or same positional fallback index).
+        # _create_subgraph_section is the single place that turns a candidate
+        # into a declared "subgraph <id>" line, so it is the only place that
+        # can see -- and must guarantee -- that no id is declared twice.
+        self._declared_subgraph_ids: set[str] = set()
+
         self.component_by_category: dict[str, list[str]] = dict()
         self.component_by_subcategory: dict[str, dict[str, list[str]]] = dict()
         self.control_by_category: dict[str, list[str]] = dict()
@@ -88,6 +98,39 @@ class BaseGraph:
 
         if isinstance(risks, dict) and all(isinstance(node, RiskNode) for node in risks.values()):
             self.risks = risks
+
+    def _reset_declared_subgraph_ids(self) -> None:
+        """
+        Clear subgraph-id collision tracking at the start of a render pass.
+
+        _declared_subgraph_ids accumulates every id _create_subgraph_section
+        has written for this instance. Scoped to the instance's whole
+        lifetime rather than to a single render pass, that history leaks
+        across calls: a category id that legitimately reappears every render
+        (categories don't change between calls) gets misread as an
+        already-taken id left over from a prior pass and is disambiguated
+        for no reason -- see _create_subgraph_section's docstring for why
+        that disambiguation exists in the first place.
+
+        Every subclass method that begins a fresh render pass over the same
+        instance must call this first. That includes both a graph type's own
+        top-level build method (e.g. ComponentGraph.build_graph) and any
+        finer-grained method that can be invoked as an independent pass by a
+        composing graph type -- ControlGraph._get_subgraph is called
+        separately for its controls and components passes, and again by
+        RiskGraph reusing an already-built ControlGraph instance, so it
+        resets here rather than only in ControlGraph.build_controls_graph.
+        Resetting is safe in every case because the ids in play never share
+        a namespace across the graph types that render through this method:
+        control ids, component ids, and risk ids each carry a fixed,
+        distinct prefix.
+
+        ControlGraph additionally tracks cluster-specific bookkeeping
+        (_processed_subgroups, _subgroup_render_ids) that is not shared
+        state declared here; ControlGraph._get_subgraph resets those itself
+        at the same point.
+        """
+        self._declared_subgraph_ids.clear()
 
     def to_mermaid(self, output_format: str = "markdown"):
         lines = self.graph
@@ -243,6 +286,13 @@ class BaseGraph:
                 else:
                     subgroup_name = f"{node_category_prefix}Subgroup{i + 1}"
 
+                # NOTE: this name is derived from this call's own cluster list
+                # only and is not guaranteed unique across separate calls (one
+                # per category -- see ControlGraph._find_optimal_subgroupings).
+                # Two categories can legitimately derive the identical
+                # candidate here. That collision is resolved downstream, at
+                # actual declaration time, by _create_subgraph_section -- see
+                # its docstring for why the fix lives there and not here.
                 result[subgroup_name] = cluster_list
 
         return result
@@ -404,11 +454,44 @@ class BaseGraph:
 
         Returns:
             List of Mermaid syntax lines for the subgraph section
+
+        Note:
+            A Mermaid graph with two "subgraph <id>" declarations sharing the
+            same <id> fails to render. Callers derive `category` independently
+            per invocation (see _find_node_clusters), so two different callers
+            can legitimately request the same id -- most notably, one
+            per-category call to cluster-derived subgroup naming can collide
+            with another. This method is the single place every DYNAMICALLY
+            (cluster-)derived subgraph id is turned into a declaration, so it
+            is the only place that can guarantee that specific invariant for
+            those ids: on collision, it declares the requested content under
+            a disambiguated id instead of silently overwriting or dropping
+            it. It is NOT the only place a literal "subgraph <id>" line is
+            written in this codebase -- fixed-id containers (e.g. the
+            top-level "controls"/"components"/"risks" wrappers, and each
+            parent category's own container line in _get_nested_subgraph /
+            _get_nested_subgraph_new) are written directly and never
+            registered here, because their ids are schema-fixed and cannot
+            collide the way a derived cluster name can. The return type stays
+            list[str] (not the (lines, id) tuple that would make the actual
+            id explicit) because callers -- including test harnesses -- treat
+            the return value as the literal rendered lines; the id actually
+            used is always recoverable from the first line.
         """
+        subgraph_id = category
+        if subgraph_id in self._declared_subgraph_ids:
+            suffix = 2
+            while (candidate_id := f"{category}{suffix}") in self._declared_subgraph_ids:
+                suffix += 1
+            subgraph_id = candidate_id
+        self._declared_subgraph_ids.add(subgraph_id)
+
         lines = []
-        lines.append(f'{indent}subgraph {category} ["{category_name}"]')
+        lines.append(f'{indent}subgraph {subgraph_id} ["{category_name}"]')
 
         # Special case for governance controls (can be extended for other categories)
+        # Keyed on the logical category, not the disambiguated id: this is a
+        # business-logic special case unrelated to collision handling.
         if category == "controlsGovernance":
             lines.append(f"{indent}    direction LR")
 

--- a/scripts/hooks/riskmap_validator/graphing/component_graph.py
+++ b/scripts/hooks/riskmap_validator/graphing/component_graph.py
@@ -57,6 +57,12 @@ class ComponentGraph(BaseGraph):
         Returns:
             str: Complete Mermaid graph as string
         """
+        # Start each render pass with a clean subgraph-id collision set (see
+        # BaseGraph._reset_declared_subgraph_ids). Category ids are fixed and
+        # reappear on every call; without this, a second call to build_graph()
+        # on the same instance would see its own first-pass ids as already
+        # taken and rename them for no reason.
+        self._reset_declared_subgraph_ids()
 
         # Load graph configuration and category styles
         _, graph_preamble = self.config_loader.get_graph_config("component")

--- a/scripts/hooks/riskmap_validator/graphing/controls_graph.py
+++ b/scripts/hooks/riskmap_validator/graphing/controls_graph.py
@@ -56,6 +56,14 @@ class ControlGraph(BaseGraph):
         self._group_controls_by_category()
 
         self.initial_mapping: dict[str, list[str]] = dict()
+        # Subgroup names claimed by more than one parent category (a naming
+        # collision -- see _find_node_clusters). Populated by
+        # _integrate_subgroupings; _get_category_check_order excludes these
+        # from full-category-coverage matching, since their
+        # component_by_category entry is a union spanning multiple distinct
+        # rendered boxes, not one.
+        self._split_subgroup_names: set[str] = set()
+
         # Find subgroupings and integrate them
         self.subgroupings = self._find_optimal_subgroupings()
         if self.debug and self.subgroupings:
@@ -64,6 +72,12 @@ class ControlGraph(BaseGraph):
 
         # Graph generation state
         self._processed_subgroups = set()
+        # Maps (parent_category, subgroup_name) -> the id actually declared for
+        # it. Usually equal to subgroup_name; differs when _create_subgraph_
+        # section had to disambiguate a collision with another parent
+        # category's subgroup of the same name. build_controls_graph's style
+        # pass reads this so a style line targets what was actually declared.
+        self._subgroup_render_ids: dict[tuple[str, str], str] = {}
         self._universal_control_edge_indices = []
         self._category_edge_indices = []
         self._multi_edge_styler = MultiEdgeStyler(self)
@@ -88,6 +102,19 @@ class ControlGraph(BaseGraph):
             return False
 
         category_components = set(self.component_by_category[category])
+
+        # A category with no members has nothing to "fully cover". Without
+        # this guard, set().issubset(x) is vacuously True for any x, so
+        # EVERY control -- including one with zero components in common --
+        # would appear to fully cover an empty category. A category ends up
+        # empty when all of its components were absorbed into a cluster (see
+        # _integrate_subgroupings); that category still gets rendered as a
+        # container for its nested subgroup, so a control wrongly matched
+        # here would silently point at a real, declared box instead of
+        # failing loudly with an unresolved edge target.
+        if not category_components:
+            return False
+
         control_component_set = set(control_components)
 
         # Check if control covers all category components
@@ -149,23 +176,55 @@ class ControlGraph(BaseGraph):
                 if component_id not in all_subgrouped_components
             ]
 
-            # Add subgroups as categories
+            # Add subgroups as categories. subgroup_name is derived
+            # independently per parent category (see _find_node_clusters) and
+            # can collide across two different parents; merge memberships
+            # rather than overwrite so this mapping -- the one
+            # _maps_to_full_category and edge-target optimization read --
+            # never silently forgets a colliding parent's members. Without
+            # this, a control that only covers the *other* colliding parent's
+            # members could be (mis)matched against this one's alone.
             for subgroup_name, subgroup_components in subgroups.items():
-                self.component_by_category[subgroup_name] = subgroup_components
+                existing = self.component_by_category.get(subgroup_name, [])
+                if existing:
+                    # subgroup_name was already claimed by another parent
+                    # category -- a naming collision. _create_subgraph_section
+                    # renders each parent's contribution under a distinct id
+                    # (see its docstring), so the merged entry below no longer
+                    # corresponds to one physical box. Track it so
+                    # _get_category_check_order can exclude it: a control that
+                    # covers the full union would otherwise be optimized to a
+                    # single edge pointing at only one of the (now multiple)
+                    # boxes, silently losing coverage of the other(s).
+                    self._split_subgroup_names.add(subgroup_name)
+                merged = existing + [c for c in subgroup_components if c not in existing]
+                self.component_by_category[subgroup_name] = merged
 
     def _get_category_check_order(self) -> list[str]:
         """
         Get category check order: subgroups first, then main categories.
+
+        Split subgroup names (claimed by more than one parent category, see
+        _integrate_subgroupings) are excluded entirely, from both lists: their
+        component_by_category entry is a union spanning multiple distinct
+        rendered boxes, so matching a control against it as a single
+        "fully covers this category" target would be checking coverage of a
+        box that does not physically exist. Excluded names fall through to
+        individual component matching instead, which is always safe.
         """
         # Collect subgroups and main categories
         subgroup_names = []
         main_categories = []
 
         for parent_category, subgroups in self.subgroupings.items():
-            subgroup_names.extend(subgroups.keys())
+            for name in subgroups:
+                if name not in self._split_subgroup_names:
+                    subgroup_names.append(name)
 
         # Add main categories excluding subgroups
         for category in self.component_by_category.keys():
+            if category in self._split_subgroup_names:
+                continue
             if category not in subgroup_names:
                 main_categories.append(category)
 
@@ -231,17 +290,57 @@ class ControlGraph(BaseGraph):
         ):
             return []
 
+        # Scope the id-dedup/subgroup-emission bookkeeping to THIS call, not
+        # the instance's lifetime. RiskGraph composes an already-built
+        # ControlGraph and calls _get_controls_subgraph()/_get_component_
+        # subgraph() again to embed the same subgraphs a second time (the
+        # first render already happened inside ControlGraph.__init__ to
+        # build self.graph). Without resetting here, that second pass sees
+        # every id the first pass declared as "already taken" and
+        # disambiguates all of them -- renaming ids that never had a genuine
+        # collision, purely because they were rendered twice. Resetting is
+        # safe because control ids and component ids never share a
+        # namespace (fixed "controls"/"components" prefixes), so nothing is
+        # lost by starting each call's declarations fresh. The shared half of
+        # this reset (_declared_subgraph_ids) lives on BaseGraph -- see
+        # _reset_declared_subgraph_ids -- since every graph type needs it,
+        # not just this one; the two lines below are this subclass's own
+        # cluster bookkeeping and reset alongside it.
+        self._reset_declared_subgraph_ids()
+        self._processed_subgroups.clear()
+        self._subgroup_render_ids.clear()
+
         subgraph_lines = []
 
         if subgraph_type == "controls":
             item_by_category = self.control_by_category.items()
             items = self.controls
+            subgroup_names: set[str] = set()
         else:
             item_by_category = self.component_by_category.items()
             items = self.components
+            # _integrate_subgroupings() also registers every subgroup as a
+            # flat entry in component_by_category (needed so control-mapping
+            # logic can treat subgroups and categories uniformly). A subgroup
+            # must only ever be rendered nested inside its parent category via
+            # _get_nested_subgraph below -- never iterated here as if it were
+            # its own top-level category. Without this exclusion, a category
+            # visited before its parent (or a parent with no leftover direct
+            # members, see the item_ids check below) can reach this flat entry
+            # and re-emit it as a second, non-nested "subgraph <id>" section.
+            subgroup_names = {name for subgroups in self.subgroupings.values() for name in subgroups}
 
         for category, item_ids in item_by_category:
-            if not item_ids or category in self._processed_subgroups:
+            if category in subgroup_names or category in self._processed_subgroups:
+                continue
+
+            # A parent category can have no leftover direct members when every
+            # one of its components was absorbed into a cluster (subgroupings
+            # is non-empty for it); that category must still be visited so its
+            # nested subgroup(s) get emitted -- only skip when there is
+            # genuinely nothing to render.
+            has_subgroups = subgraph_type == "components" and bool(self.subgroupings.get(category))
+            if not item_ids and not has_subgroups:
                 continue
 
             category_name = self._get_category_display_name(category)
@@ -275,6 +374,15 @@ class ControlGraph(BaseGraph):
             subgroup_lines = self._create_subgraph_section(
                 subgroup_name, subgroup_display_name, subgroup_components, self.components, "        "
             )
+
+            # _create_subgraph_section disambiguates on collision (another
+            # parent category's subgroup already claimed subgroup_name); the
+            # id it actually declared is embedded in the first line. Record
+            # it so build_controls_graph's style pass can target what was
+            # actually declared, not the pre-collision logical name.
+            if subgroup_lines:
+                self._subgroup_render_ids[(category, subgroup_name)] = subgroup_lines[0].split()[1]
+
             # Remove the empty line at the end for nested subgroups
             if subgroup_lines and subgroup_lines[-1] == "":
                 subgroup_lines.pop()
@@ -440,11 +548,22 @@ class ControlGraph(BaseGraph):
                 style_str = self._get_node_style("componentCategory", category_config=category_config)
                 lines.append(f"    style {category_key} {style_str}")
 
-        # Add dynamic styling for subgroups using configuration
+        # Add dynamic styling for subgroups using configuration.
+        # subgroup_name is the pre-collision logical name and can repeat
+        # across parent categories (see _integrate_subgroupings); look up
+        # what was actually declared for THIS (parent, subgroup_name) pair
+        # and style that id instead, deduplicating so a shared logical name
+        # gets styled exactly once and a disambiguated sibling still gets its
+        # own line rather than being silently left uncolored.
+        styled_subgraph_ids: set[str] = set()
         for parent_category, subgroups in self.subgroupings.items():
             style_str = self._get_node_style("dynamicSubgroup", parent_category=parent_category)
             for subgroup_name in subgroups.keys():
-                lines.append(f"    style {subgroup_name} {style_str}")
+                declared_id = self._subgroup_render_ids.get((parent_category, subgroup_name), subgroup_name)
+                if declared_id in styled_subgraph_ids:
+                    continue
+                styled_subgraph_ids.add(declared_id)
+                lines.append(f"    style {declared_id} {style_str}")
 
         lines.extend([])
 

--- a/scripts/hooks/riskmap_validator/graphing/risks_graph.py
+++ b/scripts/hooks/riskmap_validator/graphing/risks_graph.py
@@ -144,6 +144,13 @@ class RiskGraph(BaseGraph):
         Returns:
             Complete Mermaid graph with three-layer hierarchy and styling
         """
+        # Start this instance's own render pass with a clean subgraph-id
+        # collision set (see BaseGraph._reset_declared_subgraph_ids). This
+        # only covers the risk-layer ids declared directly on self (via
+        # _get_risk_subgraphs); the reused ControlGraph instance resets its
+        # own state independently inside _get_subgraph.
+        self._reset_declared_subgraph_ids()
+
         # Get graph configuration for risk graph type
         config_result = self.config_loader.get_graph_config("risk")
         if isinstance(config_result, tuple) and len(config_result) == 2:

--- a/scripts/hooks/tests/test_base_graph.py
+++ b/scripts/hooks/tests/test_base_graph.py
@@ -770,6 +770,242 @@ class TestNodeClustering:
                 assert "components" in cluster_name.lower() or "subgroup" in cluster_name.lower()
 
 
+class TestSubgraphIdUniqueness:
+    """
+    Guard the Mermaid rendering contract that every generated graph must satisfy:
+    no "subgraph <id>" declaration id is emitted more than once. A duplicated
+    subgraph id makes the whole file unrenderable (mmdc exits 1 with a
+    TypeError; mermaid.live fails on it too).
+
+    This lives at the BaseGraph level -- not against ControlGraph's or
+    RiskGraph's rendered output -- because GitHub issue #477 will remove
+    controls_graph.py and risks_graph.py shortly. A guard written only against
+    a concrete graph type's output would be deleted along with it. Every graph
+    type, including ComponentGraph (which survives #477 and is the vehicle for
+    future work), is built on BaseGraph's clustering (_find_node_clusters /
+    _find_component_clusters) and subgraph-emission (_create_subgraph_section)
+    primitives exercised here directly.
+
+    The test asserts the guarantee (no duplicate id in emitted output), not a
+    mechanism: it does not assert which naming branch is taken, what a name is
+    spelled, or that any particular code path inside _find_node_clusters ran.
+    """
+
+    @pytest.fixture
+    def mock_config_loader(self):
+        """Provide mock config loader."""
+        return Mock(spec=MermaidConfigLoader)
+
+    def test_clusters_from_independent_categories_do_not_emit_duplicate_subgraph_ids(self, mock_config_loader):
+        """
+        Reproduce a duplicate subgraph id using clusters whose members span two
+        different component categories.
+
+        Fixture shape: two categories (componentsApplication,
+        componentsExternalTools), each containing a pair of components that
+        shares 2+ controls (the clustering threshold) and whose IDs have no
+        meaningful common prefix once "component" is stripped -- e.g.
+        "componentA1"/"componentB2" strip to "A1"/"B2", which share no prefix,
+        forcing the positional fallback subgroup name. Component clustering
+        itself is scoped to one category at a time (this is how every caller in
+        the codebase invokes it -- see controls_graph.py's per-category loop),
+        so this fixture calls _find_component_clusters once per category, the
+        same way a real caller does, without going through ControlGraph.
+
+        Given: two independently-clustered categories, each producing one
+               2-member cluster via BaseGraph._find_component_clusters
+        When: a subgraph section is emitted for every discovered cluster, the
+              same way every graph type emits sections via
+              BaseGraph._create_subgraph_section
+        Then: no subgraph id appears in more than one "subgraph <id> [...]"
+              declaration across the combined output
+        """
+        components = {
+            "componentA1": ComponentNode(
+                title="A1 Title", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentB2": ComponentNode(
+                title="B2 Title", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentC3": ComponentNode(
+                title="C3 Title", category="componentsExternalTools", to_edges=[], from_edges=[]
+            ),
+            "componentD4": ComponentNode(
+                title="D4 Title", category="componentsExternalTools", to_edges=[], from_edges=[]
+            ),
+        }
+        graph = BaseGraph(components=components, config_loader=mock_config_loader)
+        graph.component_by_category = {
+            "componentsApplication": ["componentA1", "componentB2"],
+            "componentsExternalTools": ["componentC3", "componentD4"],
+        }
+
+        # Each category's node-to-controls map is independent, mirroring how
+        # _find_optimal_subgroupings builds one map per category before
+        # clustering within it.
+        node_to_controls_by_category = {
+            "componentsApplication": {
+                "componentA1": {"ctrl1", "ctrl2"},
+                "componentB2": {"ctrl1", "ctrl2"},
+            },
+            "componentsExternalTools": {
+                "componentC3": {"ctrl3", "ctrl4"},
+                "componentD4": {"ctrl3", "ctrl4"},
+            },
+        }
+
+        emitted_ids: list[str] = []
+        for category, node_to_controls in node_to_controls_by_category.items():
+            clusters = graph._find_component_clusters(node_to_controls, min_shared_controls=2, min_nodes=2)
+
+            # Vacuity guard: if clustering stops producing subgroups for this
+            # fixture (threshold tuning, a shape assumption breaking elsewhere
+            # in the module), the test must fail loudly instead of silently
+            # passing over an empty set -- this module's history includes
+            # guards that passed because their derivation returned nothing.
+            assert clusters, (
+                f"No clusters found for category {category!r}; fixture no longer "
+                "exercises clustering -- update the fixture, don't let this pass empty."
+            )
+
+            for subgroup_name, member_ids in clusters.items():
+                section = graph._create_subgraph_section(
+                    category=subgroup_name,
+                    category_name=subgroup_name,
+                    item_ids=member_ids,
+                    items=graph.components,
+                )
+                for line in section:
+                    stripped = line.strip()
+                    if stripped.startswith("subgraph "):
+                        # Line format: 'subgraph <id> ["<display name>"]'
+                        emitted_ids.append(stripped.split()[1])
+
+        # Sanity check on the harness itself: two sections should have been
+        # emitted (one per category) before checking for collisions between
+        # them.
+        assert len(emitted_ids) == 2
+
+        duplicate_ids = {sid for sid in emitted_ids if emitted_ids.count(sid) > 1}
+        assert not duplicate_ids, (
+            f"Duplicate subgraph id(s) {duplicate_ids} emitted across categories "
+            f"{list(node_to_controls_by_category)}; a Mermaid graph with a repeated "
+            "subgraph id fails to render (mmdc exits 1, mermaid.live fails too)."
+        )
+
+    def test_common_prefix_branch_collision_across_categories_does_not_emit_duplicate_subgraph_ids(
+        self, mock_config_loader
+    ):
+        """
+        Same guarantee as the test above, reached via the OTHER naming branch in
+        _find_node_clusters (base.py:230-242, the common-prefix branch) instead of
+        the positional fallback. A fix that only patches the fallback branch (e.g.
+        making its positional index globally unique) leaves this branch shipping
+        an identical collision, since it computes names independently via
+        commonprefix() and never consults what the fallback branch or a sibling
+        category's call produced.
+
+        Fixture shape: two categories, each clustering a pair of components whose
+        IDs share a >2-char prefix once "component" is stripped
+        ("GizmoAlpha"/"GizmoBeta" -> "Gizmo"; "GizmoGamma"/"GizmoDelta" -> "Gizmo"),
+        so both independent per-category calls derive the same name
+        "componentsGizmo" via the common-prefix branch specifically. "Gizmo" is a
+        fictitious prefix, chosen so this fixture doesn't also collide with the
+        real schema's "componentsModel" category (a genuine top-level component
+        category), which would confound the assertion with an unrelated,
+        pre-existing collision.
+
+        Given: two independently-clustered categories, each producing one
+               2-member cluster whose name resolves through the common-prefix
+               branch to the same string
+        When: a subgraph section is emitted for every discovered cluster via
+              BaseGraph._create_subgraph_section
+        Then: no subgraph id appears in more than one declaration, AND (fixture-
+              reach guard) the two categories' derived names actually match each
+              other and are not fallback-pattern names -- proving this fixture
+              still exercises the common-prefix branch and not the scenario the
+              previous test already covers
+        """
+        components = {
+            "componentGizmoAlpha": ComponentNode(
+                title="Gizmo Alpha", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentGizmoBeta": ComponentNode(
+                title="Gizmo Beta", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentGizmoGamma": ComponentNode(
+                title="Gizmo Gamma", category="componentsExternalTools", to_edges=[], from_edges=[]
+            ),
+            "componentGizmoDelta": ComponentNode(
+                title="Gizmo Delta", category="componentsExternalTools", to_edges=[], from_edges=[]
+            ),
+        }
+        graph = BaseGraph(components=components, config_loader=mock_config_loader)
+        graph.component_by_category = {
+            "componentsApplication": ["componentGizmoAlpha", "componentGizmoBeta"],
+            "componentsExternalTools": ["componentGizmoGamma", "componentGizmoDelta"],
+        }
+
+        node_to_controls_by_category = {
+            "componentsApplication": {
+                "componentGizmoAlpha": {"ctrl1", "ctrl2"},
+                "componentGizmoBeta": {"ctrl1", "ctrl2"},
+            },
+            "componentsExternalTools": {
+                "componentGizmoGamma": {"ctrl3", "ctrl4"},
+                "componentGizmoDelta": {"ctrl3", "ctrl4"},
+            },
+        }
+
+        derived_names: list[str] = []
+        emitted_ids: list[str] = []
+        for category, node_to_controls in node_to_controls_by_category.items():
+            clusters = graph._find_component_clusters(node_to_controls, min_shared_controls=2, min_nodes=2)
+
+            assert clusters, (
+                f"No clusters found for category {category!r}; fixture no longer "
+                "exercises clustering -- update the fixture, don't let this pass empty."
+            )
+
+            for subgroup_name, member_ids in clusters.items():
+                derived_names.append(subgroup_name)
+                section = graph._create_subgraph_section(
+                    category=subgroup_name,
+                    category_name=subgroup_name,
+                    item_ids=member_ids,
+                    items=graph.components,
+                )
+                for line in section:
+                    stripped = line.strip()
+                    if stripped.startswith("subgraph "):
+                        emitted_ids.append(stripped.split()[1])
+
+        # Fixture-reach guard: confirm this fixture actually reaches the
+        # common-prefix collision it was built for -- both categories' clusters
+        # resolved to the identical name, and that name did not come from the
+        # positional fallback branch already covered by the previous test. This
+        # is a mechanism assertion on the fixture's own construction (what
+        # inputs were fed in and what name resulted), not on which production
+        # branch fired -- it exists so a refactor of the naming logic can't
+        # silently make this fixture stop exercising the common-prefix branch
+        # while the test keeps passing for the wrong reason.
+        assert len(derived_names) == 2 and derived_names[0] == derived_names[1], (
+            f"Fixture no longer produces identical names across categories (got {derived_names}); "
+            "it no longer reaches the collision this test targets -- update the fixture."
+        )
+        assert "Subgroup" not in derived_names[0], (
+            "Fixture drifted onto the positional fallback naming branch instead of "
+            "the common-prefix branch this test is meant to exercise."
+        )
+
+        duplicate_ids = {sid for sid in emitted_ids if emitted_ids.count(sid) > 1}
+        assert not duplicate_ids, (
+            f"Duplicate subgraph id(s) {duplicate_ids} emitted across categories via the "
+            f"common-prefix naming branch; a Mermaid graph with a repeated subgraph id "
+            "fails to render (mmdc exits 1, mermaid.live fails too)."
+        )
+
+
 class TestGroupNodeBy:
     """
     Test _group_node_by method.

--- a/scripts/hooks/tests/test_risk_graph.py
+++ b/scripts/hooks/tests/test_risk_graph.py
@@ -36,10 +36,12 @@ on RiskGraph functionality while ensuring integration with existing
 ControlGraph optimizations.
 """
 
+import re
 from unittest.mock import MagicMock, patch
 
 import pytest
 from riskmap_validator.graphing.base import MermaidConfigLoader
+from riskmap_validator.graphing.controls_graph import ControlGraph
 from riskmap_validator.graphing.risks_graph import RiskGraph
 from riskmap_validator.models import ComponentNode, ControlNode, RiskNode
 
@@ -515,3 +517,84 @@ class TestIntegrationScenarios:
         assert "MinimalRisk --> MinimalControl" in mermaid_output
         # ControlGraph optimization maps to category when it contains all components in that category
         assert "MinimalControl --> componentsData" in mermaid_output
+
+
+class TestComposedControlGraphReuseDoesNotRenameIds:
+    """
+    Regression guard for a composition re-entrancy defect.
+
+    RiskGraph.build_risk_control_component_graph() reuses the composed
+    ControlGraph's _get_controls_subgraph()/_get_component_subgraph() to embed
+    the control/component layers -- but that ControlGraph instance already
+    rendered those exact same subgraphs once, inside its own __init__, to
+    build risk_graph.control_graph.graph. Subgraph-id collision-tracking state
+    that lives for the ControlGraph instance's full lifetime (rather than
+    being scoped to a single render pass) sees this second pass's ids as
+    already declared by the first pass and disambiguates every one of them
+    (e.g. "controlsData" -> "controlsData2"), even on a corpus with no
+    genuine subgroup-name collision at all. The existing
+    test_basic_graph_generation only asserts "controlsData" in mermaid_output,
+    which "controlsData2" also satisfies -- it cannot see this. These tests
+    pin the actual declared id set instead of a substring.
+    """
+
+    def test_risk_graph_control_and_component_ids_match_standalone_control_graph(
+        self, sample_risks, sample_controls, sample_components
+    ):
+        """
+        Given: a corpus with no subgroup-naming collisions (no pair of
+               sample_components shares 2+ controls, so no clustering fires)
+        When: a RiskGraph is built (composing a ControlGraph, then reusing
+              that already-built instance's subgraph-emission methods a
+              second time to embed them in the three-layer graph)
+        Then: every "subgraph <id>" declared in the RiskGraph's own rendered
+              output, aside from its own "risks" layer, is exactly the set
+              the standalone ControlGraph declares for the same input --
+              not a "...2"-suffixed variant introduced purely by being
+              rendered a second time through composition
+        """
+        standalone = ControlGraph(sample_controls, sample_components)
+        standalone_ids = set(re.findall(r"^\s*subgraph (\S+)", standalone.graph, flags=re.MULTILINE))
+
+        risk_graph = RiskGraph(sample_risks, sample_controls, sample_components)
+        risk_graph_ids = set(re.findall(r"^\s*subgraph (\S+)", risk_graph.graph, flags=re.MULTILINE))
+
+        # RiskGraph declares an additional "risks" subgraph the standalone
+        # ControlGraph never does; every other id must match exactly.
+        risk_graph_control_component_ids = risk_graph_ids - {"risks"}
+
+        assert risk_graph_control_component_ids == standalone_ids, (
+            f"RiskGraph's reused control/component subgraph ids "
+            f"{risk_graph_control_component_ids} differ from the standalone "
+            f"ControlGraph's {standalone_ids} -- composition disambiguated ids "
+            "that were never involved in a genuine naming collision."
+        )
+
+    def test_reusing_a_built_control_graphs_subgraph_methods_is_idempotent(
+        self, sample_controls, sample_components
+    ):
+        """
+        Given: a fully-built ControlGraph (its own __init__ already rendered
+               controls/component subgraphs once, while building self.graph)
+        When: _get_controls_subgraph()/_get_component_subgraph() -- the exact
+              methods RiskGraph's composition calls -- are invoked again on
+              the same instance
+        Then: the ids declared on the second call are identical to the ids
+              declared on the first call, in the same order -- not
+              disambiguated against a false "already declared" collision
+              left over from the instance's first (and only legitimate)
+              render pass
+        """
+        control_graph = ControlGraph(sample_controls, sample_components)
+
+        first_pass = "\n".join(control_graph._get_controls_subgraph() + control_graph._get_component_subgraph())
+        first_ids = re.findall(r"^\s*subgraph (\S+)", first_pass, flags=re.MULTILINE)
+
+        second_pass = "\n".join(control_graph._get_controls_subgraph() + control_graph._get_component_subgraph())
+        second_ids = re.findall(r"^\s*subgraph (\S+)", second_pass, flags=re.MULTILINE)
+
+        assert second_ids == first_ids, (
+            f"Calling the subgraph-emission methods a second time on an "
+            f"already-built ControlGraph produced different ids: first pass "
+            f"{first_ids}, second pass {second_ids}."
+        )

--- a/scripts/hooks/tests/test_validate_component_edges.py
+++ b/scripts/hooks/tests/test_validate_component_edges.py
@@ -40,6 +40,7 @@ and reproducibility. Each test class focuses on a specific aspect of the system:
 - TestEndToEndIntegration: Complete validation workflows
 """
 
+import re
 import subprocess
 
 # Import the validator using git repo root
@@ -79,6 +80,46 @@ from riskmap_validator.utils import get_staged_yaml_files  # noqa: E402
 
 # Import the validator and its exception from the validator module
 from riskmap_validator.validator import ComponentEdgeValidator, EdgeValidationError  # noqa: E402
+
+
+def _parse_mermaid_graph_structure(graph_text: str) -> dict:
+    """
+    Parse the subset of Mermaid syntax this codebase's graph generators emit.
+
+    Test-only structural parser (not a general Mermaid parser) used to assert
+    rendering invariants against generated graph text:
+      - "subgraph <id>" / "subgraph <id> [\"<display>\"]" container declarations
+      - "<id>[<label>]" leaf node declarations
+      - "<source> --> <target>" / "<source> -.-> <target>" edges
+      - "style <id> <style-string>" style declarations
+
+    Returns:
+        dict with keys "subgraph_ids", "node_ids", "edges", "style_ids" -- each
+        a list preserving duplicates/order, so callers can detect both
+        missing-declaration and duplicate-declaration failures.
+    """
+    subgraph_ids: list[str] = []
+    node_ids: list[str] = []
+    edges: list[tuple[str, str]] = []
+    style_ids: list[str] = []
+
+    for line in graph_text.split("\n"):
+        stripped = line.strip()
+        if m := re.match(r"^subgraph (\S+)", stripped):
+            subgraph_ids.append(m.group(1))
+        elif m := re.match(r"^style (\S+)\s", stripped):
+            style_ids.append(m.group(1))
+        elif m := re.match(r"^(\S+)\s+(?:-->|-\.->)\s+(\S+)$", stripped):
+            edges.append((m.group(1), m.group(2)))
+        elif m := re.match(r"^(\w+)\[", stripped):
+            node_ids.append(m.group(1))
+
+    return {
+        "subgraph_ids": subgraph_ids,
+        "node_ids": node_ids,
+        "edges": edges,
+        "style_ids": style_ids,
+    }
 
 
 class TestComponentEdgeValidator:
@@ -806,6 +847,45 @@ class TestComponentGraph:
         assert "```mermaid" in mermaid_output
         assert "```" in mermaid_output
 
+    def test_build_graph_is_idempotent_across_repeated_calls(self, simple_forward_map, simple_components):
+        """
+        Regression guard: calling build_graph() twice on the same instance
+        must declare the same subgraph ids in the same order both times.
+
+        _create_subgraph_section's collision-tracking state
+        (_declared_subgraph_ids, declared in BaseGraph.__init__) is scoped to
+        the instance's whole lifetime rather than to a single render pass. A
+        category id (e.g. "componentsData") legitimately reappears every time
+        build_graph() runs -- categories don't change between calls -- but
+        without a reset at the start of a render pass, the second call sees
+        every id the first call already declared as "taken" and disambiguates
+        it (e.g. "componentsData" -> "componentsData2"), even though no two
+        categories collide with each other. NOTE: asserting against
+        to_mermaid() output would not catch this -- to_mermaid() only
+        formats self.graph, which is built once in __init__ and never
+        touched again; the defect is only visible by calling build_graph()
+        itself a second time.
+        """
+        # __init__ already calls build_graph() once to populate self.graph;
+        # that is "first pass" here. A second, explicit call is the
+        # re-entrant one under test.
+        graph = ComponentGraph(simple_forward_map, simple_components)
+        first_pass = graph.graph
+        first_ids = _parse_mermaid_graph_structure(first_pass)["subgraph_ids"]
+
+        second_pass = graph.build_graph()
+        second_ids = _parse_mermaid_graph_structure(second_pass)["subgraph_ids"]
+
+        assert second_ids == first_ids, (
+            f"Calling build_graph() a second time on the same ComponentGraph "
+            f"instance produced different subgraph ids: first pass {first_ids}, "
+            f"second pass {second_ids}."
+        )
+        assert second_pass == first_pass, (
+            "Calling build_graph() a second time on the same ComponentGraph "
+            "instance produced different output text."
+        )
+
 
 class TestControlNode:
     """
@@ -1300,3 +1380,701 @@ class TestControlGraph:
             line for line in link_style_lines if any(color in line for color in multi_edge_colors)
         ]
         assert len(multi_edge_styles) == 0  # Should be 0 since this control maps to categories
+
+    def test_control_graph_output_has_no_duplicate_subgraph_ids(self):
+        """
+        Companion test to base.py's TestSubgraphIdUniqueness, exercised against the
+        concrete ControlGraph output that a rendering failure is actually reported
+        against. This test is expected to be deleted along with controls_graph.py
+        per issue #477; the load-bearing guard lives in test_base_graph.py because
+        it survives that deletion.
+
+        Fixture shape: two component categories (componentsApplication,
+        componentsExternalTools), each with one pair of components that shares 2
+        controls (triggering component clustering) plus one additional standalone
+        component (so the parent category subgraph still has members left over
+        after the pair is pulled into a subgroup, and its nested-subgraph section
+        is actually emitted -- an all-clustered category is skipped entirely by
+        ControlGraph._get_subgraph and would mask the collision). Each pair's IDs
+        share no meaningful prefix once "component" is stripped, so cluster naming
+        falls back to the positional "{prefix}Subgroup{i+1}" pattern in both
+        categories independently, producing the id collision reported against the
+        real corpus (componentsSubgroup1 declared under both componentsApplication
+        and componentsExternalTools).
+
+        Given: components/controls shaped to produce one cluster per category,
+               under two different parent categories
+        When: ControlGraph builds its Mermaid graph
+        Then: no "subgraph <id>" declaration id appears more than once in the
+              rendered output
+        """
+        components = {
+            "componentA1": ComponentNode(
+                title="A1 Title", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentB2": ComponentNode(
+                title="B2 Title", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentA3": ComponentNode(
+                title="A3 Title", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentC3": ComponentNode(
+                title="C3 Title", category="componentsExternalTools", to_edges=[], from_edges=[]
+            ),
+            "componentD4": ComponentNode(
+                title="D4 Title", category="componentsExternalTools", to_edges=[], from_edges=[]
+            ),
+            "componentC5": ComponentNode(
+                title="C5 Title", category="componentsExternalTools", to_edges=[], from_edges=[]
+            ),
+        }
+        controls = {
+            "ctrl1": ControlNode(
+                title="Ctrl 1",
+                category="controlsData",
+                components=["componentA1", "componentB2"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl2": ControlNode(
+                title="Ctrl 2",
+                category="controlsData",
+                components=["componentA1", "componentB2"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl3": ControlNode(
+                title="Ctrl 3",
+                category="controlsData",
+                components=["componentC3", "componentD4"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl4": ControlNode(
+                title="Ctrl 4",
+                category="controlsData",
+                components=["componentC3", "componentD4"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl5": ControlNode(
+                title="Ctrl 5", category="controlsData", components=["componentA3"], risks=[], personas=[]
+            ),
+            "ctrl6": ControlNode(
+                title="Ctrl 6", category="controlsData", components=["componentC5"], risks=[], personas=[]
+            ),
+        }
+
+        graph = ControlGraph(controls, components)
+
+        # Vacuity guard: if this fixture stops producing subgroupings (clustering
+        # thresholds changed, shape assumption broke), the test must fail loudly
+        # rather than silently pass over nothing to check.
+        assert graph.subgroupings, (
+            "Fixture produced no subgroupings; it no longer exercises clustering "
+            "-- update the fixture, don't let this pass on an empty derivation."
+        )
+
+        subgraph_ids = re.findall(r"^\s*subgraph (\S+)", graph.graph, flags=re.MULTILINE)
+        duplicate_ids = {sid for sid in subgraph_ids if subgraph_ids.count(sid) > 1}
+
+        assert not duplicate_ids, (
+            f"Duplicate subgraph id(s) {duplicate_ids} declared in ControlGraph output; "
+            "a Mermaid graph with a repeated subgraph id fails to render (mmdc exits 1, "
+            "mermaid.live fails too)."
+        )
+
+    def _fallback_collision_components_and_controls(self):
+        """
+        Same fixture shape as test_control_graph_output_has_no_duplicate_subgraph_ids:
+        two categories, each with a 2-member cluster (sharing 2 controls, no common
+        ID prefix -> positional fallback naming) plus one standalone component per
+        category so the parent subgraph still has leftover members and the
+        nested-subgraph path actually fires. Factored out so multiple guarantee
+        tests can exercise the identical scenario without re-declaring it.
+        """
+        components = {
+            "componentA1": ComponentNode(
+                title="A1 Title", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentB2": ComponentNode(
+                title="B2 Title", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentA3": ComponentNode(
+                title="A3 Title", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentC3": ComponentNode(
+                title="C3 Title", category="componentsExternalTools", to_edges=[], from_edges=[]
+            ),
+            "componentD4": ComponentNode(
+                title="D4 Title", category="componentsExternalTools", to_edges=[], from_edges=[]
+            ),
+            "componentC5": ComponentNode(
+                title="C5 Title", category="componentsExternalTools", to_edges=[], from_edges=[]
+            ),
+        }
+        controls = {
+            "ctrl1": ControlNode(
+                title="Ctrl 1",
+                category="controlsData",
+                components=["componentA1", "componentB2"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl2": ControlNode(
+                title="Ctrl 2",
+                category="controlsData",
+                components=["componentA1", "componentB2"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl3": ControlNode(
+                title="Ctrl 3",
+                category="controlsData",
+                components=["componentC3", "componentD4"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl4": ControlNode(
+                title="Ctrl 4",
+                category="controlsData",
+                components=["componentC3", "componentD4"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl5": ControlNode(
+                title="Ctrl 5", category="controlsData", components=["componentA3"], risks=[], personas=[]
+            ),
+            "ctrl6": ControlNode(
+                title="Ctrl 6", category="controlsData", components=["componentC5"], risks=[], personas=[]
+            ),
+        }
+        return components, controls
+
+    def test_control_graph_declared_subgraphs_have_exactly_one_style_line(self):
+        """
+        Guard against a cosmetic fix that renames the second colliding subgraph
+        id (making declared ids unique) without updating self.subgroupings, which
+        is the only source the style-emission loop reads from. Measured on the
+        rename-on-collision fix: the original id still gets two "style" lines
+        (last one silently wins in Mermaid) and the renamed id gets zero -- a
+        graph that renders, but colors one subgroup wrong and the other not at
+        all. A bare "no duplicate declared subgraph id" check cannot see this,
+        because by the time ids are unique the duplication has moved from the
+        subgraph declaration to the style declaration.
+
+        Given: the fallback-collision fixture (two categories, each producing a
+               same-named 2-member cluster via the positional fallback branch)
+        When: ControlGraph builds its Mermaid graph
+        Then: every dynamically-generated subgroup id (the ones build_controls_graph
+              styles via self.subgroupings, as opposed to control categories or
+              component categories absent from the styling config -- neither of
+              which are styled by design and are out of scope here) has exactly
+              one "style <id> ..." line
+        """
+        components, controls = self._fallback_collision_components_and_controls()
+        graph = ControlGraph(controls, components)
+
+        assert graph.subgroupings, (
+            "Fixture produced no subgroupings; it no longer exercises clustering "
+            "-- update the fixture, don't let this pass on an empty derivation."
+        )
+
+        # Scope the check to subgroup ids specifically (from self.subgroupings),
+        # not every declared subgraph id: control categories never get a "style"
+        # line by design, and not every component category is present in the
+        # styling config either -- both are pre-existing, unrelated behavior.
+        # Only dynamically-generated subgroups are guaranteed a style line by
+        # build_controls_graph's dedicated subgroup-styling loop.
+        subgroup_ids = {name for subgroups in graph.subgroupings.values() for name in subgroups.keys()}
+
+        parsed = _parse_mermaid_graph_structure(graph.graph)
+        style_counts = {sid: parsed["style_ids"].count(sid) for sid in subgroup_ids}
+        wrong_counts = {sid: count for sid, count in style_counts.items() if count != 1}
+
+        assert not wrong_counts, (
+            f"Declared subgraph(s) without exactly one style line: {wrong_counts} "
+            "(0 = the subgraph renders uncolored/default; >1 = Mermaid keeps only "
+            "the last style, silently discarding the others)."
+        )
+
+    def test_control_graph_edges_resolve_to_declared_ids(self):
+        """
+        Every edge must target something that was actually declared (a node or a
+        subgraph/category id) -- an edge to an undeclared id is invisible/broken
+        in the rendered graph even when the file technically parses.
+
+        Given: the fallback-collision fixture
+        When: ControlGraph builds its Mermaid graph
+        Then: every "-->"/"-.->" edge target is among the declared node ids or
+              declared subgraph ids
+        """
+        components, controls = self._fallback_collision_components_and_controls()
+        graph = ControlGraph(controls, components)
+
+        assert graph.subgroupings, (
+            "Fixture produced no subgroupings; it no longer exercises clustering "
+            "-- update the fixture, don't let this pass on an empty derivation."
+        )
+
+        parsed = _parse_mermaid_graph_structure(graph.graph)
+        declared = set(parsed["subgraph_ids"]) | set(parsed["node_ids"])
+        # "components" is a valid universal edge target (controls mapped to
+        # "all") even though it's also a subgraph id already covered above.
+        unresolved_targets = sorted({target for _, target in parsed["edges"] if target not in declared})
+
+        assert not unresolved_targets, (
+            f"Edge target(s) {unresolved_targets} are not declared anywhere in the output "
+            "(no matching node or subgraph id) -- these edges point at nothing."
+        )
+
+    def test_control_graph_every_component_appears_at_least_once(self):
+        """
+        Every component passed into ControlGraph must be declared as a node
+        somewhere in the output. This is the guarantee that catches silent data
+        loss, which a "no duplicate id" check cannot: when a category is fully
+        absorbed into a subgroup with no leftover members, ControlGraph._get_subgraph
+        skips that (now-empty) category entirely, so the nested-subgraph call that
+        would have embedded the subgroup never fires -- see
+        test_control_graph_fully_clustered_category_does_not_lose_components for
+        that shape specifically. This test uses the leftover-members fixture as a
+        baseline: it should never regress even when the fixture is "well-behaved".
+
+        Given: the fallback-collision fixture
+        When: ControlGraph builds its Mermaid graph
+        Then: every component id in the input appears as a declared node at least
+              once in the output
+        """
+        components, controls = self._fallback_collision_components_and_controls()
+        graph = ControlGraph(controls, components)
+
+        assert graph.subgroupings, (
+            "Fixture produced no subgroupings; it no longer exercises clustering "
+            "-- update the fixture, don't let this pass on an empty derivation."
+        )
+
+        parsed = _parse_mermaid_graph_structure(graph.graph)
+        declared_node_ids = set(parsed["node_ids"])
+        missing = sorted(cid for cid in components if cid not in declared_node_ids)
+
+        assert not missing, (
+            f"Component id(s) {missing} never declared as a node in the output -- silently dropped."
+        )
+
+    def test_control_graph_fully_clustered_category_does_not_lose_components(self):
+        """
+        F2 shape: two categories with NO leftover members -- every component in
+        each category is absorbed into that category's single cluster. This is
+        the discriminator the leftover-members fixtures above cannot exercise:
+        when a category's item list becomes empty after clustering,
+        ControlGraph._get_subgraph's "if not item_ids: continue" skips it
+        entirely, so the nested-subgraph call that would emit the subgroup (and
+        the components inside it) for that category never runs. Measured: this
+        drops 2 of 4 components from the rendered output entirely, with NO
+        duplicate subgraph id in sight -- the naive duplicate-id check reports
+        this fixture as clean. A rename-on-collision fix does not touch this
+        path at all (the skip happens before _create_subgraph_section is ever
+        called for the affected category), so this is also a discriminator
+        against that cosmetic fix specifically.
+
+        Given: two categories, each entirely absorbed into one 2-member cluster
+               (no components left over in either parent category)
+        When: ControlGraph builds its Mermaid graph
+        Then: every component id in the input still appears as a declared node
+        """
+        components = {
+            "componentA1": ComponentNode(
+                title="A1 Title", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentB2": ComponentNode(
+                title="B2 Title", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentC3": ComponentNode(
+                title="C3 Title", category="componentsExternalTools", to_edges=[], from_edges=[]
+            ),
+            "componentD4": ComponentNode(
+                title="D4 Title", category="componentsExternalTools", to_edges=[], from_edges=[]
+            ),
+        }
+        controls = {
+            "ctrl1": ControlNode(
+                title="Ctrl 1",
+                category="controlsData",
+                components=["componentA1", "componentB2"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl2": ControlNode(
+                title="Ctrl 2",
+                category="controlsData",
+                components=["componentA1", "componentB2"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl3": ControlNode(
+                title="Ctrl 3",
+                category="controlsData",
+                components=["componentC3", "componentD4"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl4": ControlNode(
+                title="Ctrl 4",
+                category="controlsData",
+                components=["componentC3", "componentD4"],
+                risks=[],
+                personas=[],
+            ),
+        }
+
+        graph = ControlGraph(controls, components)
+
+        assert graph.subgroupings, (
+            "Fixture produced no subgroupings; it no longer exercises clustering "
+            "-- update the fixture, don't let this pass on an empty derivation."
+        )
+
+        # Fixture-reach guard: confirm this fixture actually reaches the F2 shape
+        # it was built for -- every member of each clustered category absorbed
+        # into that category's subgroup(s), with nothing left over. This is a
+        # mechanism assertion on the fixture's own construction (not on which
+        # production code path fires), so a future change that alters how
+        # much gets clustered can't silently turn this into a no-op leftover
+        # fixture that duplicates the other tests without testing F2 at all.
+        for category, subgroups in graph.subgroupings.items():
+            clustered_members = {member for members in subgroups.values() for member in members}
+            original_members = {cid for cid, node in components.items() if node.category == category}
+            assert clustered_members == original_members, (
+                f"Fixture no longer fully clusters category {category!r} "
+                f"(leftover members: {original_members - clustered_members}); "
+                "this test targets the fully-clustered (F2) shape specifically -- "
+                "update the fixture to restore it, don't let this silently degrade "
+                "into the leftover-members shape already covered elsewhere."
+            )
+
+        parsed = _parse_mermaid_graph_structure(graph.graph)
+        declared_node_ids = set(parsed["node_ids"])
+        missing = sorted(cid for cid in components if cid not in declared_node_ids)
+
+        assert not missing, (
+            f"Component id(s) {missing} never declared as a node in the output -- silently dropped "
+            "when their category has no leftover members after clustering."
+        )
+
+    def test_control_graph_common_prefix_collision_does_not_duplicate_or_lose_data(self):
+        """
+        A collision reached via the common-prefix naming branch (base.py:230-242),
+        not the positional fallback the other tests above exercise. Two
+        categories each cluster a pair of components whose IDs share a >2-char
+        prefix once "component" is stripped ("GizmoAlpha"/"GizmoBeta" ->
+        "Gizmo"; "GizmoGamma"/"GizmoDelta" -> "Gizmo"), so both clusters are
+        named "componentsGizmo" independently of the fallback's positional
+        index. A fix that only patches the fallback branch (i+1 restarting, or
+        similar) leaves this branch shipping the identical bug. "Gizmo" is a
+        fictitious prefix chosen so this fixture doesn't also collide with the
+        real schema's "componentsModel" category, which would confound the
+        assertions with an unrelated pre-existing collision.
+
+        Given: two categories whose clusters both resolve through the
+               common-prefix naming branch to the same derived name
+        When: ControlGraph builds its Mermaid graph
+        Then: no subgraph id is declared twice, every declared subgraph has
+              exactly one style line, and no component is silently dropped
+        """
+        components = {
+            "componentGizmoAlpha": ComponentNode(
+                title="Gizmo Alpha", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentGizmoBeta": ComponentNode(
+                title="Gizmo Beta", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentA3": ComponentNode(
+                title="A3 Title", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentGizmoGamma": ComponentNode(
+                title="Gizmo Gamma", category="componentsExternalTools", to_edges=[], from_edges=[]
+            ),
+            "componentGizmoDelta": ComponentNode(
+                title="Gizmo Delta", category="componentsExternalTools", to_edges=[], from_edges=[]
+            ),
+            "componentC5": ComponentNode(
+                title="C5 Title", category="componentsExternalTools", to_edges=[], from_edges=[]
+            ),
+        }
+        controls = {
+            "ctrl1": ControlNode(
+                title="Ctrl 1",
+                category="controlsData",
+                components=["componentGizmoAlpha", "componentGizmoBeta"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl2": ControlNode(
+                title="Ctrl 2",
+                category="controlsData",
+                components=["componentGizmoAlpha", "componentGizmoBeta"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl3": ControlNode(
+                title="Ctrl 3",
+                category="controlsData",
+                components=["componentGizmoGamma", "componentGizmoDelta"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl4": ControlNode(
+                title="Ctrl 4",
+                category="controlsData",
+                components=["componentGizmoGamma", "componentGizmoDelta"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl5": ControlNode(
+                title="Ctrl 5", category="controlsData", components=["componentA3"], risks=[], personas=[]
+            ),
+            "ctrl6": ControlNode(
+                title="Ctrl 6", category="controlsData", components=["componentC5"], risks=[], personas=[]
+            ),
+        }
+
+        graph = ControlGraph(controls, components)
+
+        assert graph.subgroupings, (
+            "Fixture produced no subgroupings; it no longer exercises clustering "
+            "-- update the fixture, don't let this pass on an empty derivation."
+        )
+
+        # Fixture-reach guard: confirm the two categories' clusters actually
+        # resolved to the SAME name (the collision this fixture targets) and
+        # that the name came from the common-prefix branch, not the positional
+        # fallback already covered by the other fixtures in this file and in
+        # test_base_graph.py. This is a mechanism assertion on the fixture's
+        # own construction, not on production internals -- it exists so a
+        # cosmetic fix or an unrelated refactor can't silently neuter this
+        # specific scenario without the test noticing it stopped exercising it.
+        derived_names = {
+            subgroup_name for subgroups in graph.subgroupings.values() for subgroup_name in subgroups.keys()
+        }
+        assert derived_names == {"componentsGizmo"}, (
+            f"Fixture no longer produces a single shared common-prefix name across "
+            f"categories (got {derived_names}); it no longer reaches the branch this "
+            "test targets -- update the fixture, don't let this silently pass."
+        )
+        assert "Subgroup" not in next(iter(derived_names)), (
+            "Fixture drifted onto the positional fallback naming branch instead of "
+            "the common-prefix branch this test is meant to exercise."
+        )
+
+        parsed = _parse_mermaid_graph_structure(graph.graph)
+        subgraph_ids = parsed["subgraph_ids"]
+        duplicate_ids = {sid for sid in subgraph_ids if subgraph_ids.count(sid) > 1}
+        assert not duplicate_ids, (
+            f"Duplicate subgraph id(s) {duplicate_ids} declared via the common-prefix naming "
+            "branch; a Mermaid graph with a repeated subgraph id fails to render."
+        )
+
+        # Scope the style-line check to the dynamically-generated subgroup ids
+        # (derived_names, already confirmed above), not every declared subgraph:
+        # control categories and unconfigured component categories never get a
+        # "style" line by design, which is pre-existing and unrelated here.
+        style_counts = {sid: parsed["style_ids"].count(sid) for sid in derived_names}
+        wrong_counts = {sid: count for sid, count in style_counts.items() if count != 1}
+        assert not wrong_counts, (
+            f"Declared subgraph(s) without exactly one style line: {wrong_counts} "
+            "-- a fallback-only naming fix leaves this branch's collision shipping."
+        )
+
+        declared_node_ids = set(parsed["node_ids"])
+        missing = sorted(cid for cid in components if cid not in declared_node_ids)
+        assert not missing, (
+            f"Component id(s) {missing} never declared as a node in the output -- silently dropped."
+        )
+
+    def test_control_graph_empty_category_does_not_falsely_appear_covered(self):
+        """
+        Regression guard for a loud-to-silent conversion.
+
+        _maps_to_full_category checks
+        set(component_by_category[category]).issubset(control_components).
+        When a category is fully absorbed into a cluster,
+        component_by_category[category] is []; the empty set is a subset of
+        every set, so this check is vacuously True for ANY control, including
+        one with zero components in common with the category.
+
+        Before _get_subgraph was fixed to still render a fully-absorbed
+        category's nested subgroup (see
+        test_control_graph_fully_clustered_category_does_not_lose_components),
+        a control wrongly optimized to target that category pointed at an id
+        that was never declared anywhere -- an unresolved edge target, loud
+        and easy to catch. Now that the category IS declared (as a container
+        for its nested subgroup), the same vacuous-coverage bug would
+        silently point a bogus edge at a real, correctly-styled box instead.
+        This test targets the mapping bug directly, at the level where it
+        actually lives, so it cannot resurface through a future emission-path
+        change.
+
+        Given: a category fully absorbed into a subgroup (no direct members)
+               and a control whose components have no relationship to that
+               category at all
+        When: ControlGraph builds its control-to-component mapping
+        Then: that control is never optimized to target the empty category,
+              and no edge to it appears in the rendered graph
+        """
+        components = {
+            "componentA1": ComponentNode(
+                title="A1 Title", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentB2": ComponentNode(
+                title="B2 Title", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentX": ComponentNode(
+                title="X Title", category="componentsExternalTools", to_edges=[], from_edges=[]
+            ),
+        }
+        controls = {
+            "ctrl1": ControlNode(
+                title="Ctrl 1",
+                category="controlsData",
+                components=["componentA1", "componentB2"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl2": ControlNode(
+                title="Ctrl 2",
+                category="controlsData",
+                components=["componentA1", "componentB2"],
+                risks=[],
+                personas=[],
+            ),
+            # Unrelated to componentsApplication entirely -- must never be
+            # considered to "cover" it, empty or not.
+            "ctrlUnrelated": ControlNode(
+                title="Ctrl Unrelated", category="controlsData", components=["componentX"], risks=[], personas=[]
+            ),
+        }
+
+        graph = ControlGraph(controls, components)
+
+        assert graph.component_by_category.get("componentsApplication") == [], (
+            "Fixture no longer fully absorbs componentsApplication into its cluster "
+            "-- update the fixture, don't let this pass without exercising the "
+            "empty-category shape this test targets."
+        )
+
+        assert "componentsApplication" not in graph.control_to_component_map["ctrlUnrelated"], (
+            "ctrlUnrelated was optimized to target 'componentsApplication', a category "
+            "it shares zero components with -- the empty-category vacuous-subset bug "
+            "in _maps_to_full_category."
+        )
+
+        assert "ctrlUnrelated --> componentsApplication" not in graph.graph, (
+            "A bogus edge from an unrelated control to the empty category was rendered."
+        )
+
+    def test_control_graph_full_union_coverage_of_split_subgroup_still_edges_every_member(self):
+        """
+        Regression guard for the "wrong box" risk in a collision resolved by
+        merging component_by_category[subgroup_name] across colliding parent
+        categories (see _integrate_subgroupings).
+
+        A control that covers the FULL union of two colliding subgroups' true
+        memberships would, if the merged/unioned entry were offered as a
+        "control fully covers this category" optimization target, collapse to
+        a single edge pointing at whichever of the (now multiple, physically
+        distinct) rendered boxes happens to hold the unrenamed id -- silently
+        losing all coverage of the box that got renamed on collision, with no
+        edge, no visual trace, and no test failure to catch it. Before the
+        merge fix, this same control would instead have fallen through to
+        individual per-component edges (safe, if visually noisier).
+
+        Given: two categories whose clusters collide on the same subgroup
+               name (common-prefix branch), and a control that covers every
+               member of both colliding clusters
+        When: ControlGraph builds its control-to-component mapping
+        Then: the collided/merged subgroup name is never used as an
+              optimization target for that control -- every member component
+              still gets an edge (individually), so none are silently dropped
+        """
+        components = {
+            "componentGizmoAlpha": ComponentNode(
+                title="Gizmo Alpha", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentGizmoBeta": ComponentNode(
+                title="Gizmo Beta", category="componentsApplication", to_edges=[], from_edges=[]
+            ),
+            "componentGizmoGamma": ComponentNode(
+                title="Gizmo Gamma", category="componentsExternalTools", to_edges=[], from_edges=[]
+            ),
+            "componentGizmoDelta": ComponentNode(
+                title="Gizmo Delta", category="componentsExternalTools", to_edges=[], from_edges=[]
+            ),
+        }
+        controls = {
+            "ctrl1": ControlNode(
+                title="Ctrl 1",
+                category="controlsData",
+                components=["componentGizmoAlpha", "componentGizmoBeta"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl2": ControlNode(
+                title="Ctrl 2",
+                category="controlsData",
+                components=["componentGizmoAlpha", "componentGizmoBeta"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl3": ControlNode(
+                title="Ctrl 3",
+                category="controlsData",
+                components=["componentGizmoGamma", "componentGizmoDelta"],
+                risks=[],
+                personas=[],
+            ),
+            "ctrl4": ControlNode(
+                title="Ctrl 4",
+                category="controlsData",
+                components=["componentGizmoGamma", "componentGizmoDelta"],
+                risks=[],
+                personas=[],
+            ),
+            # Covers the FULL union of both colliding clusters' true members.
+            "ctrlFullUnion": ControlNode(
+                title="Ctrl Full Union",
+                category="controlsData",
+                components=[
+                    "componentGizmoAlpha",
+                    "componentGizmoBeta",
+                    "componentGizmoGamma",
+                    "componentGizmoDelta",
+                ],
+                risks=[],
+                personas=[],
+            ),
+        }
+
+        graph = ControlGraph(controls, components)
+
+        derived_names = {
+            subgroup_name for subgroups in graph.subgroupings.values() for subgroup_name in subgroups.keys()
+        }
+        assert derived_names == {"componentsGizmo"}, (
+            f"Fixture no longer produces the shared common-prefix collision this test "
+            f"targets (got {derived_names}) -- update the fixture, don't let this "
+            "silently pass."
+        )
+
+        full_union_targets = set(graph.control_to_component_map["ctrlFullUnion"])
+        all_four_members = {
+            "componentGizmoAlpha",
+            "componentGizmoBeta",
+            "componentGizmoGamma",
+            "componentGizmoDelta",
+        }
+
+        assert all_four_members <= full_union_targets, (
+            f"ctrlFullUnion's targets {full_union_targets} do not cover all four "
+            f"members {all_four_members} individually -- collapsing to a collided "
+            "subgroup id silently dropped coverage of at least one physical box."
+        )


### PR DESCRIPTION
Component clustering derives a subgroup id independently for each category, so two categories can land on the same candidate id. Nothing downstream expected that, and it failed four different ways — one loud, three silent.

### What was broken

**The loud one: the graph stopped rendering.** During MCP paper decomposition the same `subgraph` id was declared twice, which makes the whole Mermaid file unparseable — `mmdc` exits 1 with `TypeError: Cannot read properties of undefined (reading 'posX')`. A corpus growing controls from 37 to 67 produced it; renaming one occurrence by hand rendered the identical file.

**Silent component loss.** When a category's members were entirely absorbed into one cluster, the colliding entry overwrote the first, the emptied category was skipped, and its components disappeared from a graph that still rendered and still passed CI. The live corpus was **one component away** from that shape.

**A re-entrancy regression.** Collision state was scoped to the object rather than the render pass, and the risk graph reuses an already-built control graph — so every id in it was renamed on the second pass, producing unresolved edge targets and a box that lost its fill. No test caught it: the assertion was `"controlsData" in output`, and `controlsData2` satisfies it.

**A vacuous-truth coverage bug.** A category with no members made the full-coverage check trivially true — `set().issubset(x)` — so a control could appear to cover a category it had nothing to do with.

### What changed

- Declaration is now the single point that guarantees a cluster-derived id is written once. 
- Memberships merge rather than overwrite. 
- A category whose members are all absorbed is still visited, so its subgroup is emitted. 
- Collision state resets per render pass rather than per object. 
- A logical name rendered as two boxes is no longer offered as a coverage-optimisation target, since collapsing to one edge would point at one box and silently drop the other members.

### Generated artifacts are unchanged

All six regenerate byte-identical on the current corpus, where no collision occurs — verified through the real entry point (`validate_riskmap.py --force --to-graph … --to-controls-graph … --to-risk-graph …`), not by inspection. The fix only changes behaviour where a collision exists.

### How it was tested

Thirteen tests, 1,097 lines. They assert **guarantees rather than mechanisms**, because three separate patches to name generation left the defect untouched before the real cause was found downstream of naming — a monotonic counter produced four distinct names and the emitted graph still repeated the first.

Four of the assertions exist specifically because a rename-on-collision satisfies the naive check while leaving the output wrong: such a fix emits two `style` lines for the original id and none for the renamed subgraph, and leaves every edge pointing at the first. It renders, and it passes CI. Style-line count, edge-target resolution and component presence are what distinguish it from a real fix.

Each guard was verified by reproducing the mutation it catches, and the two review rounds this went through each rejected a version that was green.


### What this does *not* fix

**#488** — `ComponentGraph`'s category container writes its id raw and unguarded, so a category and
subcategory sharing an id still collide. Different mechanism, latent today (the enums are disjoint),
and tracked separately. The clustering machinery here is what that fix will need.

### Scope

Infrastructure → `main` per ADR-002. No corpus, schema or generated-artifact changes.