### PR TITLE
feat(lifecycle): add decommissioning as lifecycle stage 9

### DIFF
--- a/risk-map/docs/guide-metadata.md
+++ b/risk-map/docs/guide-metadata.md
@@ -347,7 +347,7 @@ The schemas enforce these validation rules for metadata fields:
 
 3. **Enum Constraints**: All specific values must match their respective schema enums:
    - Framework IDs in `mappings` must exist in `frameworks.yaml`
-   - Lifecycle stages must be one of the 8 stages defined in `lifecycle-stage.schema.json`
+   - Lifecycle stages must be one of the 9 stages defined in `lifecycle-stage.schema.json`
    - Impact types must be one of the 10 types defined in `impact-type.schema.json`
    - Actor access levels must be one of the 9 levels defined in `actor-access.schema.json`
 
@@ -357,7 +357,7 @@ The schemas enforce these validation rules for metadata fields:
 
 1. **Be selective**: Only include metadata fields that add meaningful context
 2. **Use multiple values**: Most metadata fields accept arrays - include all relevant values
-3. **Consider the full lifecycle**: Think about where risks/controls apply across all 8 stages
+3. **Consider the full lifecycle**: Think about where risks/controls apply across all 9 stages
 4. **Map to multiple frameworks**: Cross-referencing helps users from different security backgrounds
 5. **Choose primary impacts**: Focus on the most significant impact types rather than listing everything
 

--- a/risk-map/schemas/lifecycle-stage.schema.json
+++ b/risk-map/schemas/lifecycle-stage.schema.json
@@ -28,7 +28,8 @@
             "evaluation",
             "deployment",
             "runtime",
-            "maintenance"
+            "maintenance",
+            "decommissioning"
           ]
         },
         "title": {
@@ -41,9 +42,9 @@
         },
         "order": {
           "type": "integer",
-          "description": "Sequential order in the lifecycle (1-8)",
+          "description": "Sequential order in the lifecycle (1-9)",
           "minimum": 1,
-          "maximum": 8
+          "maximum": 9
         }
       },
       "required": ["id", "title", "description"],

--- a/risk-map/yaml/lifecycle-stage.yaml
+++ b/risk-map/yaml/lifecycle-stage.yaml
@@ -5,10 +5,11 @@
 title: Lifecycle Stages
 description:
   - >
-    Defines the phases of AI system development, deployment, and operation. This eight-stage
+    Defines the phases of AI system development, deployment, and operation. This nine-stage
     lifecycle covers the complete journey from initial planning through data preparation,
-    model training, development, evaluation, deployment, runtime operation, and ongoing
-    maintenance. Each stage presents unique security considerations and risk profiles
+    model training, development, evaluation, deployment, runtime operation, ongoing
+    maintenance, and eventual decommissioning. Each stage presents unique security
+    considerations and risk profiles
 lifecycleStages:
   - id: planning
     title: Planning
@@ -49,3 +50,11 @@ lifecycleStages:
     title: Maintenance
     description: Ongoing monitoring, updates, retraining, and system maintenance
     order: 8
+
+  - id: decommissioning
+    title: Decommissioning
+    description: >-
+      Terminal retirement of the AI system: revoking authenticators and tombstoning
+      identities, revoking delegated authority across descendants, and disposing of
+      models, data, memory, and decision traces against a verified disposition record
+    order: 9


### PR DESCRIPTION
**Review this:** 5 files, small. About 5 minutes.

**State:** ready for review as of 2026-09-16. All checks green at `5a2cd49`; this head adds only docs and one description paragraph. The blocker named in the earlier body (RFC [ws4#170](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/170) disposition) is cleared: the reviewers on that thread converged on 9/3 to 9/14 and @imran-siddique cleared it here on 9/9. The RFC body edit and the WS4 chair acceptance are still in progress on ws4#170; nothing in that edit changes this diff.

**What this makes work:** `decommissioning` becomes a taggable lifecycle stage, so risks about retiring an agent stop landing on `maintenance`.

## What changes

1. `risk-map/schemas/lifecycle-stage.schema.json`: add `decommissioning` to the id enum, move the `order` maximum from 8 to 9.
2. `risk-map/yaml/lifecycle-stage.yaml`: add the stage entry at order 9, update the header count.
3. `risk-map/docs/guide-metadata.md`: the two stage counts, and the "Valid Values" list (nine entries now).
4. `risk-map/docs/design/metadata-mappings.md`: the "8-Stage AI Lifecycle Model" heading and list, flagged in review. Now nine.

Additive only. No existing stage is renamed, reordered, or removed.

## Why

The corpus lifecycle ends at `maintenance`. Risks whose exposure is specific to *retiring* an agent (authenticator revocation, delegation-tree teardown, memory and trace disposition) have no stage to tag. Today they land on `maintenance`, which covers ongoing operation of a live system, or they go untagged.

Implements RFC [ws4#170](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/170).

## Decisions already baked in

The stage is **terminal**. Decommissioning ends the agent's authority to act; pause, suspend, quarantine and kill switch stay in `runtime` or `maintenance`; any later return is a new admission. This is the definition ws4#170's reviewers settled on (@NicolaiNielsenTR, @imran-siddique, @raymondsheh, @billbrietstout), replacing the original proposal's soft/hard split rather than renaming it.

The wording follows those reviews. Authenticator revocation and identity tombstoning rather than identity deletion, because deleting an identifier breaks replay detection. Disposal against a verified disposition record rather than "deletion", since a conforming outcome may be retained under hold or crypto-shredded. And, from the 9/3 review, the terminal state and its effective time are published where a relying party can verify them, so a record signed after retirement is distinguishable from one signed before.

## Two things reviewers usually ask

`order` carried `"maximum": 8`, so a ninth stage fails validation on the numeric bound as well as on the id enum. Both move to 9.

`docs/adr/022-supporting-schemas.md` says 8 in four places. It is a historical ADR recording a decision at a point in time, so this PR leaves it alone, per the 9/9 review. `scripts/hooks/tests/test_lifecycle_stage_order_uniqueness.py` has a stale fixture comment ("8 stages"); fixtures are inline and pass, and `scripts/**` bases on `main` per ADR-002, so it stays out of this PR.

## Landing order

Taxonomy prerequisite (ADR-034 D1). Sequence after this merges:

1. Companion PR: append `decommissioning` to five existing risks (`riskShadowAndUnknownAgents`, `riskZombieShadowMCPServers`, `riskSensitiveDataDisclosure`, `riskExcessiveDataHandlingDuringInference`, `riskRetrievalVectorStorePoisoning`).
2. Follow-on catalog PR: new decommissioning risk IDs, from ws4#170's follow-on table.

Independent of the reflection stage ([#401](https://github.com/cosai-oasis/secure-ai-tooling/issues/401)); numbering reconciles if both advance. The observability component PR (#501) referenced in the earlier body is closed; its successor is a control, [ws4#195](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/195), and does not interact with this stage.

## Validation

1. `check-jsonschema --schemafile lifecycle-stage.schema.json ../yaml/lifecycle-stage.yaml`: ok
2. `python3 scripts/hooks/validate_riskmap.py --mode lifecycle --force`: passed
3. `pytest scripts/hooks/tests/test_lifecycle_stage_order_uniqueness.py`: 20 passed

---

*PR body and the 2026-09-16 revision drafted with Claude Fable 5.1; reviewed by @edonadei.*
