### PR TITLE
ADR-033 D8: neutrality scanning + eval pairing enforcement for scripts/agents-evals/

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -28,6 +28,7 @@ on:
       # its_governed_hooks_scan in scripts/hooks/tests/test_ci_block_parity.py.
       - 'scripts/agents/*.md'
       - 'scripts/skills/**'
+      - 'scripts/agents-evals/**'
       - 'scripts/build_persona_site_data.py'
       - 'scripts/hooks/_sentinel_expansion.py'
       - 'scripts/hooks/precommit/_linter_types.py'
@@ -62,6 +63,7 @@ on:
       # its_governed_hooks_scan in scripts/hooks/tests/test_ci_block_parity.py.
       - 'scripts/agents/*.md'
       - 'scripts/skills/**'
+      - 'scripts/agents-evals/**'
       - 'scripts/build_persona_site_data.py'
       - 'scripts/hooks/_sentinel_expansion.py'
       - 'scripts/hooks/precommit/_linter_types.py'

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -21,6 +21,7 @@ on:
       - 'scripts/hooks/precommit/validate_all_schemas.py'
       - 'scripts/hooks/precommit/validate_persona_site_build.py'
       - 'scripts/hooks/precommit/validate_neutrality.py'
+      - 'scripts/hooks/precommit/validate_eval_pairing.py'
       - 'scripts/tools/hook_file_list.py'
       # ADR-037 D1: content the governed hooks above scan, and modules their
       # validators import locally — not the validators themselves, which are
@@ -56,6 +57,7 @@ on:
       - 'scripts/hooks/precommit/validate_all_schemas.py'
       - 'scripts/hooks/precommit/validate_persona_site_build.py'
       - 'scripts/hooks/precommit/validate_neutrality.py'
+      - 'scripts/hooks/precommit/validate_eval_pairing.py'
       - 'scripts/tools/hook_file_list.py'
       # ADR-037 D1: content the governed hooks above scan, and modules their
       # validators import locally — not the validators themselves, which are
@@ -694,6 +696,40 @@ jobs:
           exit 1
         fi
 
+  eval-pairing-validation:
+    runs-on: ubuntu-latest
+    name: Eval Pairing Validation
+    needs: setup
+    outputs:
+      eval_pairing_status: ${{ steps.validate-eval-pairing.outputs.status }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      with:
+        python-version: '3.14'
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: pip install -r requirements.txt
+
+    - name: Run Eval Pairing Validation
+      id: validate-eval-pairing
+      run: |
+        echo "🔍 Running agent/skill eval pairing validation..."
+
+        if python3 scripts/hooks/precommit/validate_eval_pairing.py; then
+          echo "✅ Agent/skill eval pairing validation completed successfully"
+          echo "status=success" >> $GITHUB_OUTPUT
+        else
+          echo "❌ Agent/skill eval pairing validation failed"
+          echo "::error::Agent/skill eval pairing validation failed (ADR-033 D6/D8, ADR-031 D6)"
+          echo "status=failed" >> $GITHUB_OUTPUT
+          exit 1
+        fi
+
   graph-validation:
     runs-on: ubuntu-latest
     name: Graph Validation
@@ -786,7 +822,7 @@ jobs:
   validation-summary:
     runs-on: ubuntu-latest
     name: Validation Summary
-    needs: [schema-validation, format-validation, component-edge-validation, control-risk-validation, framework-validation, identification-questions-validation, prose-subset-validation, prose-references-validation, mapping-purity-validation, mapping-drift-validation, versionid-purity-validation, persona-site-build-validation, neutrality-validation, neutrality-policy-validation, graph-validation]
+    needs: [schema-validation, format-validation, component-edge-validation, control-risk-validation, framework-validation, identification-questions-validation, prose-subset-validation, prose-references-validation, mapping-purity-validation, mapping-drift-validation, versionid-purity-validation, persona-site-build-validation, neutrality-validation, neutrality-policy-validation, eval-pairing-validation, graph-validation]
     if: always()
     steps:
     - name: Generate Summary
@@ -809,6 +845,7 @@ jobs:
         persona_site_build_result="${{ needs.persona-site-build-validation.result }}"
         neutrality_result="${{ needs.neutrality-validation.result }}"
         neutrality_policy_result="${{ needs.neutrality-policy-validation.result }}"
+        eval_pairing_result="${{ needs.eval-pairing-validation.result }}"
         graph_result="${{ needs.graph-validation.result }}"
 
         # Get output details
@@ -915,6 +952,13 @@ jobs:
           echo "- ✅ **Agent/skill neutrality policy re-scan**: Passed" >> $GITHUB_STEP_SUMMARY
         else
           echo "- ❌ **Agent/skill neutrality policy re-scan**: $neutrality_policy_result" >> $GITHUB_STEP_SUMMARY
+          overall_success=false
+        fi
+
+        if [ "$eval_pairing_result" = "success" ]; then
+          echo "- ✅ **Agent/skill eval pairing validation**: Passed" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "- ❌ **Agent/skill eval pairing validation**: $eval_pairing_result" >> $GITHUB_STEP_SUMMARY
           overall_success=false
         fi
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -248,20 +248,21 @@ repos:
         pass_filenames: true
 
   # ---------------------------------------------------------------------------
-  # ADR-033 D2a/D5 vendor-neutrality check. Scoped to the two neutral-surface
-  # trees that ship in this repository — scripts/agents/** and
-  # scripts/skills/** — not the whole repo; scripts/skills/ does not exist yet,
-  # but the `files:` pattern activates automatically once it does. Flags
-  # harness-specific vendor/product/model names, invocation stage directions,
-  # and config paths in those two trees only.
+  # ADR-033 D2a/D5/D8 vendor-neutrality check. Scoped to the three neutral-surface
+  # trees that ship in this repository — scripts/agents/**, scripts/skills/**,
+  # and scripts/agents-evals/** — not the whole repo; scripts/skills/ and
+  # scripts/agents-evals/ do not exist yet, but the `files:` pattern activates
+  # automatically once either does. Flags harness-specific vendor/product/model
+  # names, invocation stage directions, and config paths in those three trees
+  # only.
   # ---------------------------------------------------------------------------
   - repo: local
     hooks:
       - id: validate-neutrality
-        name: 'validate: vendor-neutrality of agent/skill surfaces (ADR-033)'
+        name: 'validate: vendor-neutrality of agent/skill/evals surfaces (ADR-033)'
         language: system
         entry: python3 scripts/hooks/precommit/validate_neutrality.py
-        files: ^scripts/(agents|skills)/
+        files: ^scripts/(agents|skills|agents-evals)/
         pass_filenames: true
       # Re-scans the whole agent/skill corpus when the denylist/allowlist
       # policy data or the validator logic itself changes, since neither is

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -282,6 +282,23 @@ repos:
         pass_filenames: false
 
   # ---------------------------------------------------------------------------
+  # ADR-033 D6/D8 and ADR-031 D6 eval pairing check: every shipped agent
+  # (scripts/agents/<name>.md, unless grandfathered) and every shipped skill
+  # (scripts/skills/<name>/) must have a matching eval on disk. This is a
+  # corpus-completeness check, not a per-file scanner, so pass_filenames is
+  # false and the validator always self-discovers from the repo root via
+  # find_pairing_violations regardless of which files triggered it.
+  # ---------------------------------------------------------------------------
+  - repo: local
+    hooks:
+      - id: validate-eval-pairing
+        name: 'validate: agent/skill eval pairing (ADR-033 D6/D8, ADR-031 D6)'
+        language: system
+        entry: python3 scripts/hooks/precommit/validate_eval_pairing.py
+        files: ^scripts/(agents|agents-evals|skills)/
+        pass_filenames: false
+
+  # ---------------------------------------------------------------------------
   # Prose authoring linters. Both consume the shared _prose_tokens.py tokenizer
   # and block on violations.
   # validate-yaml-prose-subset enforces ADR-017 D4 grammar rejections;

--- a/docs/adr/037-ci-validation-authority-and-block-parity.md
+++ b/docs/adr/037-ci-validation-authority-and-block-parity.md
@@ -42,7 +42,7 @@ The rule quantifies over pre-commit's **blocking** hooks, not over a fixed list 
 
 This settles the developer question directly. Contributors who have not installed hooks are fully covered, because nothing depends on their having done so. Hooks are an accelerator that moves a failure from minutes-after-push to seconds-before-commit; they are not load-bearing for correctness. "The hook may not be installed" stops being a caveat and becomes a statement about latency.
 
-The twelve hooks the rule resolves to, and what it requires of each. The table lists the rule's *instances*, not the rule; it is expected to grow without this ADR changing. It is a dated record of what the change consisted of, not the register the rule quantifies over — see [D9c](#d9c-d1s-instance-table-is-a-dated-record-not-the-register) in the 2026-08-04 addendum, which is where the register is defined.
+The thirteen hooks the rule resolves to, and what it requires of each. The table lists the rule's *instances*, not the rule; it is expected to grow without this ADR changing. It is a dated record of what the change consisted of, not the register the rule quantifies over — see [D9c](#d9c-d1s-instance-table-is-a-dated-record-not-the-register) in the 2026-08-04 addendum, which is where the register is defined.
 
 | pre-commit hook id | Validator | CI state before this decision | Required by D1 | Instance |
 |---|---|---|---|---|
@@ -58,6 +58,7 @@ The twelve hooks the rule resolves to, and what it requires of each. The table l
 | `validate-neutrality` | `scripts/hooks/precommit/validate_neutrality.py` | not invoked | add the invocation | D8 |
 | `validate-neutrality-policy` | `scripts/hooks/precommit/validate_neutrality.py` | not invoked | add the invocation | D8 |
 | `validate-prose-references` | `scripts/hooks/precommit/validate_prose_references.py` | not invoked | add the invocation | D7 |
+| `validate-eval-pairing` | `scripts/hooks/precommit/validate_eval_pairing.py` | not invoked | add the invocation | D8 |
 
 D3 carves the one exception, and it is an exception at the level of a specific *invocation* rather than of a validator: the validator D2 governs is also called for graph emission, and that call site does not take the flag.
 

--- a/scripts/hooks/precommit/validate_eval_pairing.py
+++ b/scripts/hooks/precommit/validate_eval_pairing.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+Pre-commit lint: enforce ADR-033 D6/D8 and ADR-031 D6 eval pairing for shipped
+authoring surfaces.
+
+Every shipped agent and skill must carry a portable eval alongside it:
+  - `scripts/agents/<name>.md`      -> `scripts/agents-evals/<name>/evals.json`
+  - `scripts/skills/<name>/`        -> `scripts/skills/<name>/evals/evals.json`
+
+This is a corpus-completeness check, not a per-file scanner: it always
+self-discovers both authoring surfaces from the current working directory and
+reports every unpaired entry in one pass, rather than taking file arguments or
+stopping at the first violation. Discovery walk mirrors
+`discover_neutral_surface_files` in validate_neutrality.py; the
+missing/stale-exemption comparison mirrors `compare_control_maps` in
+validate_control_risk_references.py (collect every mismatch, never fail
+fast).
+
+Six agents shipped before this eval requirement existed and are grandfathered
+via `EXEMPT_AGENT_NAMES`. Skills have no equivalent exemption: every skill on
+`main` already ships an eval, so the requirement is unconditional for that
+surface. An exempted agent that unexpectedly already has an eval on disk is
+flagged as a distinct "stale exemption" finding (remedy: drop the exemption,
+not add another eval) so a maintainer never has to read this module's source
+to know which of the two problems applies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+HOOK_NAME = "validate-eval-pairing"
+
+# The 6 agents grandfathered in before the eval requirement existed. Each
+# entry is independently load-bearing (a fixed enumeration, not a pattern) and
+# is expected to shrink over time as agents backfill evals and drop off this
+# set — never grow it as a way to avoid shipping an eval for a new agent.
+#
+# Retrofit tracking: gh-drafts/backlog/draft-agent-eval-retrofit-6-landed-agents-issue.md
+# (unfiled draft; no issue number yet, hence "TBD" below rather than a fabricated one).
+EXEMPT_AGENT_NAMES: frozenset[str] = frozenset(
+    {
+        "architect",  # tracked: backlog issue TBD
+        "code-reviewer",  # tracked: backlog issue TBD
+        "content-reviewer",  # tracked: backlog issue TBD
+        "issue-response-reviewer",  # tracked: backlog issue TBD
+        "swe",  # tracked: backlog issue TBD
+        "testing",  # tracked: backlog issue TBD
+    }
+)
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A single eval-pairing violation (missing eval or stale exemption)."""
+
+    surface: str  # "agent" | "skill"
+    name: str
+    path: Path  # the (missing or unexpectedly-present) eval path this finding is anchored to
+    message: str
+
+
+def discover_shipped_agents(root: Path) -> list[str]:
+    """
+    Return stem names of top-level `scripts/agents/<name>.md` files under `root`.
+
+    Only direct children of `scripts/agents/` are considered (`glob`, not
+    `rglob`) — a nested file such as `scripts/agents/<name>/notes.md` is
+    bundled material for that agent, not a second agent definition, so
+    discovery must not recurse into it.
+
+    Tolerates an absent `scripts/agents/` tree (returns []).
+    """
+    agents_dir = root / "scripts" / "agents"
+    if not agents_dir.is_dir():
+        return []
+    return sorted(path.stem for path in agents_dir.glob("*.md"))
+
+
+def discover_shipped_skills(root: Path) -> list[str]:
+    """
+    Return names of `scripts/skills/<name>/` directories under `root` that contain a `SKILL.md`.
+
+    Presence of `SKILL.md` is the sole discriminator — a stray non-skill file
+    directly under `scripts/skills/` (e.g. the real corpus's `README.md`) is
+    not a directory and has no `SKILL.md`, so it is naturally excluded without
+    an explicit denylist.
+
+    Tolerates an absent `scripts/skills/` tree (returns []).
+    """
+    skills_dir = root / "scripts" / "skills"
+    if not skills_dir.is_dir():
+        return []
+    return sorted(path.name for path in skills_dir.iterdir() if path.is_dir() and (path / "SKILL.md").is_file())
+
+
+def find_pairing_violations(root: Path) -> list[Violation]:
+    """
+    Check every shipped agent and skill under `root` for a matching eval sibling.
+
+    Collects every violation in one pass (never fails fast), mirroring
+    `compare_control_maps` in validate_control_risk_references.py. Either
+    authoring surface, or the `scripts/agents-evals/` tree itself, may be
+    absent without error.
+
+    Args:
+        root: Directory to scan (contains a `scripts/` subtree, or does not).
+
+    Returns:
+        List of violations, empty if every shipped agent/skill is paired (or
+        grandfathered, for agents).
+    """
+    violations: list[Violation] = []
+
+    for agent_name in discover_shipped_agents(root):
+        eval_path = root / "scripts" / "agents-evals" / agent_name / "evals.json"
+        # Repo-relative rendering for the message text (not the absolute
+        # `eval_path`): the absolute form embeds `root`, which under a pytest
+        # tmp_path fixture can itself contain incidental substrings (e.g. a
+        # test name), so a message built from the absolute path is not safe
+        # against accidental lexical overlap between the two failure classes.
+        relative_hint = f"scripts/agents-evals/{agent_name}/evals.json"
+        has_eval = eval_path.is_file()
+        is_exempt = agent_name in EXEMPT_AGENT_NAMES
+
+        if is_exempt and has_eval:
+            # Stale exemption: the grandfathering no longer reflects reality.
+            # Remedy is to drop the name from EXEMPT_AGENT_NAMES, not add
+            # another eval file (one already exists).
+            violations.append(
+                Violation(
+                    surface="agent",
+                    name=agent_name,
+                    path=eval_path,
+                    message=(
+                        f"agent {agent_name!r} carries a stale exemption: it is still listed in "
+                        f"EXEMPT_AGENT_NAMES, but an eval already exists at {relative_hint}. Drop "
+                        f"{agent_name!r} from EXEMPT_AGENT_NAMES."
+                    ),
+                )
+            )
+        elif not is_exempt and not has_eval:
+            # Missing eval: a non-exempt agent must ship one.
+            violations.append(
+                Violation(
+                    surface="agent",
+                    name=agent_name,
+                    path=eval_path,
+                    message=(
+                        f"agent {agent_name!r} is missing its required eval. Add {relative_hint} (or "
+                        f"add {agent_name!r} to EXEMPT_AGENT_NAMES if this is a known gap)."
+                    ),
+                )
+            )
+        # is_exempt and not has_eval: grandfathered, no violation.
+        # not is_exempt and has_eval: fully paired, no violation.
+
+    for skill_name in discover_shipped_skills(root):
+        eval_path = root / "scripts" / "skills" / skill_name / "evals" / "evals.json"
+        relative_hint = f"scripts/skills/{skill_name}/evals/evals.json"
+        if not eval_path.is_file():
+            # Skills have no exemption set: unconditional requirement.
+            violations.append(
+                Violation(
+                    surface="skill",
+                    name=skill_name,
+                    path=eval_path,
+                    message=f"skill {skill_name!r} is missing its required eval. Add {relative_hint}.",
+                )
+            )
+
+    return violations
+
+
+def format_violation(violation: Violation) -> str:
+    """Format one violation for stderr, prefixed with HOOK_NAME."""
+    return f"{HOOK_NAME}: {violation.surface} {violation.name!r}: {violation.message}"
+
+
+def main(argv: list[str]) -> int:
+    """
+    CLI entry point for pre-commit and manual validation.
+
+    This validator is a corpus-completeness check, not a per-file scanner: it
+    always self-discovers both authoring surfaces from the current working
+    directory. `argv` is accepted only for shape-consistency with the other
+    precommit validators' `main(argv) -> int` signature. No options are
+    defined, so an empty `argv` is a no-op; an unrecognized flag still raises
+    via argparse's own `SystemExit(2)`, since this validator never receives
+    one in its actual (`pass_filenames: false`) invocation.
+
+    Returns:
+        1 if any violations are found, else 0.
+    """
+    parser = argparse.ArgumentParser(description="Validate ADR-033/ADR-031 agent/skill eval pairing.")
+    parser.parse_args(argv)
+
+    violations = find_pairing_violations(Path.cwd())
+
+    for violation in violations:
+        print(format_violation(violation), file=sys.stderr)
+
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/hooks/precommit/validate_neutrality.py
+++ b/scripts/hooks/precommit/validate_neutrality.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """
-Pre-commit lint: enforce ADR-033 D2a/D5 vendor-neutrality for shipped surfaces.
+Pre-commit lint: enforce ADR-033 D2a/D5/D8 vendor-neutrality for shipped surfaces.
 
-`scripts/agents/**` and `scripts/skills/**` are the two authoring surfaces
-that ship in this repository. Prose in those trees must not name a specific
+`scripts/agents/**`, `scripts/skills/**`, and `scripts/agents-evals/**` are
+the three authoring surfaces that ship in this repository. Prose in those
+trees must not name a specific
 AI harness product, company, CLI entry point, or model identifier; must not
 embed harness-invocation stage directions (`<invoke ... tool>`,
 `subagent_type`, "auto-loads"/"auto-triggers"); and must not reference
@@ -439,9 +440,10 @@ def validate_file(path: Path) -> list[Violation]:
 
 def discover_neutral_surface_files(root: Path) -> list[Path]:
     """
-    Return files under `root/scripts/agents/**` and `root/scripts/skills/**`.
+    Return files under `root/scripts/agents/**`, `root/scripts/skills/**`, and
+    `root/scripts/agents-evals/**`.
 
-    Deliberately targets only these two subtrees directly rather than walking
+    Deliberately targets only these three subtrees directly rather than walking
     a common `scripts/` ancestor and filtering — that would risk reaching
     `scripts/hooks/`, this checker's own home and the one place denylist
     tokens legitimately appear as detection data.
@@ -464,11 +466,12 @@ def discover_neutral_surface_files(root: Path) -> list[Path]:
     feeding a directory to `validate_file` would not make sense.
 
     Returns:
-        Discovered files, agents subtree first, skills subtree second, each
-        subtree sorted. Either subtree may be empty (or absent) without error.
+        Discovered files in subtree-append order: agents, skills, then
+        agents-evals, each subtree sorted internally. Any subtree may be
+        empty (or absent) without error.
     """
     discovered: list[Path] = []
-    for subdir in ("scripts/agents", "scripts/skills"):
+    for subdir in ("scripts/agents", "scripts/skills", "scripts/agents-evals"):
         base = root / subdir
         if not base.is_dir():
             continue

--- a/scripts/hooks/tests/test_ci_block_parity.py
+++ b/scripts/hooks/tests/test_ci_block_parity.py
@@ -6833,6 +6833,33 @@ def _write_neutrality_self_scan_corpus(base: Path, poisoned: bool) -> None:
     target.write_text(text, encoding="utf-8")
 
 
+# Relative path a self-scanning validate-eval-pairing corpus writes its probe
+# agent at. Not a real shipped agent name — a synthetic one, so this probe
+# cannot collide with a real EXEMPT_AGENT_NAMES entry and always exercises the
+# "missing eval" finding class rather than the grandfathered-pass path.
+_EVAL_PAIRING_PROBE_AGENT_NAME = "eval-pairing-probe"
+_EVAL_PAIRING_PROBE_REL_PATH = f"scripts/agents/{_EVAL_PAIRING_PROBE_AGENT_NAME}.md"
+
+
+def _write_eval_pairing_corpus(base: Path, poisoned: bool) -> None:
+    """Corpus for validate_eval_pairing.py's self-scanning hook (validate-eval-pairing).
+
+    Writes one shipped agent under scripts/agents/ so discover_shipped_agents
+    finds it from the mirror's working directory. The clean case also writes
+    the paired eval at scripts/agents-evals/<name>/evals.json; the poisoned
+    case omits it, reproducing the "missing eval" finding — this probe's name
+    is not in EXEMPT_AGENT_NAMES, so the omission is a real violation rather
+    than a grandfathered pass.
+    """
+    target = base / _EVAL_PAIRING_PROBE_REL_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("# Eval Pairing Probe Agent\n\nBody.\n", encoding="utf-8")
+    if not poisoned:
+        eval_path = base / "scripts" / "agents-evals" / _EVAL_PAIRING_PROBE_AGENT_NAME / "evals.json"
+        eval_path.parent.mkdir(parents=True, exist_ok=True)
+        eval_path.write_text('{"cases": []}\n', encoding="utf-8")
+
+
 class UnflaggedProbe(NamedTuple):
     """A flagless blocking validator plus the means to make it fail.
 
@@ -6881,6 +6908,11 @@ UNFLAGGED_PROBES: dict[str, UnflaggedProbe] = {
         write_corpus=_write_neutrality_self_scan_corpus,
         marker=_NEUTRALITY_POISON_TERM,
         rule="ADR-033 vendor/product denylist term under scripts/agents|skills/**",
+    ),
+    "validate_eval_pairing.py": UnflaggedProbe(
+        write_corpus=_write_eval_pairing_corpus,
+        marker=_EVAL_PAIRING_PROBE_AGENT_NAME,
+        rule="agent shipped with no matching eval (ADR-033 D6/D8, ADR-031 D6)",
     ),
 }
 

--- a/scripts/hooks/tests/test_precommit_hook_install.py
+++ b/scripts/hooks/tests/test_precommit_hook_install.py
@@ -727,6 +727,14 @@ _LOCAL_VALIDATOR_TRIGGER_COVERAGE: dict[str, set[str] | None] = {
     # Exempt per ADR-005 § Addendum 2026-05-08: Hook trigger-vs-read-set
     # invariant.
     "validate-neutrality-policy": None,
+    # validate-eval-pairing: SENTINEL — corpus-completeness hook for ADR-033
+    # D6/D8 / ADR-031 D6 eval pairing. With no file args, main([]) self-
+    # discovers via find_pairing_violations(cwd), which walks scripts/agents/**,
+    # scripts/agents-evals/** and scripts/skills/** at runtime; the read set is
+    # whatever agents/skills currently exist in those trees, not a fixed list.
+    # Exempt per ADR-005 § Addendum 2026-05-08: Hook trigger-vs-read-set
+    # invariant.
+    "validate-eval-pairing": None,
     # validate-frameworks-versionid-purity: reads only frameworks.yaml at the
     # canonical path. Trigger is anchored on the same path.
     "validate-frameworks-versionid-purity": {

--- a/scripts/hooks/tests/test_validate_eval_pairing.py
+++ b/scripts/hooks/tests/test_validate_eval_pairing.py
@@ -1,0 +1,677 @@
+#!/usr/bin/env python3
+"""
+Tests for scripts/hooks/precommit/validate_eval_pairing.py.
+
+ADR-033 D6/D8 and ADR-031 D6 require every shipped authoring surface to carry
+a portable eval alongside it:
+  - `scripts/agents/<name>.md`      -> `scripts/agents-evals/<name>/evals.json`
+  - `scripts/skills/<name>/`        -> `scripts/skills/<name>/evals/evals.json`
+
+Nothing currently enforces this pairing (no hook, no CI check). PR #434
+shipped an agent with no eval, caught only by a human reviewer. This module
+is the corpus-completeness validator that closes that gap: given the two
+authoring surfaces on disk, does every entry have its required eval sibling.
+
+This test file was authored before `scripts/hooks/precommit/validate_eval_pairing.py`
+existed, as the behavioral spec an implementation step then built against
+and confirmed as-is (no API changes were needed).
+
+Public API this module provides:
+
+    - `HOOK_NAME = "validate-eval-pairing"`
+    - `EXEMPT_AGENT_NAMES: frozenset[str]` — the 6 agents grandfathered in
+      before the eval requirement existed: architect, code-reviewer,
+      content-reviewer, issue-response-reviewer, swe, testing. Skills have no
+      equivalent exemption set — every skill on `main` already ships an eval.
+    - `Violation` frozen dataclass: `surface` ("agent" | "skill"), `name`
+      (the agent/skill identifier), `path` (the filesystem path the finding
+      is anchored to — the expected-but-missing eval path for a "missing"
+      finding, or the eval path that unexpectedly exists for a "stale
+      exemption" finding), `message` (human-readable, actionable text).
+    - `discover_shipped_agents(root: Path) -> list[str]` — names of
+      top-level `scripts/agents/<name>.md` files (stem only, no nested
+      files).
+    - `discover_shipped_skills(root: Path) -> list[str]` — names of
+      `scripts/skills/<name>/` directories that contain a `SKILL.md` (a
+      stray non-skill file directly under `scripts/skills/`, e.g. the real
+      corpus's `README.md`, is not a skill and must not be treated as one).
+    - `find_pairing_violations(root: Path) -> list[Violation]` — the
+      corpus-completeness check. Self-scanning: it walks `root` itself
+      (mirroring `discover_neutral_surface_files` in validate_neutrality.py)
+      rather than taking file arguments, and it collects every violation in
+      one pass rather than stopping at the first (matching this repo's
+      established pattern in both validate_neutrality.py's `main()`, which
+      accumulates `all_violations` across every discovered file, and
+      validate_control_risk_references.py's `compare_control_maps()`, which
+      accumulates every mismatch into one `errors` list).
+    - `format_violation(violation: Violation) -> str` — one rendered line
+      for stderr/CLI output, prefixed with `HOOK_NAME`.
+    - `main(argv: list[str]) -> int` — CLI entry point. This validator takes
+      no file arguments at all (it is a corpus-completeness check, not a
+      per-file scanner), so it always
+      self-discovers from the current working directory; `argv` is accepted
+      only for shape-consistency with the other two precommit validators'
+      `main(argv: list[str]) -> int` signature. Returns 0 if no violations,
+      else 1.
+
+Two distinguishable failure classes, by design:
+  - "missing eval": a shipped agent (not in EXEMPT_AGENT_NAMES) or a shipped
+    skill (no exemption ever applies) has no matching eval file. Fix: add
+    the eval.
+  - "stale exemption": a name in EXEMPT_AGENT_NAMES already has an eval on
+    disk. Fix: remove the name from the exemption set, not add an eval (it
+    already has one). This can only happen on the agent surface; skills have
+    no exemption set to go stale.
+A maintainer reading a failure must be able to tell which of the two applies
+without reading the validator's source, so this suite asserts the two
+message classes are lexically distinguishable (a "missing" message never
+also reads as a stale-exemption message and vice versa), not just that *a*
+violation exists.
+
+Structural analog: this validator's discovery step (walk `scripts/agents/`
+and `scripts/skills/` on disk to build the "what should have an eval" set)
+is modeled on `discover_neutral_surface_files` in validate_neutrality.py —
+same filesystem-walk shape, same tolerance for an absent/empty subtree, same
+`Violation` dataclass + `format_violation` + `main(argv) -> int` CLI
+convention (all in the `precommit/` package, unlike the older top-level
+`scripts/hooks/validate_control_risk_references.py`). The specific
+"does-every-X-have-a-matching-Y" comparison semantics — collect every
+mismatch in one pass, never fail fast — mirrors
+validate_control_risk_references.py's `compare_control_maps()`, which is the
+closer analog for that part of the behavior even though its inputs are two
+parsed YAML dicts rather than a filesystem walk. This suite follows the
+filesystem/dataclass shape of the neutrality checker since the pairing check
+is fundamentally about directory/file presence, not YAML field
+cross-referencing.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "precommit"))
+
+import validate_eval_pairing  # noqa: E402
+from validate_eval_pairing import (  # noqa: E402
+    EXEMPT_AGENT_NAMES,
+    discover_shipped_agents,
+    discover_shipped_skills,
+    find_pairing_violations,
+    format_violation,
+    main,
+)
+
+
+def _write_agent(tmp_path: Path, name: str, content: str = "# Example Agent\n\nBody.\n") -> Path:
+    """Write scripts/agents/<name>.md under tmp_path and return its path."""
+    agents_dir = tmp_path / "scripts" / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    path = agents_dir / f"{name}.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _write_agent_eval(tmp_path: Path, agent_name: str, content: str = '{"cases": []}\n') -> Path:
+    """Write scripts/agents-evals/<agent_name>/evals.json under tmp_path and return its path."""
+    path = tmp_path / "scripts" / "agents-evals" / agent_name / "evals.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _write_skill(tmp_path: Path, name: str, content: str = "---\nname: x\ndescription: y\n---\nBody.\n") -> Path:
+    """Write scripts/skills/<name>/SKILL.md under tmp_path and return the skill directory path."""
+    skill_dir = tmp_path / "scripts" / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+    return skill_dir
+
+
+def _write_skill_eval(tmp_path: Path, skill_name: str, content: str = '{"cases": []}\n') -> Path:
+    """Write scripts/skills/<skill_name>/evals/evals.json under tmp_path and return its path."""
+    path = tmp_path / "scripts" / "skills" / skill_name / "evals" / "evals.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+class TestExemptAgentNamesRegressionGuard:
+    """
+    Cheap regression guard on the exemption set itself (mirrors
+    TestFrameworkAllowlist.test_allowlist_terms_are_present_in_the_data_module
+    in test_validate_neutrality.py — the one test in that suite that reaches
+    into a fixed vocabulary and locks its exact membership).
+    """
+
+    def test_exempt_agent_names_matches_the_six_grandfathered_agents(self):
+        """
+        Given: The EXEMPT_AGENT_NAMES set
+        When: its membership is inspected
+        Then: It contains exactly the 6 agents that shipped before the eval
+              requirement existed, no more, no fewer
+
+        A silent drift here (someone adding a 7th exemption instead of
+        shipping an eval, or removing one of the 6 without adding its eval)
+        is exactly the kind of governance regression this validator exists
+        to prevent, so the exemption set itself is locked.
+        """
+        assert EXEMPT_AGENT_NAMES == frozenset(
+            {
+                "architect",
+                "code-reviewer",
+                "content-reviewer",
+                "issue-response-reviewer",
+                "swe",
+                "testing",
+            }
+        )
+
+
+class TestAgentEvalPairingPasses:
+    """An agent with a matching eval directory passes (case 1)."""
+
+    def test_agent_with_matching_eval_produces_no_violation_for_that_agent(self, tmp_path):
+        """
+        Given: scripts/agents/example-agent.md and a matching
+               scripts/agents-evals/example-agent/evals.json
+        When: find_pairing_violations scans the fixture root
+        Then: No violation names "example-agent"
+        """
+        _write_agent(tmp_path, "example-agent")
+        _write_agent_eval(tmp_path, "example-agent")
+
+        violations = find_pairing_violations(tmp_path)
+
+        assert all(v.name != "example-agent" for v in violations)
+
+    def test_clean_single_agent_corpus_returns_empty_list_not_none(self, tmp_path):
+        """
+        Given: A fixture root with exactly one agent and its matching eval
+        When: find_pairing_violations scans the fixture root
+        Then: It returns [] (an empty list), not None or another falsy value
+
+        Mirrors test_clean_file_returns_empty_list_not_none in
+        test_validate_neutrality.py: callers rely on list semantics
+        (`len`, iteration), not just truthiness.
+        """
+        _write_agent(tmp_path, "example-agent")
+        _write_agent_eval(tmp_path, "example-agent")
+
+        violations = find_pairing_violations(tmp_path)
+
+        assert violations == []
+        assert isinstance(violations, list)
+
+
+class TestAgentEvalPairingMissing:
+    """An agent with no eval, not in the exemption set, fails (case 2)."""
+
+    def test_non_exempt_agent_with_no_eval_produces_a_missing_violation(self, tmp_path):
+        """
+        Given: scripts/agents/example-agent.md with no scripts/agents-evals/
+               tree at all for it, and "example-agent" is not in
+               EXEMPT_AGENT_NAMES
+        When: find_pairing_violations scans the fixture root
+        Then: Exactly one violation names "example-agent", on the "agent"
+              surface, actionable enough to name both the agent and what is
+              missing
+        """
+        assert "example-agent" not in EXEMPT_AGENT_NAMES
+        _write_agent(tmp_path, "example-agent")
+
+        violations = find_pairing_violations(tmp_path)
+
+        matches = [v for v in violations if v.name == "example-agent"]
+        assert len(matches) == 1
+        violation = matches[0]
+        assert violation.surface == "agent"
+        assert "example-agent" in violation.message
+        assert "missing" in violation.message.lower() or "no eval" in violation.message.lower()
+
+    def test_missing_violation_path_names_the_expected_eval_location(self, tmp_path):
+        """
+        Given: A non-exempt agent with no eval
+        When: find_pairing_violations scans the fixture root
+        Then: The violation's path points at the expected (absent)
+              scripts/agents-evals/<name>/evals.json location, so a
+              maintainer can act on it without reading the validator source
+        """
+        _write_agent(tmp_path, "example-agent")
+
+        violations = find_pairing_violations(tmp_path)
+
+        matches = [v for v in violations if v.name == "example-agent"]
+        assert len(matches) == 1
+        expected_path = tmp_path / "scripts" / "agents-evals" / "example-agent" / "evals.json"
+        assert matches[0].path == expected_path
+
+
+class TestExemptAgentGrandfathered:
+    """An exempted agent with no eval directory passes (case 3)."""
+
+    @pytest.mark.parametrize("exempt_name", sorted(EXEMPT_AGENT_NAMES) if EXEMPT_AGENT_NAMES else [])
+    def test_exempt_agent_with_no_eval_produces_no_violation(self, tmp_path, exempt_name):
+        """
+        Given: A shipped agent whose name is one of the 6 grandfathered
+               exemptions, with no matching eval directory
+        When: find_pairing_violations scans the fixture root
+        Then: No violation names that agent
+
+        Parametrized across all 6 real exemption names (not just one) since
+        the exemption set is a fixed enumeration, not a pattern — each entry
+        is independently load-bearing.
+        """
+        _write_agent(tmp_path, exempt_name)
+
+        violations = find_pairing_violations(tmp_path)
+
+        assert all(v.name != exempt_name for v in violations)
+
+
+class TestStaleExemption:
+    """An exempted agent that already has an eval is a stale-exemption failure (case 4)."""
+
+    @pytest.mark.parametrize("exempt_name", sorted(EXEMPT_AGENT_NAMES) if EXEMPT_AGENT_NAMES else [])
+    def test_exempt_agent_with_unexpected_eval_produces_a_stale_exemption_violation(self, tmp_path, exempt_name):
+        """
+        Given: A shipped agent whose name is in EXEMPT_AGENT_NAMES, which
+               unexpectedly already has a matching eval on disk
+        When: find_pairing_violations scans the fixture root
+        Then: Exactly one violation names that agent, distinguishable from
+              the "missing eval" message class (a maintainer must be able to
+              tell "remove the exemption" from "add the eval" without
+              reading source)
+        """
+        _write_agent(tmp_path, exempt_name)
+        _write_agent_eval(tmp_path, exempt_name)
+
+        violations = find_pairing_violations(tmp_path)
+
+        matches = [v for v in violations if v.name == exempt_name]
+        assert len(matches) == 1
+        violation = matches[0]
+        assert violation.surface == "agent"
+        assert "stale exemption" in violation.message.lower() or "stale" in violation.message.lower()
+        # Distinguishable from the "missing eval" wording used in case 2/4 tests above.
+        assert "missing" not in violation.message.lower()
+
+    def test_stale_exemption_message_differs_from_missing_message_for_the_same_agent_name(self, tmp_path):
+        """
+        Given: Two separate fixture roots for the same exempt agent name —
+               one where it has no eval (grandfathered pass) and one where
+               it unexpectedly has an eval (stale exemption failure)
+        When: find_pairing_violations scans each root
+        Then: The stale-exemption root produces a violation whose message is
+              lexically distinct from what a "missing eval" violation for a
+              non-exempt agent of the same name would read as — proving the
+              two failure classes are not rendered with interchangeable text
+
+        This directly covers the task's "distinguishable failure message"
+        requirement: a maintainer fixing this must be able to tell which
+        remedy applies (add an eval vs. remove the exemption entry) from the
+        message text alone.
+        """
+        exempt_name = next(iter(EXEMPT_AGENT_NAMES))
+
+        stale_root = tmp_path / "stale"
+        _write_agent(stale_root, exempt_name)
+        _write_agent_eval(stale_root, exempt_name)
+        stale_violations = [v for v in find_pairing_violations(stale_root) if v.name == exempt_name]
+
+        missing_root = tmp_path / "missing"
+        # Use a synthetic non-exempt name sharing no exemption ambiguity, so this
+        # arm exercises the "missing eval" message text in isolation.
+        _write_agent(missing_root, "non-exempt-example")
+        missing_violations = [v for v in find_pairing_violations(missing_root) if v.name == "non-exempt-example"]
+
+        assert len(stale_violations) == 1
+        assert len(missing_violations) == 1
+        assert stale_violations[0].message != missing_violations[0].message
+        assert "stale" in stale_violations[0].message.lower()
+        assert "missing" not in stale_violations[0].message.lower()
+        assert "stale" not in missing_violations[0].message.lower()
+
+
+class TestSkillEvalPairingPasses:
+    """A skill with a matching evals/evals.json passes (case 5)."""
+
+    def test_skill_with_matching_eval_produces_no_violation_for_that_skill(self, tmp_path):
+        """
+        Given: scripts/skills/example-skill/SKILL.md and a matching
+               scripts/skills/example-skill/evals/evals.json
+        When: find_pairing_violations scans the fixture root
+        Then: No violation names "example-skill"
+        """
+        _write_skill(tmp_path, "example-skill")
+        _write_skill_eval(tmp_path, "example-skill")
+
+        violations = find_pairing_violations(tmp_path)
+
+        assert all(v.name != "example-skill" for v in violations)
+
+
+class TestSkillEvalPairingMissing:
+    """A skill with no evals/evals.json fails, unconditionally (case 6)."""
+
+    def test_skill_with_no_eval_produces_a_missing_violation(self, tmp_path):
+        """
+        Given: scripts/skills/example-skill/SKILL.md with no evals/ subdirectory
+        When: find_pairing_violations scans the fixture root
+        Then: Exactly one violation names "example-skill" on the "skill"
+              surface — skills have no exemption set, so this is unconditional
+        """
+        _write_skill(tmp_path, "example-skill")
+
+        violations = find_pairing_violations(tmp_path)
+
+        matches = [v for v in violations if v.name == "example-skill"]
+        assert len(matches) == 1
+        violation = matches[0]
+        assert violation.surface == "skill"
+        assert "example-skill" in violation.message
+        assert "missing" in violation.message.lower() or "no eval" in violation.message.lower()
+
+    def test_skill_named_like_an_exempt_agent_still_requires_its_own_eval(self, tmp_path):
+        """
+        Given: A skill directory sharing its name with one of the 6
+               agent-surface exemptions (e.g. "architect"), with no
+               evals/evals.json
+        When: find_pairing_violations scans the fixture root
+        Then: A "skill" surface violation is still produced for that name —
+              the agent-only exemption set must not leak across surfaces
+
+        Guards against an implementation bug where EXEMPT_AGENT_NAMES is
+        checked without also gating on `surface == "agent"`.
+        """
+        exempt_name = next(iter(EXEMPT_AGENT_NAMES))
+        _write_skill(tmp_path, exempt_name)
+
+        violations = find_pairing_violations(tmp_path)
+
+        matches = [v for v in violations if v.name == exempt_name and v.surface == "skill"]
+        assert len(matches) == 1
+
+    def test_non_skill_file_directly_under_skills_root_is_not_treated_as_a_skill(self, tmp_path):
+        """
+        Given: A plain file (e.g. README.md, matching the real corpus's
+               scripts/skills/README.md) directly under scripts/skills/,
+               alongside one real skill with a matching eval
+        When: find_pairing_violations scans the fixture root
+        Then: No violation is produced for "README" or "README.md" — a
+              stray non-skill file must not be misdiscovered as an unpaired
+              skill
+        """
+        skills_dir = tmp_path / "scripts" / "skills"
+        skills_dir.mkdir(parents=True, exist_ok=True)
+        (skills_dir / "README.md").write_text("# Skills\n\nIndex of skills.\n", encoding="utf-8")
+        _write_skill(tmp_path, "example-skill")
+        _write_skill_eval(tmp_path, "example-skill")
+
+        violations = find_pairing_violations(tmp_path)
+
+        assert all("README" not in v.name for v in violations)
+
+
+class TestMultipleViolationsCollectedInOneRun:
+    """
+    The validator collects every violation in one pass rather than stopping
+    at the first (case 7).
+
+    Confirmed against this repo's established pattern: both
+    validate_neutrality.py's `main()` (accumulates `all_violations` across
+    every discovered file before reporting any of them) and
+    validate_control_risk_references.py's `compare_control_maps()`
+    (accumulates every mismatch into one `errors` list, e.g.
+    test_compare_multiple_errors_returns_all /
+    test_end_to_end_catches_universal_violations) collect-all-then-report;
+    neither validator in this repo fails fast. This validator matches that
+    established pattern.
+    """
+
+    def test_mixed_corpus_reports_every_failure_not_just_the_first(self, tmp_path):
+        """
+        Given: A fixture corpus mixing all four agent-side outcomes (clean
+               pass, non-exempt missing, exempt grandfathered pass, exempt
+               stale) and both skill-side outcomes (clean pass, missing) in
+               one run
+        When: find_pairing_violations scans the fixture root once
+        Then: All 3 expected violations are present in a single returned
+              list — a maintainer does not have to re-run the validator 3
+              times to discover all 3 problems
+        """
+        exempt_pass_name = "architect"
+        exempt_stale_name = "swe"
+        assert exempt_pass_name in EXEMPT_AGENT_NAMES
+        assert exempt_stale_name in EXEMPT_AGENT_NAMES
+
+        # Agent surface: alpha passes, beta is missing, architect is grandfathered
+        # (passes), swe is a stale exemption (fails).
+        _write_agent(tmp_path, "alpha")
+        _write_agent_eval(tmp_path, "alpha")
+        _write_agent(tmp_path, "beta")
+        _write_agent(tmp_path, exempt_pass_name)
+        _write_agent(tmp_path, exempt_stale_name)
+        _write_agent_eval(tmp_path, exempt_stale_name)
+
+        # Skill surface: gamma passes, delta is missing.
+        _write_skill(tmp_path, "gamma")
+        _write_skill_eval(tmp_path, "gamma")
+        _write_skill(tmp_path, "delta")
+
+        violations = find_pairing_violations(tmp_path)
+
+        flagged_names = {v.name for v in violations}
+        assert flagged_names == {"beta", exempt_stale_name, "delta"}
+        assert len(violations) == 3, f"expected exactly 3 violations, got {len(violations)}: {violations}"
+
+        by_name = {v.name: v for v in violations}
+        beta_msg = by_name["beta"].message.lower()
+        assert "missing" in beta_msg or "no eval" in beta_msg
+        assert "stale" in by_name[exempt_stale_name].message.lower()
+        delta_msg = by_name["delta"].message.lower()
+        assert "missing" in delta_msg or "no eval" in delta_msg
+        assert by_name["delta"].surface == "skill"
+
+
+class TestAbsenceTolerance:
+    """
+    An absent/optional tree does not crash the validator (case 8).
+
+    Mirrors the tolerance documented and locked for
+    `discover_neutral_surface_files` in validate_neutrality.py ("Either
+    subtree may be empty (or absent) without error" —
+    test_absent_skills_subtree_contributes_nothing_without_erroring /
+    test_absent_agents_evals_subtree_contributes_nothing_without_erroring).
+    """
+
+    def test_absent_agents_evals_tree_does_not_crash_and_flags_non_exempt_agents(self, tmp_path):
+        """
+        Given: scripts/agents/ present (one exempt, one non-exempt agent)
+               and scripts/agents-evals/ entirely absent from the fixture root
+        When: find_pairing_violations scans the fixture root
+        Then: It does not raise; the non-exempt agent is flagged missing
+              (there is nowhere for its eval to be, so it is unpaired) and
+              the exempt agent is not flagged (grandfathered)
+        """
+        exempt_name = next(iter(EXEMPT_AGENT_NAMES))
+        _write_agent(tmp_path, exempt_name)
+        _write_agent(tmp_path, "non-exempt-example")
+        assert not (tmp_path / "scripts" / "agents-evals").exists()
+
+        violations = find_pairing_violations(tmp_path)
+
+        flagged_names = {v.name for v in violations}
+        assert flagged_names == {"non-exempt-example"}
+
+    def test_wholly_absent_agents_and_skills_trees_pass_vacuously(self, tmp_path):
+        """
+        Given: A fixture root with no scripts/agents/, scripts/skills/, or
+               scripts/agents-evals/ trees at all
+        When: find_pairing_violations scans the fixture root
+        Then: It does not raise and returns no violations — nothing shipped,
+              nothing to pair
+        """
+        assert not (tmp_path / "scripts").exists()
+
+        violations = find_pairing_violations(tmp_path)
+
+        assert violations == []
+
+    def test_absent_agents_tree_with_skills_present_only_checks_skills(self, tmp_path):
+        """
+        Given: scripts/agents/ entirely absent, scripts/skills/ present with
+               one clean skill
+        When: find_pairing_violations scans the fixture root
+        Then: It does not raise and returns no violations (nothing on the
+              agent surface to check, the skill surface is clean)
+        """
+        _write_skill(tmp_path, "example-skill")
+        _write_skill_eval(tmp_path, "example-skill")
+        assert not (tmp_path / "scripts" / "agents").exists()
+
+        violations = find_pairing_violations(tmp_path)
+
+        assert violations == []
+
+
+class TestDiscoveryHelpers:
+    """Light coverage of the two discovery helpers in isolation from the comparison logic."""
+
+    def test_discover_shipped_agents_returns_stem_names(self, tmp_path):
+        """
+        Given: Two agent files under scripts/agents/
+        When: discover_shipped_agents scans the fixture root
+        Then: It returns their stem names (no .md suffix, no directory prefix)
+        """
+        _write_agent(tmp_path, "alpha")
+        _write_agent(tmp_path, "beta")
+
+        names = discover_shipped_agents(tmp_path)
+
+        assert set(names) == {"alpha", "beta"}
+
+    def test_discover_shipped_skills_excludes_non_skill_files(self, tmp_path):
+        """
+        Given: One real skill directory and one stray file (README.md)
+               directly under scripts/skills/
+        When: discover_shipped_skills scans the fixture root
+        Then: Only the real skill directory name is returned
+        """
+        skills_dir = tmp_path / "scripts" / "skills"
+        skills_dir.mkdir(parents=True, exist_ok=True)
+        (skills_dir / "README.md").write_text("# Skills\n", encoding="utf-8")
+        _write_skill(tmp_path, "example-skill")
+
+        names = discover_shipped_skills(tmp_path)
+
+        assert names == ["example-skill"]
+
+    def test_discover_functions_tolerate_absent_trees(self, tmp_path):
+        """
+        Given: Neither scripts/agents/ nor scripts/skills/ exists
+        When: discover_shipped_agents and discover_shipped_skills scan the root
+        Then: Both return an empty list without raising
+        """
+        assert discover_shipped_agents(tmp_path) == []
+        assert discover_shipped_skills(tmp_path) == []
+
+
+class TestCli:
+    """
+    main(argv: list[str]) -> int shape (case 9), matching the
+    `main(argv) -> int` return-code contract validate_neutrality.py
+    establishes (0 on success, non-zero on any violation).
+    validate_control_risk_references.py's `main()` takes no `argv` and
+    calls `sys.exit()` directly, so it is not a precedent for this shape —
+    only its collect-all-violations behavior (cited elsewhere in this file)
+    carries over from that script.
+
+    This validator is self-scanning only — it does not accept file
+    arguments — so, mirroring how test_validate_neutrality.py
+    tests self-discovery (`monkeypatch.chdir(tmp_path)` then `main([])`),
+    every test here drives `main` via a chdir'd fixture root rather than an
+    explicit path argument or an environment variable.
+    """
+
+    def test_main_returns_zero_on_a_fully_paired_corpus(self, tmp_path, monkeypatch, capsys):
+        """
+        Given: A fixture root where every shipped agent and skill has a
+               matching eval (or is grandfathered)
+        When: main([]) runs with that root as cwd
+        Then: It returns 0 and writes no violation output to stderr
+        """
+        exempt_name = next(iter(EXEMPT_AGENT_NAMES))
+        _write_agent(tmp_path, "alpha")
+        _write_agent_eval(tmp_path, "alpha")
+        _write_agent(tmp_path, exempt_name)
+        _write_skill(tmp_path, "example-skill")
+        _write_skill_eval(tmp_path, "example-skill")
+        monkeypatch.chdir(tmp_path)
+
+        exit_code = main([])
+        captured = capsys.readouterr()
+
+        assert exit_code == 0
+        assert captured.err == ""
+
+    def test_main_returns_nonzero_and_reports_violations_on_stderr(self, tmp_path, monkeypatch, capsys):
+        """
+        Given: A fixture root with one non-exempt agent missing its eval
+        When: main([]) runs with that root as cwd
+        Then: It returns a non-zero exit code and the agent's name appears
+              in the stderr output
+        """
+        _write_agent(tmp_path, "beta")
+        monkeypatch.chdir(tmp_path)
+
+        exit_code = main([])
+        captured = capsys.readouterr()
+
+        assert exit_code != 0
+        assert "beta" in captured.err
+
+    def test_format_violation_includes_hook_name_and_message(self, tmp_path):
+        """
+        Given: A violation produced by find_pairing_violations
+        When: format_violation renders it
+        Then: The rendered line is prefixed with the validator's HOOK_NAME
+              and includes the violation's message text
+        """
+        _write_agent(tmp_path, "beta")
+
+        violations = find_pairing_violations(tmp_path)
+        rendered = format_violation(violations[0])
+
+        assert rendered.startswith(f"{validate_eval_pairing.HOOK_NAME}: ")
+        assert violations[0].message in rendered
+
+
+@pytest.mark.live_corpus
+class TestLiveCorpus:
+    """
+    Runs the validator against the real repository's scripts/agents/ and
+    scripts/skills/ trees.
+
+    As of this branch, scripts/agents-evals/ does not exist anywhere in the
+    real repository, so every real shipped agent is currently covered only
+    by grandfathering (all 6 real agents are in EXEMPT_AGENT_NAMES and none
+    have an eval yet — exactly the state the exemption set exists to
+    tolerate). Every real skill under scripts/skills/ already ships
+    evals/evals.json. So the live corpus is expected to be fully clean
+    today; this is a regression guard, not a design assertion — the moment a
+    7th agent ships (necessarily non-exempt) or scripts/agents-evals/ lands
+    with a stale exemption, this test is meant to start failing.
+    """
+
+    def test_live_corpus_has_no_pairing_violations(self, repo_root):
+        """
+        Given: The real repository's scripts/agents/ and scripts/skills/ trees
+        When: find_pairing_violations scans repo_root
+        Then: No violations are produced
+        """
+        violations = find_pairing_violations(repo_root)
+
+        assert violations == [], (
+            f"expected a fully clean live corpus, got: {[(v.surface, v.name, v.message) for v in violations]}"
+        )

--- a/scripts/hooks/tests/test_validate_neutrality.py
+++ b/scripts/hooks/tests/test_validate_neutrality.py
@@ -2,9 +2,10 @@
 """
 Tests for scripts/hooks/precommit/validate_neutrality.py.
 
-ADR-033 D2a/D5 establish a "vendor-neutral shipping" contract for the two
-authoring surfaces that ship in this repository: `scripts/agents/**` and
-`scripts/skills/**`. Prose in those trees must not name a specific AI harness
+ADR-033 D2a/D5/D8 establish a "vendor-neutral shipping" contract for the
+three authoring surfaces that ship in this repository: `scripts/agents/**`,
+`scripts/skills/**`, and `scripts/agents-evals/**`. Prose in those trees
+must not name a specific AI harness
 product, company, CLI entry point, or model identifier; must not embed
 harness-invocation stage directions (`<invoke ... tool>`, `subagent_type`,
 "auto-loads"/"auto-triggers"); and must not reference harness-specific config
@@ -27,7 +28,8 @@ Public API under test (scripts/hooks/precommit/validate_neutrality.py):
       allowlist suppression) plus frontmatter-key checks for one file.
       Returns `[]` (not `None`) when clean.
     - `discover_neutral_surface_files(root: Path) -> list[Path]` — files
-      under `root/scripts/agents/**` and `root/scripts/skills/**` only.
+      under `root/scripts/agents/**`, `root/scripts/skills/**`, and
+      `root/scripts/agents-evals/**`.
     - `format_violation(violation: Violation) -> str` — stderr line,
       `<hook_name>: <file>:<line>: <message>`.
     - `main(argv: list[str]) -> int` — CLI entry point; explicit file args or
@@ -138,6 +140,40 @@ def _write_nested_skill_md_reference(tmp_path: Path, content: str) -> Path:
     ref_dir.mkdir(parents=True, exist_ok=True)
     path = ref_dir / "SKILL.md"
     path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _write_agents_evals_file(
+    tmp_path: Path, content: str, agent_name: str = "example-agent", relative: str = "evals.json"
+) -> Path:
+    """
+    Write a synthetic file under <tmp_path>/scripts/agents-evals/<agent_name>/<relative>.
+
+    ADR-033 Amendment D8 ships agent portable evals at
+    scripts/agents-evals/<agent-name>/evals.json, a sibling tree to
+    scripts/agents/ and scripts/skills/. This tree does not exist anywhere in
+    the repository yet (no PR has created it), so every test that uses this
+    helper builds it as a synthetic tmp_path fixture, matching how
+    _write_agent_file/_write_skill_file build the other two trees.
+    """
+    path = tmp_path / "scripts" / "agents-evals" / agent_name / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _write_agents_evals_asset_bytes(
+    tmp_path: Path, relative: str, data: bytes, agent_name: str = "example-agent"
+) -> Path:
+    """
+    Write raw bytes at scripts/agents-evals/<agent_name>/<relative> and return its path.
+
+    Mirrors _write_skill_asset_bytes; used for the agents-evals tree's
+    non-text-extension discovery-exclusion test.
+    """
+    path = tmp_path / "scripts" / "agents-evals" / agent_name / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
     return path
 
 
@@ -555,6 +591,158 @@ class TestScopeBoundaries:
 
         assert agent in discovered
         assert not any("skills" in path.parts for path in discovered)
+
+
+class TestAgentsEvalsSubtree:
+    """
+    ADR-033 Amendment D8: scripts/agents-evals/<agent-name>/evals.json ships
+    portable agent evals as a third authoring surface — a sibling tree to
+    scripts/agents/ and scripts/skills/ — so eval JSON and D7b-style fixture
+    Markdown shipped there get the same neutrality scan the other two trees
+    already get.
+
+    `discover_neutral_surface_files` walks this tree via a three-entry
+    tuple, `("scripts/agents", "scripts/skills", "scripts/agents-evals")`
+    (validate_neutrality.py:471), appended last to preserve the existing
+    agents/skills discovery order.
+
+    scripts/agents-evals/ does not exist anywhere in the repository yet (no
+    PR has created it) — every fixture here is synthetic, built under
+    tmp_path exactly like the existing scripts/agents/ and scripts/skills/
+    fixtures elsewhere in this file.
+    """
+
+    def test_evals_json_under_agents_evals_is_discovered(self, tmp_path):
+        """
+        Given: scripts/agents-evals/<agent-name>/evals.json in a fixture repo root
+        When: discover_neutral_surface_files scans the root
+        Then: The evals.json file is included in the returned list
+        """
+        evals = _write_agents_evals_file(tmp_path, '{"cases": []}\n')
+
+        discovered = discover_neutral_surface_files(tmp_path)
+
+        assert evals in discovered
+
+    def test_nested_fixture_under_agents_evals_is_discovered(self, tmp_path):
+        """
+        Given: scripts/agents-evals/<agent-name>/fixtures/some-fixture.md
+               (nested subdirectory, matching how scripts/agents/** and
+               scripts/skills/** already support nesting)
+        When: discover_neutral_surface_files scans the root
+        Then: The nested fixture file is included in the returned list
+        """
+        fixture = _write_agents_evals_file(
+            tmp_path, "# Fixture\n\nSample D7b-style fixture content.\n", relative="fixtures/some-fixture.md"
+        )
+
+        discovered = discover_neutral_surface_files(tmp_path)
+
+        assert fixture in discovered
+
+    def test_discover_returns_files_from_all_three_trees(self, tmp_path):
+        """
+        Given: A fixture repo with files under scripts/agents/, scripts/skills/,
+               and scripts/agents-evals/
+        When: discover_neutral_surface_files scans the root
+        Then: All three trees' files are returned, not just the two legacy trees
+        """
+        agent = _write_agent_file(tmp_path, "content\n")
+        skill = _write_skill_file(tmp_path, "---\nname: x\ndescription: y\n---\nbody\n")
+        evals = _write_agents_evals_file(tmp_path, '{"cases": []}\n')
+
+        discovered = discover_neutral_surface_files(tmp_path)
+
+        assert set(discovered) == {agent, skill, evals}
+
+    def test_absent_agents_evals_subtree_contributes_nothing_without_erroring(self, tmp_path):
+        """
+        Given: A synthetic root with scripts/agents/ and scripts/skills/
+               present (one file each) and scripts/agents-evals/ entirely absent
+        When: discover_neutral_surface_files scans the root
+        Then: Both legacy files are discovered, nothing is returned under
+              scripts/agents-evals/, and discovery does not error
+
+        Regression guard, mirroring
+        test_absent_skills_subtree_contributes_nothing_without_erroring: the
+        docstring's "Either subtree may be empty (or absent) without error"
+        must extend to the third tree once it is added — a repo that has not
+        adopted scripts/agents-evals/ yet must keep working exactly as it
+        does today.
+        """
+        agent = _write_agent_file(tmp_path, "clean agent content\n")
+        skill = _write_skill_file(tmp_path, "---\nname: x\ndescription: y\n---\nbody\n")
+        assert not (tmp_path / "scripts" / "agents-evals").exists()
+
+        discovered = discover_neutral_surface_files(tmp_path)
+
+        assert set(discovered) == {agent, skill}
+        assert not any("agents-evals" in path.parts for path in discovered)
+
+    def test_agents_evals_files_land_after_skills_in_discovery_order(self, tmp_path):
+        """
+        Given: One file each under scripts/agents/, scripts/skills/, and
+               scripts/agents-evals/
+        When: discover_neutral_surface_files scans the root
+        Then: The returned list orders agents first, skills second,
+              agents-evals third
+
+        Design decision, not an assumption: the docstring documents "agents
+        subtree first, skills subtree second, each subtree sorted" for the
+        two-tree case. Appending "scripts/agents-evals" to the walk tuple is
+        the natural, low-risk extension — existing callers that rely on the
+        agents-first/skills-second relative order are unaffected — so this
+        test locks that ordering rather than, e.g., inserting agents-evals
+        between agents and skills. If a later design decision picks a
+        different ordering, this is the test that decision must update.
+        """
+        agent = _write_agent_file(tmp_path, "content\n")
+        skill = _write_skill_file(tmp_path, "---\nname: x\ndescription: y\n---\nbody\n")
+        evals = _write_agents_evals_file(tmp_path, '{"cases": []}\n')
+
+        discovered = discover_neutral_surface_files(tmp_path)
+
+        assert discovered.index(agent) < discovered.index(skill) < discovered.index(evals)
+
+    def test_non_text_file_under_agents_evals_is_excluded(self, tmp_path):
+        """
+        Given: A non-text asset (.png) under scripts/agents-evals/<agent-name>/
+        When: discover_neutral_surface_files scans the root
+        Then: The .png file is excluded, matching the existing text-extension
+              filter behavior already locked for scripts/agents/** and
+              scripts/skills/** (test_discovery_excludes_binary_asset)
+        """
+        icon = _write_agents_evals_asset_bytes(
+            tmp_path,
+            "assets/icon.png",
+            b"\x89PNG\r\n\x1a\n" + b"\x00\x01\x02\x03" * 16 + b"\xff\xfe\xfd",
+        )
+        evals = _write_agents_evals_file(tmp_path, '{"cases": []}\n')
+
+        discovered = discover_neutral_surface_files(tmp_path)
+
+        assert icon not in discovered
+        assert evals in discovered
+
+    def test_dangling_symlink_under_agents_evals_is_discovered(self, tmp_path):
+        """
+        Given: A dangling symlink (broken target) under
+               scripts/agents-evals/<agent-name>/
+        When: discover_neutral_surface_files scans the root
+        Then: The dangling symlink is included, matching the documented
+              behavior already locked for scripts/agents/** and
+              scripts/skills/** (test_e10_dangling_symlink_is_discovered_and_flagged)
+        """
+        target_dir = tmp_path / "scripts" / "agents-evals" / "example-agent"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        link = target_dir / "dangling.json"
+        link.symlink_to(target_dir / "nonexistent-target.json")
+
+        discovered = discover_neutral_surface_files(tmp_path)
+
+        assert link in discovered, (
+            "a dangling symlink under scripts/agents-evals/ must be discovered, not filtered out"
+        )
 
 
 class TestFrontmatterRulesSkill:
@@ -2018,7 +2206,7 @@ class TestTextBinaryPolicyFinding3:
 """
 Test Summary
 ============
-Total Tests: 152 (counting parametrize expansion)
+Total Tests: 159 (counting parametrize expansion)
 
 Original suite (74), unchanged except the TestScopeBoundaries/TestLiveCorpus
 moves noted below:
@@ -2028,6 +2216,16 @@ moves noted below:
 - TestFrameworkAllowlist: 8
 - TestScopeBoundaries: 4 — gained `test_absent_skills_subtree_contributes_
   nothing_without_erroring`, moved in from TestLiveCorpus (see below).
+- TestAgentsEvalsSubtree: 7 (ADR-033 Amendment D8) —
+  `discover_neutral_surface_files` now includes the
+  scripts/agents-evals/<agent-name>/ tree (a third sibling to scripts/agents/
+  and scripts/skills/, shipping portable eval JSON and D7b-style fixture
+  Markdown), appended as the third entry in its walk tuple. Covers:
+  evals.json discovered, a nested fixtures/*.md discovered, all three trees returned
+  together, the absent-third-tree case still working (mirrors the absent-
+  skills regression guard above), discovery ordering (agents, skills,
+  agents-evals — the tuple-append choice, locked here rather than assumed),
+  a non-text asset excluded, and a dangling symlink discovered.
 - TestFrontmatterRulesSkill: 6
 - TestFrontmatterRulesAgent: 7
 - TestCli: 6


### PR DESCRIPTION
## ADR-033 D8: neutrality scanning + eval pairing enforcement for scripts/agents-evals/

### Summary

ADR-033 Amendment D8 defines `scripts/agents-evals/<agent-name>/evals.json` as the shipping location for agent portable evals — a sibling tree to `scripts/agents/`. This PR does two things:

**Vendor-neutrality scanning** extended to the new tree, across all three declaration sites:
- `discover_neutral_surface_files`'s walk tuple (`scripts/hooks/precommit/validate_neutrality.py`) — appended, preserving existing agents/skills order.
- The `validate-neutrality` pre-commit hook's `files:` regex.
- `validation.yml`'s CI trigger `paths:` (both `pull_request:` and `push:` blocks).

**A new corpus-completeness check** (`scripts/hooks/precommit/validate_eval_pairing.py`) enforcing that the eval requirement's paperwork actually gets done, not silently skipped: every `scripts/agents/<name>.md` needs a paired `scripts/agents-evals/<name>/evals.json`, every `scripts/skills/<name>/` needs `evals/evals.json`. Note:
- This checks presence, not content — an empty or malformed `evals.json` currently satisfies it; content validation is out of scope for this PR. 
- Agents get a 6-entry grandfather exemption (`architect`, `code-reviewer`, `content-reviewer`, `issue-response-reviewer`, `swe`, `testing` — shipped before this requirement existed, tracked in a backlog issue); skills get none, since every skill already has one. An exempted agent found to already have an eval is flagged as a distinct "stale exemption," not silently passed. 

### One known limitation, called out rather than hidden

`test_ci_block_parity.py`'s ADR-037 D1 coverage assertion derives required CI paths from tracked files (`git ls-files`) matched against each hook's `files:` regex. Since `scripts/agents-evals/` has no tracked files yet, the CI-path additions for the neutrality scan (Phase 0) aren't exercised by that specific assertion today — confirmed empirically by reverting the CI-paths and pre-commit-regex changes independently and re-running the full parity suite (still green either way). The new pairing check (Phase 0.5) *is* independently exercised end-to-end via its own registered behavioral probe, which doesn't depend on tracked-file sampling. Not a defect; a property of the corpus-sampling design of that one assertion, documented here so it isn't mistaken for accidental coverage.

### Not in this PR

Authoring the actual evals for `control-creator`/`control-critic`/etc. (#434's own remediation) — separate, later phases of the same plan. Retrofitting evals for the 6 grandfathered agents — tracked as its own backlog issue.
