### PR TITLE
feat(pre-commit): rev-pin update channel + alignment sentinel (#382)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,32 @@ updates:
           - "minor"
           - "patch"
 
+  # pre-commit - .pre-commit-config.yaml
+  # Bumps upstream hook `rev:` pins (check-jsonschema, ruff-pre-commit) so the
+  # dual-versioned tools stay aligned with their requirements.txt pins (#382).
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 5
+    assignees:
+      - "davidlabianca"
+      - "shrey-bagga"
+    labels: ["dependencies", "pre-commit", "security"]
+    commit-message:
+      prefix: "deps(pre-commit)"
+    groups:
+      major:
+        update-types:
+          - "major"
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
   # Node.js (npm) - package.json
   - package-ecosystem: "npm"
     directory: "/"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
   # the schema file itself against --schemafile and fail.
   # ---------------------------------------------------------------------------
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.4
+    rev: 0.38.0
     hooks:
       - id: check-jsonschema
         name: 'schema: actor-access.yaml'
@@ -136,7 +136,7 @@ repos:
   # time. Runs whenever any schema file is staged.
   # ---------------------------------------------------------------------------
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.4
+    rev: 0.38.0
     hooks:
       - id: check-metaschema
         name: 'schema: meta-validate .schema.json files'
@@ -190,7 +190,7 @@ repos:
   # Ruff lint + format for Python.
   # ---------------------------------------------------------------------------
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.0
+    rev: v0.16.3
     hooks:
       - id: ruff
         name: 'ruff: lint'

--- a/docs/adr/005-pre-commit-framework.md
+++ b/docs/adr/005-pre-commit-framework.md
@@ -92,7 +92,7 @@ Operational properties worth pinning:
 
 - Keep the `.pre-commit-config.yaml` inline comments current as hooks evolve — they encode non-obvious operational rationale (the `pass_filenames` notes, the `require_serial` notes) that is expensive to rediscover.
 - If a future hook refactor materially changes validation coverage, consider reintroducing a bounded parity check (new-vs-old, or framework-vs-golden-output) for the duration of that refactor, modeled on the #221 gate.
-- Revisit `pre-commit autoupdate` cadence. Pinned revisions in `.pre-commit-config.yaml` (`check-jsonschema` 0.37.1, `ruff-pre-commit` v0.15.10 at time of writing) are good hygiene but need periodic bumps; Dependabot does not currently track them.
+- Revisit `rev:` pin cadence. Pinned revisions in `.pre-commit-config.yaml` are good hygiene but need periodic bumps, and the repository had not configured the `pre-commit` ecosystem in `.github/dependabot.yml`. Resolved by the [2026-08-19 addendum](#addendum-2026-08-19-rev-pin-update-channel-and-alignment-sentinel-382), which configures Dependabot's native `pre-commit` ecosystem to open real `rev:`-bump PRs plus a PR-blocking alignment sentinel keyed off the `requirements.txt` pins for the two dual-versioned upstream hooks (`check-jsonschema`, `ruff-pre-commit`).
 - If the repository adds a non-Python orchestration surface in the future (for example, a site build under `risk-map/site/`), confirm that `pre-commit` remains the right orchestration layer for that surface or document the split explicitly.
 - Consider adding a CI job that validates every PR as a belt-and-braces over local hook execution. The choice of command is tactical: `pre-commit run --all-files` followed by `git diff --exit-code` catches both validator failures and any generator-driven drift; `./scripts/tools/validate-all.sh` is pure inspection and avoids generator invocation in CI. Contributors can skip hooks locally with `--no-verify`; a CI gate closes that escape hatch without forcing the parity harness back into the commit path.
 
@@ -172,3 +172,58 @@ The structural invariant needs no new machinery: the existing `_LOCAL_VALIDATOR_
 - `risk-map/schemas/frameworks.schema.json` via `DEFAULT_SCHEMA_PATH` / `load_pinned_patterns()` — the **schema oracle**. An edit to the strict pinned patterns or the ISO controlled-vocab enum there — the kind Work 2 itself made when activating the strict patterns, and future D10 version bumps — can likewise flip a pinned consumer value's verdict without ever touching a data file.
 
 Neither oracle is in the scanned-content set: editing one alone can flip verdicts. Both hooks originally triggered only on the four consumer YAMLs and ran `pass_filenames: true`, so an oracle-only commit either skipped them entirely or (had an oracle been in the trigger) handed the validator a non-content file as argv. Work 6 adds `frameworks.yaml` and then `frameworks.schema.json` to both triggers — via the path alternation `^risk-map/(yaml/(risks|controls|components|personas|frameworks)\.yaml|schemas/frameworks\.schema\.json)$`, mirroring the line-62 `check-jsonschema` "schema: frameworks.yaml" precedent — and flips both to `pass_filenames: false`, registering the union (four consumer YAMLs + `frameworks.yaml` + `frameworks.schema.json`) in the coverage table.
+
+## Addendum 2026-08-19: `rev:` pin update channel and alignment sentinel (#382)
+
+**Status:** Draft (maintainer to flip to Accepted)
+
+Authored 2026-08-19 alongside [#382](https://github.com/cosai-oasis/secure-ai-tooling/issues/382). Resolves the original Follow-up item on `rev:` pin cadence; it does not reset the ADR's status.
+
+### Context
+
+Two upstream hook repos in [`.pre-commit-config.yaml`](../../.pre-commit-config.yaml) are **dual-versioned**: their `rev:` pin names a version that also has an independent `==` pin in [`requirements.txt`](../../requirements.txt), because the same tool is both a framework-managed hook and a project Python dependency:
+
+- `check-jsonschema` — pinned as a `rev:` on the `python-jsonschema/check-jsonschema` repo (two hook blocks: `check-jsonschema`, `check-metaschema`) and as `check-jsonschema==<v>` in `requirements.txt`.
+- `ruff` — pinned as a `rev:` on `astral-sh/ruff-pre-commit` (hooks `ruff`, `ruff-format`) and as `ruff==<v>` in `requirements.txt` (the `ruff-pre-commit` tag is the `ruff` version with a leading `v`).
+
+[ADR-029](029-dual-python-package-management.md) owns the `requirements.txt` side of these tools: it makes `requirements.txt` the single dependency input consumed by both `pip` and `uv` and by CI. Dependabot tracks that file through the `pip` ecosystem, so the `==` pins advance on their own weekly cadence. The `rev:` pins did **not** advance with them — Dependabot gained native `pre-commit` support in 2026-03, but this repository had simply not configured that ecosystem in `.github/dependabot.yml`, so nothing tracked the `rev:` side. The two pins therefore drifted silently and recurrently: when #382 was filed the gap was `check-jsonschema` `rev: 0.37.1` against a `requirements.txt` pin of `0.37.4` (and `ruff-pre-commit` `v0.15.10` against `ruff==0.16.0`); that instance was realigned by hand, and the gap re-opened as soon as the next Dependabot `pip` bump advanced `requirements.txt` again — at the time this addendum's realignment lands, `check-jsonschema` sits at `rev: 0.37.4` against `0.38.0` and `ruff-pre-commit` at `v0.16.0` against `ruff==0.16.3`. That hand-realign-then-reopen recurrence is the evidence that the channel must be automated, not manual: nothing signalled the gap, and nothing blocked it from widening.
+
+The original ADR (line 78 of the Decision) names the upstream upgrade path for these hooks, and the hook-isolation boundary (line 79 Consequences) keeps these upstream tools in framework-managed isolated environments, separate from the project venv where the `requirements.txt` copy lives. That boundary is the reason the two pins can disagree at all — the isolated `check-jsonschema` a hook runs is a different install from the `check-jsonschema` a validator imports — and #382 asks for a channel that keeps the two in step without dissolving the boundary.
+
+### Decision
+
+We keep the two tools as isolated upstream `pre-commit` hooks (ADR-005's hook-isolation boundary, preserved), we configure **Dependabot's native `pre-commit` ecosystem** to keep the `rev:` pins moving on the same trusted mechanism as the repository's five existing ecosystems, and we keep the **PR-blocking alignment sentinel** as a backstop that makes the pip and pre-commit ecosystem PRs land together for these dual-versioned tools.
+
+#### D1. Keep the tools as isolated upstream hooks (Option A)
+
+`check-jsonschema` and `ruff` remain declared as upstream `repo:` entries with their own `rev:` pins, running in the framework's per-repo isolated environments per the original Decision. We do **not** collapse them to `language: system` local hooks that would resolve the tool from the project environment (and thus from `requirements.txt` directly, making the two pins one). That collapse — "Option B" in #382 — is rejected below.
+
+#### D2. Keep the PR-blocking alignment sentinel with a direction-aware tolerance policy
+
+A structural test guards alignment on every PR (authored in a downstream TDD phase; not written by this addendum). Its contract:
+
+- **Inputs.** It parses the `rev:` value on each dual-versioned upstream `repo:` block in `.pre-commit-config.yaml` (both `check-jsonschema` blocks must agree with each other; the `ruff-pre-commit` tag has its leading `v` stripped) and the corresponding `==` pin in `requirements.txt`. The comparison is `rev`-vs-`requirements.txt`, not a live network fetch — the test is hermetic and needs no upstream call.
+- **Tolerance policy — direction-aware.** The sentinel **FAILS when a `rev:` pin is *behind* its `requirements.txt` pin** and **tolerates a `rev:` pin that is *ahead of or equal to*.** It is not an exact-match check. The failure message must identify the offending hook repo and the two versions, and point the maintainer at the sibling Dependabot `pre-commit` ecosystem PR (or the grouped update) as the primary realign path, with `pre-commit autoupdate` as the manual fallback.
+- **Rationale.** *Policy:* a `rev:` pin behind its `requirements.txt` pin is the exact rot condition #382 exists to catch, so the sentinel reds it; a `rev:` pin ahead is tolerated. *Operational reason:* Dependabot opens the `pip` bump (`requirements.txt`) and the `pre-commit` `rev:` bump (`.pre-commit-config.yaml`) as separate ecosystem PRs that land at different times, so the sentinel must tolerate the transient window where the `pre-commit` PR leads a not-yet-merged `pip` bump. Verified ground truth: the `rev:` bump moves the pins **exactly** to the `requirements.txt` versions with no overshoot (`check-jsonschema` `0.37.4`→`0.38.0`, `ruff-pre-commit` `v0.16.0`→`v0.16.3`), and at the new revs all affected hooks pass with zero file changes.
+
+#### D3. Configure Dependabot's native `pre-commit` ecosystem
+
+We add a `package-ecosystem: "pre-commit"` block to [`.github/dependabot.yml`](../../.github/dependabot.yml) (added downstream, not by this addendum), mirroring the existing `pip` block: `directory: "/"`, weekly `schedule` on Sunday 09:00 `America/Los_Angeles`, the same `major` / `minor-and-patch` `groups`, the same `assignees`, `labels: ["dependencies", "pre-commit", "security"]`, and `commit-message.prefix: "deps(pre-commit)"`. Dependabot then parses `.pre-commit-config.yaml`, watches each hook repo (`python-jsonschema/check-jsonschema`, `astral-sh/ruff-pre-commit`) for new tags, and opens real PRs that bump the `rev:` field directly — with changelogs and SHA→tag resolution — the same trusted mechanism already governing the repository's five existing ecosystems (`pip`, `npm`, `github-actions`, `docker`, `devcontainers`).
+
+This replaces the custom notification-only workflow entirely. Instead of a scheduled job that opens an issue nagging a maintainer to run `pre-commit autoupdate` by hand, the native ecosystem opens the actual `rev:`-bump PR. No new workflow, no scheduled trigger, no `issues: write` grant, no stored token — the credential and supply-chain posture is exactly Dependabot's, already ratified across the five existing ecosystems and consistent with [ADR-024](024-github-actions-pinning-posture.md).
+
+### Alternatives Considered
+
+- **Option B — collapse `check-jsonschema` / `ruff` to `language: system` local hooks.** Rejected. It would resolve both tools from the project environment, making the `rev:` and `requirements.txt` pins a single pin and mooting the drift entirely — but at the cost of reversing ADR-005's hook-isolation boundary (line 79), which deliberately keeps upstream tools out of the project venv to eliminate version skew. It rewrites ~13 hook declarations, moots the sentinel, and moves the two highest-frequency hooks (`ruff`, `check-jsonschema`) onto the ADR-029 `language: system` env-resolution surface — the exact surface ADR-029 D4 had to add binding machinery to make safe under `uv`. The isolation boundary is a ratified property of this ADR; a drift-channel request is not sufficient cause to reverse it.
+- **Pre-native custom update mechanisms** — a **notification-only scheduled workflow** (open a tracking issue, no write token; the original draft's D3), the hosted **`pre-commit.ci`** autoupdate+autofix service, and a **stored-PAT / write-token auto-PR workflow**. These were the pre-native design space: each was a way to move the `rev:` pins when no Dependabot channel tracked pre-commit. Dependabot's native `pre-commit` ecosystem (D3) supersedes all of them — it opens the real `rev:`-bump PR on the already-ratified Dependabot mechanism, so it needs no custom workflow, no external app with standing write access, and no non-Dependabot write-scoped credential (the project has no agreed posture for one). Recorded here for provenance; not relitigated.
+- **Exact-match sentinel tolerance (fail on any `rev` ≠ `requirements.txt`).** Rejected — it would red the transient-ahead window when the `pre-commit` `rev:` PR lands before the sibling `pip` PR; see D2.
+
+### Grouped-PR coupling cost (blast radius)
+
+Because `dependabot.yml` groups `pip` minor-and-patch updates, a grouped `pip` PR that bumps these tools reds the sentinel until its sibling Dependabot `pre-commit` `rev:` PR merges — merge that sibling first (or fold the `rev:` bump in), then the group lands.
+
+### Enforcement and follow-up
+
+- The alignment sentinel (D2) extends [`scripts/hooks/tests/test_precommit_hook_install.py`](../../scripts/hooks/tests/test_precommit_hook_install.py) — the same structural suite the two prior addenda use — reusing its config/requirements load helpers and `TestRequirementsPinning` precedent. Written in a downstream TDD phase.
+- The `pre-commit` ecosystem block (D3) is added to `.github/dependabot.yml` downstream, mirroring the `pip` block per D3. There is **no** new workflow under `.github/workflows/` and no companion workflow test: the custom notification-only channel from the original draft is removed, superseded by the native ecosystem.
+- The verified 3-line `rev:` realignment (`.pre-commit-config.yaml` `check-jsonschema` `0.37.4`→`0.38.0` on both blocks, `ruff-pre-commit` `v0.16.0`→`v0.16.3`) turns the sentinel from red to green in the same PR and is applied downstream, not by this addendum.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 check-jsonschema==0.38.0
 jsonschema==4.26.0
+packaging==26.2
 pre-commit==4.6.2
 pytest==9.1.1
 pytest-cov==7.1.0

--- a/scripts/hooks/tests/test_dependabot_precommit_ecosystem.py
+++ b/scripts/hooks/tests/test_dependabot_precommit_ecosystem.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+Channel-guard test for the Dependabot `pre-commit` ecosystem entry.
+
+ADR-005 Addendum 2026-08-19 (D3, issue #382) replaces the custom
+notification-only rev-drift workflow with Dependabot's native `pre-commit`
+ecosystem support. This test locks in that the ecosystem entry exists in
+.github/dependabot.yml so it cannot be silently removed — it is the minimal
+structural guard that replaces the deleted workflow's role.
+"""
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+DEPENDABOT_PATH = REPO_ROOT / ".github" / "dependabot.yml"
+
+
+def _load_dependabot() -> dict:
+    """Return the parsed .github/dependabot.yml as a dict."""
+    return yaml.safe_load(DEPENDABOT_PATH.read_text(encoding="utf-8"))
+
+
+def _precommit_entry() -> dict:
+    """Return the pre-commit ecosystem update entry."""
+    updates = _load_dependabot()["updates"]
+    matches = [u for u in updates if u.get("package-ecosystem") == "pre-commit"]
+    assert len(matches) == 1, f"Expected exactly one pre-commit ecosystem entry; got {len(matches)}"
+    return matches[0]
+
+
+class TestDependabotPrecommitEcosystem:
+    """The pre-commit ecosystem channel must be declared and correctly scoped."""
+
+    def test_precommit_ecosystem_entry_exists(self):
+        """A `package-ecosystem: "pre-commit"` update entry is declared."""
+        entry = _precommit_entry()
+        assert entry["package-ecosystem"] == "pre-commit"

--- a/scripts/hooks/tests/test_precommit_hook_install.py
+++ b/scripts/hooks/tests/test_precommit_hook_install.py
@@ -21,7 +21,9 @@ scripts/hooks/tests/precommit_parity.sh.
 import re
 from pathlib import Path
 
+import pytest
 import yaml
+from packaging.version import Version
 
 # Repo root is four levels up from this file (scripts/hooks/tests/<here>).
 REPO_ROOT = Path(__file__).parent.parent.parent.parent
@@ -1437,3 +1439,208 @@ class TestMappingValidatorOracleTrigger:
                     f"`{hook_id}` files: regex {files_regex!r} must match consumer "
                     f"YAML `{yaml_path}` (default scanned-content set)."
                 )
+
+
+# ===========================================================================
+# rev: pin alignment sentinel (ADR-005 § Addendum 2026-08-19, issue #382)
+# ===========================================================================
+
+# Maps each dual-versioned upstream hook repo to its requirements.txt pip
+# package name. Keyed by repo URL so a third dual-versioned tool is a
+# one-line addition (YAGNI: only the two real tools are registered).
+_DUAL_VERSIONED_REPOS: dict[str, str] = {
+    "https://github.com/python-jsonschema/check-jsonschema": "check-jsonschema",
+    "https://github.com/astral-sh/ruff-pre-commit": "ruff",
+}
+
+
+def _repo_blocks_by_url(repo_url: str) -> list[dict]:
+    """Return every top-level `repo:` block in the config matching repo_url.
+
+    A single repo URL can appear more than once (check-jsonschema has two
+    blocks: the schema-pair hooks and the check-metaschema hook), so this
+    returns a list rather than assuming uniqueness.
+    """
+    config = _load_config()
+    return [repo for repo in config.get("repos", []) if repo.get("repo") == repo_url]
+
+
+def _requirements_pin(package: str) -> str:
+    """Return the `==` pinned version for `package` in requirements.txt.
+
+    Raises AssertionError (via a failed match) if the package isn't pinned —
+    callers should always find a pin, since both dual-versioned packages are
+    also direct project dependencies per ADR-005 Addendum 2026-08-19.
+    """
+    content = REQUIREMENTS_PATH.read_text(encoding="utf-8")
+    match = re.search(rf"^{re.escape(package)}==(\S+)$", content, re.MULTILINE)
+    assert match, f"`{package}` must be pinned with `==` in requirements.txt"
+    return match.group(1)
+
+
+def _rev_is_behind(rev: object, requirements_version: str, repo_url: str) -> bool:
+    """Return True if `rev` is a version older than `requirements_version`.
+
+    Pure comparison helper: no file I/O, so it is unit-testable against
+    synthetic strings. Uses packaging.version.Version for numeric-aware
+    ordering (e.g. 0.37.10 > 0.37.4, which plain string comparison gets
+    wrong: "0.37.10" < "0.37.4" lexicographically).
+
+    `rev` is coerced to `str` first because an unquoted YAML value like
+    `0.38` loads as a Python float, and Version() rejects non-str input
+    with a TypeError rather than a clean assertion failure. A non-PEP440
+    rev (git SHA, branch name) raises InvalidVersion naturally — that still
+    fails the test, which is the fail-safe behavior we want.
+    """
+    rev_version = Version(str(rev))
+    requirements_pin_version = Version(requirements_version)
+    return rev_version < requirements_pin_version
+
+
+def _collect_rev_pin_failures(dual_versioned_repos: dict[str, str]) -> list[str]:
+    """Return one human-readable failure string per repo whose rev: pin is behind.
+
+    Args:
+        dual_versioned_repos: mapping of repo URL -> requirements.txt pip
+            package name (see _DUAL_VERSIONED_REPOS for the real shape).
+
+    Returns an empty list when every dual-versioned repo block's rev is at
+    or ahead of its requirements.txt pin.
+    """
+    failures: list[str] = []
+    for repo_url, pip_package in dual_versioned_repos.items():
+        requirements_version = _requirements_pin(pip_package)
+        blocks = _repo_blocks_by_url(repo_url)
+        assert blocks, f"No `{repo_url}` repo block found in .pre-commit-config.yaml"
+
+        for block in blocks:
+            raw_rev = block.get("rev")
+            assert raw_rev, f"`{repo_url}` repo block missing `rev:`"
+
+            if _rev_is_behind(raw_rev, requirements_version, repo_url):
+                failures.append(
+                    f"`{repo_url}` rev: pin is behind requirements.txt "
+                    f"(`{raw_rev}` < `{pip_package}=={requirements_version}`); "
+                    f"Dependabot's pre-commit ecosystem PR supplies the matching "
+                    f"bump, or run `pre-commit autoupdate` to realign manually."
+                )
+
+    return failures
+
+
+class TestRevPinAlignment:
+    """
+    PR-blocking alignment sentinel for dual-versioned upstream hook pins
+    (ADR-005 § Addendum 2026-08-19, issue #382).
+
+    check-jsonschema and ruff are each pinned twice: once as a `rev:` on an
+    upstream pre-commit repo block, and once as an `==` pin in requirements.txt.
+    The two pins are advanced by independent, asynchronous streams — separate
+    Dependabot ecosystem PRs (`pip` vs. `pre-commit`) landing at different
+    times — so this sentinel uses a direction-aware tolerance: it FAILS when a
+    `rev:` pin is *behind* its requirements.txt pin, and tolerates a `rev:`
+    pin that is *ahead* or equal. See the addendum's D2 for the transient-ahead
+    window rationale behind choosing direction-aware over exact-match.
+
+    This test is hermetic: it only parses the two tracked files, no network
+    call.
+    """
+
+    def test_check_jsonschema_both_blocks_agree_with_each_other(self):
+        """
+        Given: .pre-commit-config.yaml, which declares check-jsonschema twice
+               (the per-yaml schema-pair block and the check-metaschema block)
+        When:  comparing the `rev:` value on each block
+        Then:  both blocks have a non-empty `rev:` and the two revs are identical
+        """
+        repo_url = "https://github.com/python-jsonschema/check-jsonschema"
+        blocks = _repo_blocks_by_url(repo_url)
+        assert len(blocks) == 2, (
+            f"Expected exactly two `{repo_url}` repo blocks (schema-pair hooks + "
+            f"check-metaschema); found {len(blocks)}. Update this test if the "
+            f"config's block count intentionally changed."
+        )
+        revs = [block.get("rev") for block in blocks]
+        for i, rev in enumerate(revs):
+            assert rev, (
+                f"`{repo_url}` repo block {i} is missing a non-empty `rev:` key "
+                f"(got {rev!r}). Every dual-versioned repo block must pin a rev "
+                f"before it can be compared for agreement."
+            )
+        assert len(set(revs)) == 1, (
+            f"The two check-jsonschema repo blocks in .pre-commit-config.yaml must pin "
+            f"the same rev; found disagreeing revs {sorted(map(str, revs))!r}. Run "
+            f"`pre-commit autoupdate` and ensure both blocks land on the same version."
+        )
+
+    def test_rev_pins_are_not_behind_requirements_txt(self):
+        """
+        Given: .pre-commit-config.yaml rev: pins and requirements.txt == pins
+               for check-jsonschema and ruff
+        When:  comparing each rev against its requirements.txt version via
+               _collect_rev_pin_failures (numeric version comparison, so e.g.
+               0.37.10 > 0.37.4 compares correctly)
+        Then:  the rev is >= the requirements.txt pin for every dual-versioned
+               repo block (the helper returns no failures)
+
+        Direction-aware tolerance (ADR-005 § Addendum 2026-08-19 D2): a rev
+        that is *ahead* of requirements.txt is tolerated (only stale, not
+        wrong); a rev that is *behind* fails, naming the Dependabot pre-commit
+        channel and `pre-commit autoupdate` as the fix. The comparison
+        contract itself (behind/ahead/equal, numeric ordering) is pinned
+        against synthetic inputs in TestRevIsBehindHelper below.
+        """
+        failures = _collect_rev_pin_failures(_DUAL_VERSIONED_REPOS)
+        assert not failures, "rev: pin(s) behind requirements.txt:\n" + "\n".join(f"  - {f}" for f in failures)
+
+
+# ===========================================================================
+# Synthetic unit tests for the rev-vs-requirements comparison contract
+# (adversarial-review hardening, issue #382)
+# ===========================================================================
+#
+# The tests above exercise _rev_is_behind only against live repo state, which
+# means a mutation to the comparison operator (e.g. `<` -> `>` or `!=`) or a
+# deletion of the failure-append would still leave the suite green as long as
+# the live drift happens to match. These tests pin the contract against
+# synthetic version strings so the core comparison logic is unit-tested
+# independent of whatever .pre-commit-config.yaml / requirements.txt currently
+# contain.
+
+
+class TestRevIsBehindHelper:
+    """
+    Direct unit tests for the pure `_rev_is_behind` helper.
+
+    Covers the three-way direction contract (behind/ahead/equal) plus a
+    numeric-ordering case that plain string comparison would get wrong.
+    """
+
+    @pytest.mark.parametrize(
+        "rev, requirements_version, expected_behind",
+        [
+            # Behind: rev is strictly older than requirements.txt -> violation.
+            ("0.37.1", "0.37.4", True),
+            # Ahead: rev is newer than requirements.txt -> tolerated.
+            ("0.38.0", "0.37.4", False),
+            # Equal: rev matches requirements.txt exactly -> tolerated.
+            ("0.16.0", "0.16.0", False),
+            # Numeric ordering, ahead: "0.37.10" < "0.37.4" as strings, but
+            # 0.37.10 > 0.37.4 as versions -> must be tolerated, not flagged.
+            ("0.37.10", "0.37.4", False),
+            # Numeric ordering, behind: "0.9.0" > "0.10.0" as strings, but
+            # 0.9.0 < 0.10.0 as versions -> must be flagged as a violation.
+            ("0.9.0", "0.10.0", True),
+        ],
+    )
+    def test_behind_ahead_equal_contract(self, rev, requirements_version, expected_behind):
+        """
+        Given: a synthetic rev and requirements.txt version pair
+        When:  _rev_is_behind is called directly (no file I/O)
+        Then:  it returns True only when rev is strictly behind, honoring
+               numeric (not lexicographic) version ordering
+        """
+        result = _rev_is_behind(rev, requirements_version, repo_url="https://example.invalid/repo")
+        assert result is expected_behind, (
+            f"_rev_is_behind({rev!r}, {requirements_version!r}) returned {result!r}, expected {expected_behind!r}"
+        )


### PR DESCRIPTION

## Summary

Closes the structural gap in #382: `.pre-commit-config.yaml` `rev:` pins for the dual-versioned tools
(`check-jsonschema`, `ruff`) have no update channel and drift behind their Dependabot-tracked
`requirements.txt` `==`-pins. This adopts the platform-native fix now that **Dependabot supports the
`pre-commit` ecosystem** ([since 2026-03-10](https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/)).

> This drift is live on `main` right now: a manual realignment (#482) was re-opened days later when #487
> bumped the `pip` side — so this branch both **fixes the current drift** and installs the guardrail that
> prevents the next one.

Three parts:

1. **Dependabot `pre-commit` ecosystem (the channel).** Adds a `package-ecosystem: "pre-commit"` block to
   `.github/dependabot.yml`, mirroring the `pip` block's weekly-Sunday cadence, grouping, labels, and
   `deps(pre-commit)` prefix. Dependabot now opens real `rev:`-bump PRs (with changelogs, SHA→tag
   resolution) on the same trusted mechanism as the repo's five existing ecosystems — no custom workflow,
   no stored token.
2. **Alignment sentinel + rev realignment.** A hermetic, direction-aware `TestRevPinAlignment` that fails
   when a `rev:` pin is *behind* its `requirements.txt` pin (tolerating ahead-or-equal, so a Dependabot
   `pre-commit` rev-bump PR that briefly leads a not-yet-merged `pip` bump isn't blocked), plus the
   realignment that turns it green: `check-jsonschema` `0.37.4`→`0.38.0` (both blocks), `ruff-pre-commit`
   `v0.16.0`→`v0.16.3`. `packaging` is pinned directly (the sentinel imports it).
3. **ADR-005 addendum (2026-08-19).** Ratifies keeping the hooks isolated, the native ecosystem as the
   channel, and the sentinel as a PR-blocking backstop. `Status: Draft` for maintainer acceptance.

## Acceptance criteria (#382)

- [x] **AC1** — ADR-005 amended with a `rev:`-pin maintenance posture, cross-referencing ADR-024/029.
      *(Draft; maintainer flips to Accepted.)*
- [x] **AC2** — an automated update channel exists for the `rev:` pins (Dependabot's native `pre-commit`
      ecosystem).
- [x] **AC3** — `rev:` pins realigned with `requirements.txt`.
- [x] **AC4** — drift sentinel added under `scripts/hooks/tests/`.

## Verification

- Rebased onto current `main`; full test suite **3644 passed, 6 skipped**.
- Realigned hooks at their new pins (`ruff`/`ruff-format` v0.16.3, `check-jsonschema` ×10 /
  `check-metaschema` 0.38.0) pass with zero file changes.
- `.github/dependabot.yml` parses; the `pre-commit` block is valid and mirrors its siblings.
- 6 files, ~334 insertions. Sentinel + channel guard hardened through adversarial review, then trimmed to
  the minimum that keeps it honest (no gold-plating).

## Maintainer notes

- The ADR lands `Status: Draft` — please flip to `Accepted` if the posture is agreed.
- **Grouped-PR coupling cost (by design):** `.github/dependabot.yml` groups `pip` minor-and-patch updates,
  so a grouped `pip` PR that bumps `check-jsonschema`/`ruff` reds the sentinel until its **sibling
  Dependabot `pre-commit` `rev:` PR** merges — merge that sibling first (or fold the `rev:` bump in), then
  the group lands. This intended lockstep keeps the two channels aligned; the fix is a sibling
  auto-generated PR, not manual work.
- The custom notification-workflow design from an earlier draft of this branch was dropped once Dependabot's
  native `pre-commit` support was confirmed — it reinvented a platform feature.


